### PR TITLE
test(simgh): scripting, fault injection, mutation log, and snapshot/restore

### DIFF
--- a/engine/simgh_fault_classification_test.go
+++ b/engine/simgh_fault_classification_test.go
@@ -1,0 +1,136 @@
+package engine
+
+// This file satisfies acceptance criterion 5 of issue #1457: an injected
+// rate-limit error must be classified by *the engine's own* classifier as a
+// rate limit, asserted against the real predicate rather than against the
+// injector's intent. An injected error the engine does not recognise proves
+// nothing — it exercises the escalation branch while the scenario believes it
+// is exercising the defer branch.
+//
+// # Why the test lives here, in `package engine`
+//
+// isTransientAPIError and isTransientError are unexported. Their only
+// production consumer is engine/ci_settle.go's settleAwaitingCIScan, itself
+// unexported and reachable from outside only through Engine.Run(), which needs
+// the harness issue #1457 puts out of scope. So neither an external
+// `package engine_test` (which cannot see unexported identifiers) nor a
+// simgh-side test (tests/sim/simgh imports engine, so engine importing it back
+// is a cycle) can make this assertion. An internal test file that imports only
+// the stdlib-only leaf package tests/sim/simgh/ghfault can — and does so
+// without touching any production code under engine/.
+//
+// # What this test does not cover
+//
+// This is a classification assertion, not a behavioural one. The stronger
+// form — inject the same number of FetchItemDetails failures across
+// MaxRetries+ settle passes, once with a rate-limit-shaped error and once with
+// a generic one, and assert that only the generic one escalates the item to
+// fabrik:paused — needs a driveable Engine.Run(), which arrives with the
+// harness issue. It belongs there, not here.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/handarbeit/fabrik/tests/sim/simgh/ghfault"
+)
+
+// TestInjectedRateLimitErrorsAreClassifiedAsTransientAPI is the AC5
+// assertion proper: every rate-limit shape simgh can inject is recognised by
+// isTransientAPIError, the predicate settleAwaitingCIScan uses to decide
+// whether a failure defers indefinitely (#1313) or consumes the item's
+// escalation budget.
+func TestInjectedRateLimitErrorsAreClassifiedAsTransientAPI(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"RateLimit", ghfault.RateLimit()},
+		{"GraphQLRateLimit", ghfault.GraphQLRateLimit()},
+		{"SecondaryRateLimit", ghfault.SecondaryRateLimit()},
+		{"AbuseDetection", ghfault.AbuseDetection()},
+		{"TooManyRequests", ghfault.TooManyRequests()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !isTransientAPIError(tc.err) {
+				t.Errorf("isTransientAPIError(ghfault.%s()) = false, want true\n  error: %v",
+					tc.name, tc.err)
+			}
+		})
+	}
+}
+
+// The transport-layer shapes must satisfy the *narrower* predicate too.
+// isTransientError governs bounded retry; isTransientAPIError governs
+// indefinite deferral. A constructor that only reached the wider one would
+// silently skip every bounded-retry path a scenario aimed it at.
+func TestInjectedTransportErrorsAreClassifiedByBothPredicates(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"ServerError", ghfault.ServerError()},
+		{"ConnectionReset", ghfault.ConnectionReset()},
+		{"IOTimeout", ghfault.IOTimeout()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !isTransientError(tc.err) {
+				t.Errorf("isTransientError(ghfault.%s()) = false, want true\n  error: %v", tc.name, tc.err)
+			}
+			if !isTransientAPIError(tc.err) {
+				t.Errorf("isTransientAPIError(ghfault.%s()) = false, want true\n  error: %v", tc.name, tc.err)
+			}
+		})
+	}
+}
+
+// The rate-limit shapes must NOT satisfy isTransientError. The two predicates
+// route to different engine behaviour, and a constructor that tripped both
+// would make a scenario aimed at the defer-indefinitely path indistinguishable
+// from one aimed at bounded retry.
+func TestRateLimitShapesAreNotBoundedRetryTransient(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"RateLimit", ghfault.RateLimit()},
+		{"GraphQLRateLimit", ghfault.GraphQLRateLimit()},
+		{"SecondaryRateLimit", ghfault.SecondaryRateLimit()},
+		{"AbuseDetection", ghfault.AbuseDetection()},
+		{"TooManyRequests", ghfault.TooManyRequests()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if isTransientError(tc.err) {
+				t.Errorf("isTransientError(ghfault.%s()) = true, want false — the rate-limit "+
+					"shapes belong to isTransientAPIError only\n  error: %v", tc.name, tc.err)
+			}
+		})
+	}
+}
+
+// The negative half of AC5. Without this, every assertion above would still
+// pass against a classifier that returned true unconditionally.
+func TestUnrecognisedErrorsAreNotClassifiedAsTransient(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"plain error", errors.New("boom")},
+		{"ghfault.NotFound", ghfault.NotFound()},
+		{"wrapped sentinel", ghfault.Wrap(errors.New("not mergeable"), "simgh: merging PR #7")},
+		{"nil", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if isTransientAPIError(tc.err) {
+				t.Errorf("isTransientAPIError(%v) = true, want false", tc.err)
+			}
+			if isTransientError(tc.err) {
+				t.Errorf("isTransientError(%v) = true, want false", tc.err)
+			}
+		})
+	}
+}

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -48,6 +48,41 @@ means something, cheap enough to run on every commit.
 - **[`simgh/nonvacuity.sh`](simgh/nonvacuity.sh)** — a mutation sweep that
   neutralises each modelled behaviour and asserts the suite goes red.
 
+## The instrumentation layer
+
+A faithful model is a GitHub stand-in; it is not yet a test *instrument*. Three
+capabilities turn it into one, and they are what let a scenario reach behaviour
+the live bed cannot be made to produce on demand:
+
+- **Clock-driven schedules** (`simgh/schedule.go`). `SeedCheckRunsAfter`,
+  `SeedReviewsAfter` and their siblings enqueue a mutation for a future instant
+  on the injected clock — "CI goes red thirty minutes in", "the reviewer
+  responds on the third poll". Sequencing is driven by the clock rather than by
+  a read count, because **one poll is not one read**: `settleAwaitingCIScan`
+  reads a SHA's check runs twice in a single poll, and whether it does depends
+  on harness configuration. A read-count sequence would not correspond to poll
+  boundaries at all.
+- **Fault injection** (`simgh/fault.go`). Any `engine.GitHubClient` method can
+  be made to fail once, N times then succeed, always, on the Kth call, or only
+  for calls matching a predicate. The five settle scans' retry loops and
+  `MaxRetries` escalation cutovers are reachable no other way. The error shape
+  is the caller's choice and it matters — `simgh/ghfault` supplies the
+  rate-limit and abuse-detection shapes the engine classifies specially.
+- **An ordered mutation log** (`simgh/mutationlog.go`). Several engine
+  guarantees are *ordering* claims rather than state claims, and reading
+  terminal labels cannot assert one. It records every intercepted call with its
+  outcome — attempts, not just mutations — so "N failures then the success" is
+  expressible, and doubles as the harness's debugging output.
+
+Fault injection and the log live in a decorator, `simgh.Instrument(sim)`, which
+holds its `*Sim` as a **named field and never an embedded one** — embedding
+would satisfy the interface assertion by method promotion and let a forgotten
+wrapper silently bypass both instruments.
+
+`Sim.Snapshot`/`Restore` (`simgh/snapshot.go`) round-trip the model, the git
+repositories, the fault schedule and the log, so a restart scenario can discard
+the engine and rebuild against exactly the state GitHub would have retained.
+
 The seam this layer targets is `engine.NewWithDeps(cfg, GitHubClient,
 ClaudeInvoker, *WorktreeManager)`, which accepts substituted dependencies.
 Wiring `simgh` into it, along with a `ClaudeInvoker` and a scenario harness, is

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -1177,7 +1177,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 144 mutations, and
+   package cannot back up. The sweep currently catches all 145 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
    The instrumentation layer's own mutations are in there too, and one of them

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -1177,7 +1177,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 145 mutations, and
+   package cannot back up. The sweep currently catches all 146 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
    The instrumentation layer's own mutations are in there too, and one of them

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -471,19 +471,185 @@ while enqueuing it from another.
 
 ## Rate limits and transport
 
-### Rate limiting — **Absent**
+### Rate limiting — **Injectable per call, static as a budget**
 
-`RateLimitStats` reports static budgets that never deplete. No method ever fails
-with a rate-limit or secondary-rate-limit error, and there is no retry-after
-behaviour. The engine's backoff and rate-limit-exhaustion paths
-(`engine/backoff.go`, `engine/terminal.go`) **cannot** be exercised through this
-layer.
+Two halves, and they behave differently.
+
+**Per-call rate-limit failures are injectable.** Wrap a `Sim` with
+`Instrument` and any interface method can be made to return a rate-limit,
+secondary-rate-limit or abuse-detection error — once, N times, always, on the
+Kth call, or only for calls matching a predicate. Use the `ghfault`
+constructors (re-exported as `ErrRateLimit`, `ErrSecondaryRateLimit`,
+`ErrAbuseDetection`, `ErrTooManyRequests`, …) rather than an ad-hoc
+`errors.New`: the engine classifies these by substring match against
+`err.Error()` (`engine/item.go`'s `rateLimitErrorPatterns`), so an unrecognised
+message exercises the *escalation* branch while the scenario believes it is
+exercising the *defer* branch. `engine/simgh_fault_classification_test.go` pins
+each constructor against the real, unexported classifier, so a rewording on
+either side fails loudly.
+
+**The budgets themselves remain static.** `RateLimitStats` reports whatever
+`WithRateLimits` or `SeedRateLimits` set, and the numbers never deplete as
+calls are made. Nothing counts requests. A scenario that wants the engine's
+budget-ratio thresholds (`engine/backoff.go` consumes remaining/limit as a
+ratio) must *script* the budget with `SeedRateLimits`, not expect it to fall on
+its own.
+
+**`RateLimitStats` is the one method fault injection cannot fail.** It has no
+`error` return (`engine/interfaces.go`), so there is no channel through which
+an injected failure could surface. Registering a fault against it **panics**
+rather than sitting inert — a silently-inert fault is a false-pass generator,
+and the whole point of this layer is to remove those. Scripting the budget is
+the controllability that surface actually has.
 
 Timestamps (`Reset`, `UpdatedAt`) still come from the injected clock, so a test
 controlling time sees coherent values.
 
-Fault injection generally — including rate-limit error kinds — is deferred to
-the follow-on instrumentation layer (#1457).
+**Risk — retry-after: absent.** No method returns a `Retry-After` header or its
+equivalent, because the model has no transport. Any engine behaviour keyed on a
+server-supplied backoff duration is unreachable here.
+
+### Scripted verdicts are unconstrained by the repository's real state — **Divergence, deliberate**
+
+Every scripted surface — check runs, commit statuses, reviews, review requests,
+required contexts, required approvals — is set directly, with no cross-checking
+against anything else in the model. That is the point, and it is also a way to
+write a test that passes against a world GitHub could never produce.
+
+Concretely, a scenario can construct all of these, and the model will report
+them without complaint:
+
+- A **required context that no check run or status ever posts**, or conversely a
+  passing check named for a context branch protection does not require.
+- A **review from an author who is not a collaborator**, or an `APPROVED`
+  review on a PR whose author is that same person — GitHub forbids self-approval.
+- `SeedRequiredApprovals(repo, branch, 5)` on a repo with **one** reviewer, so
+  `reviewDecision` reports `REVIEW_REQUIRED` forever.
+- A **`DISMISSED` review with no dismissing actor** and no corresponding
+  dismissal event.
+- Check runs on a **SHA that is not the head of any branch or PR**, which real
+  CI would have had no commit to run against.
+
+None of these are bugs in the model: refusing them would make large parts of
+the engine's own defensive handling untestable, which is the opposite of why
+this layer exists. But a green sim-backed test proves the engine behaves *given
+that input*, not that the input is one GitHub would ever hand it. When a
+scenario's setup starts to look exotic, check it against a real board before
+concluding the engine is correct.
+
+### Clock-driven schedules have no real-GitHub correlate — **Divergence, deliberate**
+
+The `Seed*At` / `Seed*After` methods enqueue a mutation for a future instant on
+the injected clock: "this SHA goes red at T", "the reviewer responds forty
+minutes in". Nothing on GitHub works this way — CI finishes when it finishes,
+and a reviewer responds when they respond. A schedule is a test instrument, not
+a model of anything.
+
+Two properties are worth stating because scenarios will rely on them:
+
+- **A step is a pending mutation applied on read, not a read filter.** When its
+  time arrives it *writes into the model*, permanently. So repeated reads at a
+  single clock instant are stable, and — the reason for the choice — engine
+  mutations to the same surface remain observable afterwards. A filter
+  overriding `reviewRequests` would mask `AddReviewRequest`, which is the bot
+  re-prompt ladder's own mutation (ADR-1283): the engine would make the call,
+  the model would accept it, and the next read would deny it had happened.
+- **Steps fire at `at <= now`, in time order, and in seeding order within one
+  instant.** Nothing else about their relative ordering is contractual.
+
+Because a step is a write, draining it is a side effect of *reading*. Every
+read path that touches a scheduled collection therefore calls `drainCI` or
+`drainReviews` first (`schedule.go`). A scenario that reads through a path
+which forgot to drain would see stale state — which is why
+`TestScheduleVisibleThroughEveryReadPath` builds a **fresh `Sim` per read
+path**, so one path's drain cannot cover for another's.
+
+### Sequencing is clock-driven; read-count sequencing survives in one place — **Modelled, with a caveat**
+
+The general mechanism is the injected clock, not a read counter, because **one
+poll is not one read**. `settleAwaitingCIScan` primes the store with a live
+check-run read (`RefreshCheckRunsLive`) and the handler chain it then runs
+reaches `checkCIGate`, which reads check-run state again: two reads of one SHA
+in a single poll, before `MaxConcurrent` workers are considered. Worse, the
+first of those reads is guarded on the engine having a `boardcache` wired,
+which is a harness configuration decision rather than an engine invariant. A
+read-count sequence would therefore not correspond to poll boundaries at all,
+and would shift under an edit to the handler chain — the thing under test.
+
+**The exception is `prRecord.mergeableRecomputeReads`** (see *`mergeable: null`
+— the recompute window* above), which is kept as a read counter because it
+models a genuine GitHub behaviour — a recompute that resolves after some reads
+— rather than a test's notion of elapsed time.
+
+**Risk — the single-reader caveat is live for that field.** A read-count
+sequence is only reproducible when exactly *one* call site reads the surface,
+and `FetchPRMergeableFields` has three: `FetchPRMergeable`,
+`FetchPRMergeableState`, and `MergePR`'s own gate (`prs.go`). A scenario that
+seeds `MergeableRecomputeReads: 2` and then calls `MergePR` will find the
+window drained by the gate's own read. Count the reads the code actually makes,
+not the polls you intend.
+
+### `reviewDecision` is derived, not scriptable — **Modelled, deliberately**
+
+There is no `SeedReviewDecision`. `FetchPRReviewDecision` computes its answer
+from `latestReviewsByAuthor` plus `requiredApprovals`, sharing the reduction
+with `FetchPRReviews` so the two reads cannot disagree (see *`reviewDecision`
+under branch protection* above). Exposing a direct setter would reintroduce
+exactly the bug that sharing exists to prevent: two reads of one model
+reporting two different verdicts. Script `SeedReview` (or `SeedReviewsAt`) and
+`SeedRequiredApprovals`; the decision follows.
+
+### The mutation log records attempts, and its ordering is exact only within a goroutine — **Modelled, with a stated contract**
+
+`MutationLog` (`mutationlog.go`) records **every intercepted call with its
+outcome** — reads as well as mutations, failures as well as successes,
+injected failures distinguished from model failures. Its name is narrower than
+its contract, deliberately: a log of mutations that happened could not show
+"N failed attempts followed by the success", which is the whole point of
+asserting against an injected fault. `Mutations()` is the narrower view.
+
+Entries are appended in two phases — a slot reserved *before* the underlying
+call, completed after it. That gives:
+
+- **Exact ordering within a goroutine.** Every real ordering assertion is of
+  this kind: ADR-060's "`fabrik:awaiting-done` is the very first mutation" is a
+  claim about one worker's sequential code.
+- **Reserve-order, best effort, across goroutines.** Two workers whose calls
+  interleave inside the model are ordered by which reserved its slot first.
+  That is as close to a happens-before as an out-of-band log can get.
+
+**Risk — do not write a cross-goroutine ordering assertion.** Two calls made
+concurrently from different workers have no contractual order in the log, and
+an assertion that happens to hold today is a flaky test. `Precedes` errors
+rather than answering `false` when either predicate matches nothing, so a query
+that has gone stale fails loudly instead of passing for the wrong reason — but
+nothing can rescue an assertion that was never well-defined.
+
+### Snapshot and restore — **Modelled, with quiescence assumed**
+
+`Sim.Snapshot(stagingDir)` / `Restore(snap, baseDir, opts...)` round-trip the
+whole model plus a directory copy of every backing bare repository;
+`Instrumented.Snapshot` / `RestoreInstrumented` additionally carry the fault
+schedule and the mutation log, so a restart scenario's GitHub does not quietly
+heal and an ordering assertion may span the restart. The `Clock` is *not*
+carried — it is never model-owned — and is re-supplied as an `Option`, matching
+`New`.
+
+**Simplified — snapshot assumes quiescence.** Git state and model state are
+copied in two phases, and no lock is held across both; the package's
+mu-before-gitMu invariant forbids it. Each half is internally consistent, but a
+snapshot taken while engine goroutines are running may catch a mutation in one
+half and not the other. Take one the way a restart scenario naturally would:
+between polls, with nothing in flight.
+
+**Risk — stale git worktree admin entries.** `git worktree add` runs with
+`cmd.Dir = bareDir`, so git's admin entries live inside the copied directory
+and hold *absolute* paths into throwaway checkouts under the **old** `baseDir`
+— which `t.TempDir()` guarantees differs on every run. `Snapshot` runs
+`git worktree prune` under `gitMu` before copying, which clears them.
+`snapshot_test.go` asserts a git-derived answer (commits-behind, mergeable
+state, and a real merge) recomputes correctly against the restored repository,
+because that is what would actually fail if a stale entry survived.
 
 ### HTTP / GraphQL / REST wire behaviour — **Absent**
 
@@ -1011,8 +1177,13 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 103 mutations, and
+   package cannot back up. The sweep currently catches all 144 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
+
+   The instrumentation layer's own mutations are in there too, and one of them
+   is the case this kind of code fails at most characteristically: **an
+   injector that silently succeeds**. A fault-injection test that passes
+   because nothing failed asserts something about a call that was never made.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real
 GitHub* — only that the model does what this document says. For anything subtle

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -142,6 +142,7 @@ func (s *Sim) buildProjectItem(p *projectState, ref itemRef) (*gh.ProjectItem, e
 	linked := findPRByHeadLocked(r, issueBranch(iss.number))
 	var linkedHead string
 	if linked != nil {
+		s.drainReviews(linked)
 		linkedHead = linked.head
 		item.LinkedPRNumber = linked.number
 		item.LinkedPRNumberShallow = linked.number
@@ -305,6 +306,12 @@ func (s *Sim) buildProbeItem(p *projectState, ref itemRef) (*gh.BoardProbeItem, 
 	linked := findPRByHeadLocked(r, issueBranch(iss.number))
 	var linkedHead string
 	if linked != nil {
+		// The probe reads only the PR's updatedAt, but a due review step bumps
+		// exactly that — and the probe's EffectiveUpdatedAt is how the engine
+		// decides an item is worth deep-fetching. Skipping the drain here
+		// would make a scheduled review invisible until some unrelated read
+		// happened to apply it.
+		s.drainReviews(linked)
 		linkedHead = linked.head
 		probe.LinkedPRNumber = linked.number
 		probe.LinkedPRUpdatedAt = linked.updatedAt

--- a/tests/sim/simgh/ci.go
+++ b/tests/sim/simgh/ci.go
@@ -27,6 +27,16 @@ func (s *Sim) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error) {
 }
 
 // FetchCombinedStatus returns the classic commit statuses for a ref.
+//
+// The drain below covers *both* of this function's read sections. Draining is
+// repo-wide and keyed on time, not on the SHA being read, so once the first
+// section has applied everything due the second cannot have anything left to
+// apply. A second drain would be code no mutation could prove does anything —
+// the standard this package holds itself to (see allocNumber's comment). The
+// one case it would catch is a step falling due during the git subprocess
+// between the two sections, which requires a real clock; schedules exist to be
+// driven by the injected one, and under it the two sections read the same
+// instant.
 func (s *Sim) FetchCombinedStatus(owner, repo, ref string) ([]gh.CommitStatus, error) {
 	s.mu.Lock()
 	statuses, err := func() ([]gh.CommitStatus, error) {
@@ -63,7 +73,6 @@ func (s *Sim) FetchCombinedStatus(owner, repo, ref string) ([]gh.CommitStatus, e
 	if err != nil {
 		return nil, err
 	}
-	s.drainCI(r)
 	out := make([]gh.CommitStatus, len(r.commitStatuses[sha]))
 	copy(out, r.commitStatuses[sha])
 	return out, nil

--- a/tests/sim/simgh/ci.go
+++ b/tests/sim/simgh/ci.go
@@ -19,6 +19,7 @@ func (s *Sim) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error) {
 	if err != nil {
 		return nil, err
 	}
+	s.drainCI(r)
 	runs := r.checkRuns[sha]
 	out := make([]gh.CheckRun, len(runs))
 	copy(out, runs)
@@ -33,6 +34,7 @@ func (s *Sim) FetchCombinedStatus(owner, repo, ref string) ([]gh.CommitStatus, e
 		if err != nil {
 			return nil, err
 		}
+		s.drainCI(r)
 		if direct, ok := r.commitStatuses[ref]; ok {
 			out := make([]gh.CommitStatus, len(direct))
 			copy(out, direct)
@@ -61,6 +63,7 @@ func (s *Sim) FetchCombinedStatus(owner, repo, ref string) ([]gh.CommitStatus, e
 	if err != nil {
 		return nil, err
 	}
+	s.drainCI(r)
 	out := make([]gh.CommitStatus, len(r.commitStatuses[sha]))
 	copy(out, r.commitStatuses[sha])
 	return out, nil

--- a/tests/sim/simgh/fault.go
+++ b/tests/sim/simgh/fault.go
@@ -1,0 +1,343 @@
+package simgh
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+
+	"github.com/handarbeit/fabrik/engine"
+	"github.com/handarbeit/fabrik/tests/sim/simgh/ghfault"
+)
+
+// This file is the fault injector: the mechanism that makes a chosen
+// engine.GitHubClient method fail on demand.
+//
+// # Why it exists
+//
+// The five settle scans (fabrik:awaiting-done, fabrik:awaiting-ci,
+// fabrik:awaiting-member-close, fabrik:awaiting-close,
+// fabrik:awaiting-placement — ADR-060, ADR-061, ADR-062, ADR-1097, ADR-1270)
+// each retry every poll while a specific call fails and escalate after
+// MaxRetries sustained failures. Their retry loops and escalation cutovers are
+// reachable *only* by injecting a repeatedly-failing call. That machinery is
+// the least-tested in the engine precisely because nothing has ever been able
+// to provoke it.
+//
+// # The error shape is part of the test
+//
+// A fault is registered with a caller-chosen error, and the choice is
+// load-bearing rather than cosmetic: the engine classifies rate-limit and
+// abuse-detection failures as transient-and-deferrable and everything else as
+// escalation-worthy (engine/item.go's isTransientAPIError). Injecting a
+// generic error where a rate limit was meant exercises the opposite branch
+// while the scenario believes otherwise. Use the ghfault constructors
+// re-exported at the bottom of this file; engine/simgh_fault_classification_test.go
+// pins them to the real classifier.
+//
+// # RateLimitStats cannot be failed
+//
+// It is the one interface method with no error return (engine/interfaces.go),
+// so a fault registered against it could never fire. Registering one panics
+// rather than sitting silently inert — an inert fault is a false-pass
+// generator, and this layer exists to remove those. The controllability that
+// surface actually needs is scripting the *budget* it returns, since
+// engine/backoff.go consumes it as ratios rather than as a failing call; that
+// is SeedRateLimits. Recorded in FIDELITY.md.
+//
+// # Locking
+//
+// FaultTable owns its own mutex and never holds it across a call into Sim.
+// Like MutationLog it is a leaf in the package's lock ordering.
+
+// Always is the repeat count meaning "for every matching call, without limit".
+const Always = -1
+
+// unfaultableMethods are interface methods with no error return, so no fault
+// registered against them could ever fire.
+var unfaultableMethods = map[string]bool{
+	"RateLimitStats": true,
+}
+
+// interfaceMethodSet is every method name on engine.GitHubClient, derived by
+// reflection so the set maintains itself as the interface grows. A fault
+// registered against a name not in here is a typo, and a typo that silently
+// registers nothing is a test that passes because it tested nothing.
+var interfaceMethodSet = func() map[string]bool {
+	t := reflect.TypeOf((*engine.GitHubClient)(nil)).Elem()
+	out := make(map[string]bool, t.NumMethod())
+	for i := 0; i < t.NumMethod(); i++ {
+		out[t.Method(i).Name] = true
+	}
+	return out
+}()
+
+// InterfaceMethods returns every engine.GitHubClient method name, sorted.
+// Exported for the reflection-driven completeness tests, which assert that
+// every one of them is both instrumented and (bar RateLimitStats) faultable.
+func InterfaceMethods() []string {
+	out := make([]string, 0, len(interfaceMethodSet))
+	for name := range interfaceMethodSet {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// faultRule is one registered fault.
+type faultRule struct {
+	err error
+	// remaining is how many more matching calls this rule fails: a positive
+	// count, or Always.
+	remaining int
+	// onCall, when positive, restricts the rule to exactly the Kth call to the
+	// method (1-based, counted across every call since the table was created,
+	// including ones made before the rule was registered).
+	onCall int
+	// match, when non-nil, further narrows the rule to calls whose arguments
+	// satisfy it.
+	match func(Args) bool
+	// fired counts how many times this rule has produced an error.
+	fired int
+}
+
+// FaultTable holds the registered faults for one Instrumented client.
+type FaultTable struct {
+	mu sync.Mutex
+	// rules is keyed by method name; within a method they are consulted in
+	// registration order and the first eligible one wins.
+	rules map[string][]*faultRule
+	// calls counts every intercepted call per method, whether it failed or
+	// not. This is what FailOnCall's K counts.
+	calls map[string]int
+}
+
+// NewFaultTable returns an empty table.
+func NewFaultTable() *FaultTable {
+	return &FaultTable{
+		rules: make(map[string][]*faultRule),
+		calls: make(map[string]int),
+	}
+}
+
+// validateMethod panics on a name that could never fire a fault. Both cases
+// are programming errors in the scenario, not runtime conditions, so failing
+// loudly at registration is the only way they surface at all.
+func validateMethod(method string) {
+	if !interfaceMethodSet[method] {
+		panic(fmt.Sprintf("simgh: no engine.GitHubClient method named %q; "+
+			"a fault on an unknown method would never fire", method))
+	}
+	if unfaultableMethods[method] {
+		panic(fmt.Sprintf("simgh: %s has no error return, so a fault on it could never fire; "+
+			"script its returned budget with SeedRateLimits instead", method))
+	}
+}
+
+// add registers a rule, validating the method name first.
+func (f *FaultTable) add(method string, r *faultRule) {
+	validateMethod(method)
+	if r.err == nil {
+		panic(fmt.Sprintf("simgh: fault on %s registered with a nil error; "+
+			"a nil error is indistinguishable from success", method))
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rules[method] = append(f.rules[method], r)
+}
+
+// FailOnce makes the next call to method fail with err.
+func (f *FaultTable) FailOnce(method string, err error) {
+	f.add(method, &faultRule{err: err, remaining: 1})
+}
+
+// FailNTimes makes the next n calls to method fail with err, after which it
+// succeeds again. n must be positive; use FailAlways for an unbounded fault.
+func (f *FaultTable) FailNTimes(method string, n int, err error) {
+	if n < 1 {
+		panic(fmt.Sprintf("simgh: FailNTimes(%s, %d): count must be positive; use FailAlways for an unbounded fault", method, n))
+	}
+	f.add(method, &faultRule{err: err, remaining: n})
+}
+
+// FailAlways makes every call to method fail with err until the rule is
+// cleared.
+func (f *FaultTable) FailAlways(method string, err error) {
+	f.add(method, &faultRule{err: err, remaining: Always})
+}
+
+// FailOnCall makes only the kth call to method fail with err, counting from 1
+// across every call since the table was created — including calls made before
+// this rule was registered. Earlier and later calls succeed.
+func (f *FaultTable) FailOnCall(method string, k int, err error) {
+	if k < 1 {
+		panic(fmt.Sprintf("simgh: FailOnCall(%s, %d): call number must be 1-based and positive", method, k))
+	}
+	f.add(method, &faultRule{err: err, remaining: Always, onCall: k})
+}
+
+// FailWhen makes the next times calls to method whose arguments satisfy match
+// fail with err. times is a positive count or Always.
+//
+// The narrowing is what makes the settle scans testable. Each of them retries
+// a *specific* call for a *specific* issue while MaxConcurrent workers are
+// touching other items through the same methods; a method-name-only injector
+// would fail all of them at once and could not express the scenario at all.
+func (f *FaultTable) FailWhen(method string, match func(Args) bool, times int, err error) {
+	if match == nil {
+		panic(fmt.Sprintf("simgh: FailWhen(%s): nil match; use FailNTimes or FailAlways for an unnarrowed fault", method))
+	}
+	if times < 1 && times != Always {
+		panic(fmt.Sprintf("simgh: FailWhen(%s, …, %d): count must be positive or simgh.Always", method, times))
+	}
+	f.add(method, &faultRule{err: err, remaining: times, match: match})
+}
+
+// Clear removes every rule registered against method. The call counter is left
+// alone, so a subsequent FailOnCall still counts from the table's creation.
+func (f *FaultTable) Clear(method string) {
+	validateMethod(method)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.rules, method)
+}
+
+// ClearAll removes every rule. Call counters are left alone.
+func (f *FaultTable) ClearAll() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rules = make(map[string][]*faultRule)
+}
+
+// CallCount reports how many calls to method have been intercepted, whether
+// they failed or not.
+func (f *FaultTable) CallCount(method string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[method]
+}
+
+// FiredCount reports how many injected failures method has produced.
+func (f *FaultTable) FiredCount(method string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	total := 0
+	for _, r := range f.rules[method] {
+		total += r.fired
+	}
+	return total
+}
+
+// next records a call against method and returns the error to fail it with, or
+// nil to let it through. Every intercepted call goes through here exactly
+// once, before the underlying Sim call.
+func (f *FaultTable) next(method string, args Args) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.calls[method]++
+	n := f.calls[method]
+
+	for _, r := range f.rules[method] {
+		if r.match != nil && !r.match(args) {
+			continue
+		}
+		if r.onCall > 0 {
+			if n != r.onCall {
+				continue
+			}
+			r.fired++
+			return r.err
+		}
+		if r.remaining == 0 {
+			continue
+		}
+		if r.remaining > 0 {
+			r.remaining--
+		}
+		r.fired++
+		return r.err
+	}
+	return nil
+}
+
+// snapshotRules deep-copies the table's state so a Sim snapshot can carry it.
+// The match closures are shared rather than copied — they are stateless
+// predicates supplied by the scenario, and a scenario that hid mutable state
+// in one has already broken determinism for reasons this package cannot fix.
+func (f *FaultTable) snapshotRules() (map[string][]*faultRule, map[string]int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rules := make(map[string][]*faultRule, len(f.rules))
+	for method, list := range f.rules {
+		copies := make([]*faultRule, 0, len(list))
+		for _, r := range list {
+			dup := *r
+			copies = append(copies, &dup)
+		}
+		rules[method] = copies
+	}
+	calls := make(map[string]int, len(f.calls))
+	for k, v := range f.calls {
+		calls[k] = v
+	}
+	return rules, calls
+}
+
+// restoreRules replaces the table's state with a snapshot's, deep-copying
+// again so the snapshot stays reusable for a second restore.
+func (f *FaultTable) restoreRules(rules map[string][]*faultRule, calls map[string]int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rules = make(map[string][]*faultRule, len(rules))
+	for method, list := range rules {
+		copies := make([]*faultRule, 0, len(list))
+		for _, r := range list {
+			dup := *r
+			copies = append(copies, &dup)
+		}
+		f.rules[method] = copies
+	}
+	f.calls = make(map[string]int, len(calls))
+	for k, v := range calls {
+		f.calls[k] = v
+	}
+}
+
+// --- ghfault re-exports ----------------------------------------------------
+//
+// Re-exported so a scenario needs one import rather than two, while the
+// constructors themselves stay in a stdlib-only leaf package that `engine` can
+// import from a test without a cycle. See ghfault's package doc.
+
+// ErrRateLimit returns GitHub's REST primary rate-limit exhaustion error.
+func ErrRateLimit() error { return ghfault.RateLimit() }
+
+// ErrGraphQLRateLimit returns GitHub's GraphQL primary rate-limit exhaustion error.
+func ErrGraphQLRateLimit() error { return ghfault.GraphQLRateLimit() }
+
+// ErrSecondaryRateLimit returns GitHub's secondary rate-limit error.
+func ErrSecondaryRateLimit() error { return ghfault.SecondaryRateLimit() }
+
+// ErrAbuseDetection returns GitHub's abuse-detection error.
+func ErrAbuseDetection() error { return ghfault.AbuseDetection() }
+
+// ErrTooManyRequests returns a bare HTTP 429 in the engine's REST framing.
+func ErrTooManyRequests() error { return ghfault.TooManyRequests() }
+
+// ErrServerError returns a GitHub 5xx in the engine's REST framing.
+func ErrServerError() error { return ghfault.ServerError() }
+
+// ErrConnectionReset returns a transport-layer connection reset.
+func ErrConnectionReset() error { return ghfault.ConnectionReset() }
+
+// ErrIOTimeout returns a transport-layer read timeout.
+func ErrIOTimeout() error { return ghfault.IOTimeout() }
+
+// ErrNotFound returns a GitHub 404 — the non-transient control case.
+func ErrNotFound() error { return ghfault.NotFound() }
+
+// WrapErr produces an error carrying sentinel in its chain, for the engine's
+// errors.Is matches against gh.ErrNotMergeable, gh.ErrNotMergeableCI and
+// gh.ErrNotFound.
+func WrapErr(sentinel error, msg string) error { return ghfault.Wrap(sentinel, msg) }

--- a/tests/sim/simgh/fault_test.go
+++ b/tests/sim/simgh/fault_test.go
@@ -1,0 +1,282 @@
+package simgh
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// TestFaultFailsNTimesThenSucceeds is AC4.
+//
+// Two claims, and the second is the one that matters. The first is that the
+// injector counts: exactly N failures, then success. The second is that the
+// *log shows it* — N failed attempts followed by the success. A log recording
+// only mutations that happened could not, which is why its contract is "every
+// intercepted call, with its outcome" rather than what its name suggests.
+func TestFaultFailsNTimesThenSucceeds(t *testing.T) {
+	const n = 3
+	in, _ := newInstrumented(t)
+	in.Faults().FailNTimes("AddLabelToIssue", n, ErrRateLimit())
+
+	for i := 0; i < n; i++ {
+		if err := in.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-done"); err == nil {
+			t.Fatalf("attempt %d succeeded, want the injected failure", i+1)
+		}
+	}
+	if err := in.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-done"); err != nil {
+		t.Fatalf("attempt %d: %v — want success once the fault is exhausted", n+1, err)
+	}
+
+	entries := in.Log().ByMethod("AddLabelToIssue")
+	if len(entries) != n+1 {
+		t.Fatalf("log has %d AddLabelToIssue entries, want %d\n%s", len(entries), n+1, in.Log().Dump(20))
+	}
+	for i := 0; i < n; i++ {
+		if !entries[i].Failed() {
+			t.Errorf("log entry %d records a success, want the injected failure", i)
+		}
+		if !entries[i].Injected {
+			t.Errorf("log entry %d does not mark the failure as injected", i)
+		}
+	}
+	if entries[n].Failed() {
+		t.Errorf("log entry %d records a failure, want the success: %s", n, entries[n])
+	}
+
+	// The label must genuinely have been applied only by the successful call:
+	// a fault that logged a failure but let the mutation through would satisfy
+	// every assertion above.
+	labels, err := in.Sim().FetchLabels("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !contains(labels, "fabrik:awaiting-done") {
+		t.Error("label absent after the successful attempt")
+	}
+	if in.Faults().FiredCount("AddLabelToIssue") != n {
+		t.Errorf("FiredCount = %d, want %d", in.Faults().FiredCount("AddLabelToIssue"), n)
+	}
+}
+
+// A faulted call must not reach the model at all. Logging a failure while
+// letting the mutation through would make every settle-scan scenario pass
+// against a GitHub that never actually failed.
+func TestAFaultedCallDoesNotReachTheModel(t *testing.T) {
+	in, _ := newInstrumented(t)
+	in.Faults().FailAlways("AddLabelToIssue", ErrRateLimit())
+
+	if err := in.AddLabelToIssue("acme", "widgets", 7, "fabrik:paused"); err == nil {
+		t.Fatal("AddLabelToIssue succeeded despite FailAlways")
+	}
+	labels, err := in.Sim().FetchLabels("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if contains(labels, "fabrik:paused") {
+		t.Error("the faulted call still mutated the model")
+	}
+}
+
+func TestFailOnce(t *testing.T) {
+	in, _ := newInstrumented(t)
+	in.Faults().FailOnce("FetchLabels", ErrServerError())
+
+	if _, err := in.FetchLabels("acme", "widgets", 7); err == nil {
+		t.Fatal("first call succeeded, want the injected failure")
+	}
+	if _, err := in.FetchLabels("acme", "widgets", 7); err != nil {
+		t.Fatalf("second call failed: %v — FailOnce must fire exactly once", err)
+	}
+}
+
+func TestFailOnCallFiresOnlyOnTheKthCall(t *testing.T) {
+	in, _ := newInstrumented(t)
+	in.Faults().FailOnCall("FetchLabels", 3, ErrTooManyRequests())
+
+	var failedAt []int
+	for i := 1; i <= 5; i++ {
+		if _, err := in.FetchLabels("acme", "widgets", 7); err != nil {
+			failedAt = append(failedAt, i)
+		}
+	}
+	if len(failedAt) != 1 || failedAt[0] != 3 {
+		t.Errorf("calls failed at %v, want only call 3", failedAt)
+	}
+	if got := in.Faults().CallCount("FetchLabels"); got != 5 {
+		t.Errorf("CallCount = %d, want 5 — every intercepted call counts, faulted or not", got)
+	}
+}
+
+// FailWhen's narrowing is what makes the settle scans testable: each retries a
+// specific call for a specific issue while other workers touch other items
+// through the same method.
+func TestFailWhenNarrowsByArguments(t *testing.T) {
+	in, _ := newInstrumented(t)
+	in.Sim().SeedIssue("acme/widgets", IssueSeed{Number: 8, Title: "other", Status: "Implement"})
+	if err := in.Sim().Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	in.Faults().FailWhen("AddLabelToIssue",
+		func(a Args) bool { return a.Number == 7 && a.Label == "fabrik:awaiting-done" },
+		Always, ErrRateLimit())
+
+	if err := in.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-done"); err == nil {
+		t.Error("the targeted call succeeded")
+	}
+	if err := in.AddLabelToIssue("acme", "widgets", 8, "fabrik:awaiting-done"); err != nil {
+		t.Errorf("a different issue was caught by the narrowed fault: %v", err)
+	}
+	if err := in.AddLabelToIssue("acme", "widgets", 7, "fabrik:paused"); err != nil {
+		t.Errorf("a different label on the same issue was caught by the narrowed fault: %v", err)
+	}
+}
+
+func TestClearAndClearAll(t *testing.T) {
+	in, _ := newInstrumented(t)
+	in.Faults().FailAlways("FetchLabels", ErrRateLimit())
+	in.Faults().FailAlways("GetIssueBody", ErrRateLimit())
+
+	in.Faults().Clear("FetchLabels")
+	if _, err := in.FetchLabels("acme", "widgets", 7); err != nil {
+		t.Errorf("FetchLabels still faulted after Clear: %v", err)
+	}
+	if _, err := in.GetIssueBody("acme", "widgets", 7); err == nil {
+		t.Error("Clear removed a rule on a different method")
+	}
+
+	in.Faults().ClearAll()
+	if _, err := in.GetIssueBody("acme", "widgets", 7); err != nil {
+		t.Errorf("GetIssueBody still faulted after ClearAll: %v", err)
+	}
+}
+
+// The injected error must be usable with errors.Is, so a scenario can inject
+// exactly the sentinel a production path matches on.
+func TestInjectedSentinelsSurviveWrapping(t *testing.T) {
+	in, _ := newInstrumented(t)
+	in.Faults().FailOnce("MergePR", WrapErr(gh.ErrNotMergeable, "simgh: injected"))
+
+	err := in.MergePR("acme", "widgets", 1)
+	if !errors.Is(err, gh.ErrNotMergeable) {
+		t.Fatalf("MergePR err = %v, want errors.Is(err, gh.ErrNotMergeable)", err)
+	}
+}
+
+func TestRegisteringAFaultOnAnUnknownMethodPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("no panic for an unknown method name")
+		}
+		if !strings.Contains(toString(r), "FetchNonsense") {
+			t.Errorf("panic message %v does not name the offending method", r)
+		}
+	}()
+	NewFaultTable().FailOnce("FetchNonsense", ErrRateLimit())
+}
+
+// RateLimitStats has no error return, so a fault on it could never fire. A
+// silently-inert fault is a false-pass generator: the scenario believes it has
+// made the call fail and asserts against a path that was never taken.
+func TestRegisteringAFaultOnRateLimitStatsPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("no panic for a fault on RateLimitStats")
+		}
+		if !strings.Contains(toString(r), "SeedRateLimits") {
+			t.Errorf("panic message %v does not point at the supported alternative", r)
+		}
+	}()
+	NewFaultTable().FailAlways("RateLimitStats", ErrRateLimit())
+}
+
+func TestRegisteringAFaultWithANilErrorPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("no panic for a nil injected error — it is indistinguishable from success")
+		}
+	}()
+	NewFaultTable().FailOnce("FetchLabels", nil)
+}
+
+func TestFaultCountValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(*FaultTable)
+	}{
+		{"FailNTimes(0)", func(f *FaultTable) { f.FailNTimes("FetchLabels", 0, ErrRateLimit()) }},
+		{"FailNTimes(-1)", func(f *FaultTable) { f.FailNTimes("FetchLabels", -1, ErrRateLimit()) }},
+		{"FailOnCall(0)", func(f *FaultTable) { f.FailOnCall("FetchLabels", 0, ErrRateLimit()) }},
+		{"FailWhen(nil match)", func(f *FaultTable) { f.FailWhen("FetchLabels", nil, 1, ErrRateLimit()) }},
+		{"FailWhen(0)", func(f *FaultTable) {
+			f.FailWhen("FetchLabels", func(Args) bool { return true }, 0, ErrRateLimit())
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("%s did not panic", tc.name)
+				}
+			}()
+			tc.call(NewFaultTable())
+		})
+	}
+}
+
+// TestEveryInterfaceMethodIsFaultable is the fault table's drift detector: a
+// wrapper that delegated without consulting the table would make a fault
+// registered against it silently inert. Every method but RateLimitStats — the
+// one with no error return — must be reachable.
+func TestEveryInterfaceMethodIsFaultable(t *testing.T) {
+	for _, name := range InterfaceMethods() {
+		if unfaultableMethods[name] {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			in, _ := newInstrumented(t)
+			in.Faults().FailAlways(name, ErrRateLimit())
+			callInterfaceMethod(t, in, name)
+
+			entries := in.Log().Entries()
+			if len(entries) != 1 {
+				t.Fatalf("calling %s produced %d log entries, want 1", name, len(entries))
+			}
+			if !entries[0].Injected {
+				t.Errorf("%s is not faultable: the registered fault never fired\n  %s", name, entries[0])
+			}
+			if in.Faults().FiredCount(name) != 1 {
+				t.Errorf("%s: FiredCount = %d, want 1", name, in.Faults().FiredCount(name))
+			}
+		})
+	}
+}
+
+// The unfaultable set must stay exactly the methods with no error return —
+// otherwise a method could be excused from fault injection by being added to
+// the map rather than by being genuinely unfaultable.
+func TestUnfaultableSetIsExactlyTheErrorlessMethods(t *testing.T) {
+	for name := range unfaultableMethods {
+		if !interfaceMethodSet[name] {
+			t.Errorf("unfaultableMethods lists %q, which is not an engine.GitHubClient method", name)
+		}
+	}
+	if len(unfaultableMethods) != 1 || !unfaultableMethods["RateLimitStats"] {
+		t.Errorf("unfaultableMethods = %v, want exactly {RateLimitStats}; every other method returns an error",
+			unfaultableMethods)
+	}
+}
+
+func toString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if err, ok := v.(error); ok {
+		return err.Error()
+	}
+	return ""
+}

--- a/tests/sim/simgh/ghfault/ghfault.go
+++ b/tests/sim/simgh/ghfault/ghfault.go
@@ -1,0 +1,141 @@
+// Package ghfault constructs the error shapes Fabrik's engine classifies
+// specially, for injection through simgh's fault table.
+//
+// # Why this is its own package
+//
+// It is a deliberately tiny, stdlib-only leaf: it imports nothing from this
+// repository, so `engine` can import it from a test without a cycle.
+// `tests/sim/simgh` imports `engine` (it satisfies engine.GitHubClient), so an
+// internal `package engine` test cannot reach the constructors if they live
+// there — and the classifier they exist to pin, isTransientAPIError, is
+// unexported and reached only through unexported code, so an external
+// `package engine_test` cannot see it either. Splitting the constructors out
+// is what lets `engine/simgh_fault_classification_test.go` assert against the
+// real classifier without exporting it and without touching production code.
+//
+// # Why the strings matter
+//
+// The engine classifies these failures by substring match against err.Error()
+// (engine/item.go: isTransientError, rateLimitErrorPatterns,
+// isTransientAPIError). An injected error whose text the classifier does not
+// recognise exercises the *non*-transient branch, so a fault-injection test
+// built on it silently proves the opposite of what it claims. Each constructor
+// below therefore documents the exact production pattern it is built to match,
+// and engine/simgh_fault_classification_test.go asserts the match against the
+// real predicates — so a rewording of either side fails loudly rather than
+// quietly re-routing every scenario built on it.
+//
+// The messages imitate GitHub's own framing (REST's "GitHub API returned %d:
+// %s", GraphQL's error prose) rather than being minimal strings that merely
+// happen to contain the pattern. A test built on a bare "abuse detection"
+// would keep passing if the classifier were narrowed to require surrounding
+// context that real GitHub always supplies.
+package ghfault
+
+import (
+	"errors"
+	"fmt"
+)
+
+// RateLimit returns GitHub's REST primary rate-limit exhaustion error.
+//
+// Matches the "api rate limit exceeded" entry of engine/item.go's
+// rateLimitErrorPatterns, so isTransientAPIError classifies it as transient
+// (defer indefinitely, do not consume an escalation budget). Note that
+// isTransientError — the narrower, bounded-retry predicate — does *not*
+// recognise it; that asymmetry is the point of the two predicates and is
+// asserted in engine/simgh_fault_classification_test.go.
+func RateLimit() error {
+	return errors.New("GitHub API returned 403: API rate limit exceeded for user ID 12345")
+}
+
+// GraphQLRateLimit returns GitHub's GraphQL primary rate-limit exhaustion
+// error, whose wording differs from REST's.
+//
+// Matches the "api rate limit already exceeded" entry of rateLimitErrorPatterns.
+// It exists separately from RateLimit because the two phrases are separate
+// entries in that table — deliberately split so a bare "api rate limit" prefix
+// cannot match unrelated prose — and a constructor for only one of them would
+// leave the other unpinned.
+func GraphQLRateLimit() error {
+	return errors.New("GraphQL error: API rate limit already exceeded for user ID 12345")
+}
+
+// SecondaryRateLimit returns GitHub's secondary rate-limit error, the one
+// returned for bursty writes rather than for quota exhaustion.
+//
+// Matches the "secondary rate limit" entry of rateLimitErrorPatterns.
+func SecondaryRateLimit() error {
+	return errors.New("GitHub API returned 403: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.")
+}
+
+// AbuseDetection returns GitHub's abuse-detection error.
+//
+// Matches the "abuse detection" entry of rateLimitErrorPatterns.
+func AbuseDetection() error {
+	return errors.New("GitHub API returned 403: You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.")
+}
+
+// TooManyRequests returns a bare HTTP 429 in the engine's REST framing.
+//
+// Matches isTransientAPIError's "github api returned 429" substring rather
+// than any phrase-table entry: GitHub uses 429 exclusively for rate limiting,
+// so the engine treats the status code alone as sufficient. This is the one
+// rate-limit shape that carries no recognisable body prose, which is exactly
+// why it is worth being able to inject.
+func TooManyRequests() error {
+	return errors.New("GitHub API returned 429: Too Many Requests")
+}
+
+// ServerError returns a GitHub 5xx in the engine's REST framing.
+//
+// Matches isTransientError's "GitHub API returned 5" substring, so it is
+// transient under *both* predicates — unlike the rate-limit shapes, which only
+// isTransientAPIError recognises. Injecting this exercises the bounded-retry
+// paths; injecting RateLimit exercises the defer-indefinitely ones.
+func ServerError() error {
+	return errors.New("GitHub API returned 502: Bad Gateway")
+}
+
+// ConnectionReset returns a transport-layer connection reset.
+//
+// Matches isTransientError's "connection reset" substring. It is a plain
+// string error rather than a real *net.OpError on purpose: the engine's string
+// branch and its errors.As branch are separate classification routes, and this
+// constructor exists to pin the string one. A *net.OpError would be classified
+// by the other route and would leave the substring untested.
+func ConnectionReset() error {
+	return errors.New("Post \"https://api.github.com/graphql\": read tcp 10.0.0.1:54321->140.82.121.6:443: connection reset by peer")
+}
+
+// IOTimeout returns a transport-layer read timeout.
+//
+// Matches isTransientError's "i/o timeout" substring. Plain string error for
+// the same reason as ConnectionReset.
+func IOTimeout() error {
+	return errors.New("Post \"https://api.github.com/graphql\": dial tcp 140.82.121.6:443: i/o timeout")
+}
+
+// NotFound returns a GitHub 404 in the engine's REST framing.
+//
+// Deliberately *not* transient under either predicate: it is here so a
+// scenario can inject a failure the engine must escalate rather than defer,
+// which is the control case every transient-classification assertion needs.
+func NotFound() error {
+	return errors.New("GitHub API returned 404: Not Found")
+}
+
+// Wrap produces an error carrying sentinel in its chain, so that a caller
+// matching with errors.Is (as the engine does for github.ErrNotMergeable,
+// ErrNotMergeableCI and ErrNotFound) recognises the injected failure as that
+// specific condition.
+//
+// The sentinel is supplied by the caller rather than named here, because those
+// sentinels live in the `github` package and this one imports nothing from
+// this repository — see the package doc.
+func Wrap(sentinel error, msg string) error {
+	if sentinel == nil {
+		return errors.New(msg)
+	}
+	return fmt.Errorf("%s: %w", msg, sentinel)
+}

--- a/tests/sim/simgh/ghfault/ghfault_test.go
+++ b/tests/sim/simgh/ghfault/ghfault_test.go
@@ -1,0 +1,84 @@
+package ghfault
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The authoritative assertion that these constructors are shaped correctly is
+// engine/simgh_fault_classification_test.go, which runs them through the
+// engine's real (unexported) classifier. These tests are the local guard: they
+// pin the substring each constructor promises, so a reworded message fails
+// here — in the package that owns the wording — rather than only in a distant
+// engine test.
+func TestConstructorsCarryTheirClassificationPhrase(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string // lowercased substring the engine matches on
+	}{
+		{"RateLimit", RateLimit(), "api rate limit exceeded"},
+		{"GraphQLRateLimit", GraphQLRateLimit(), "api rate limit already exceeded"},
+		{"SecondaryRateLimit", SecondaryRateLimit(), "secondary rate limit"},
+		{"AbuseDetection", AbuseDetection(), "abuse detection"},
+		{"TooManyRequests", TooManyRequests(), "github api returned 429"},
+		{"ServerError", ServerError(), "github api returned 5"},
+		{"ConnectionReset", ConnectionReset(), "connection reset"},
+		{"IOTimeout", IOTimeout(), "i/o timeout"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.err == nil {
+				t.Fatal("constructor returned nil")
+			}
+			if got := strings.ToLower(tc.err.Error()); !strings.Contains(got, tc.want) {
+				t.Errorf("%s() = %q, want it to contain %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// NotFound is the control case: it must not carry any transient phrase, or
+// every "this error escalates" assertion built on it would be testing the
+// defer path instead.
+func TestNotFoundCarriesNoTransientPhrase(t *testing.T) {
+	msg := strings.ToLower(NotFound().Error())
+	for _, phrase := range []string{
+		"api rate limit", "secondary rate limit", "abuse detection",
+		"github api returned 429", "github api returned 5",
+		"connection reset", "i/o timeout",
+	} {
+		if strings.Contains(msg, phrase) {
+			t.Errorf("NotFound() = %q, must not contain transient phrase %q", msg, phrase)
+		}
+	}
+}
+
+func TestWrapPreservesTheSentinel(t *testing.T) {
+	sentinel := errors.New("not mergeable")
+	err := Wrap(sentinel, "simgh: merging PR #7")
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Wrap(%v) = %v, want errors.Is to match the sentinel", sentinel, err)
+	}
+	if !strings.Contains(err.Error(), "simgh: merging PR #7") {
+		t.Errorf("Wrap() = %q, want it to carry the caller's message", err)
+	}
+	if !strings.Contains(err.Error(), "not mergeable") {
+		t.Errorf("Wrap() = %q, want it to carry the sentinel's message", err)
+	}
+}
+
+// A nil sentinel must still yield a usable error rather than a nil the
+// injector would read as "no fault" — silently turning a registered fault into
+// a call that succeeds is the exact false pass this layer exists to prevent.
+func TestWrapWithNilSentinelStillReturnsAnError(t *testing.T) {
+	err := Wrap(nil, "boom")
+	if err == nil {
+		t.Fatal("Wrap(nil, …) = nil, want a non-nil error")
+	}
+	if err.Error() != "boom" {
+		t.Errorf("Wrap(nil, \"boom\") = %q, want %q", err, "boom")
+	}
+}

--- a/tests/sim/simgh/helpers_test.go
+++ b/tests/sim/simgh/helpers_test.go
@@ -3,6 +3,7 @@ package simgh
 import (
 	"errors"
 	"os/exec"
+	"reflect"
 	"testing"
 	"time"
 
@@ -68,6 +69,42 @@ func seedBasicBoard(t *testing.T) (*Sim, *fakeClock) {
 		t.Fatalf("seeding: %v", err)
 	}
 	return s, clk
+}
+
+// newInstrumented builds a Sim over the usual basic board and wraps it in the
+// instrumentation layer.
+func newInstrumented(t *testing.T) (*Instrumented, *fakeClock) {
+	t.Helper()
+	s, clk := seedBasicBoard(t)
+	return Instrument(s), clk
+}
+
+// callInterfaceMethod invokes the named engine.GitHubClient method on in with
+// zero-valued arguments, discarding whatever it returns.
+//
+// The reflection-driven completeness tests care only that the call was
+// intercepted, not that it succeeded — most of these fail inside the model
+// because nothing relevant is seeded, and that is fine: a failed call is still
+// an intercepted one, and the log records attempts rather than mutations.
+// Pointer parameters get a fresh zero value rather than nil, so a method that
+// rejects nil outright still reaches its wrapper the same way.
+func callInterfaceMethod(t *testing.T, in *Instrumented, name string) {
+	t.Helper()
+	m := reflect.ValueOf(in).MethodByName(name)
+	if !m.IsValid() {
+		t.Fatalf("*Instrumented has no method %q — every engine.GitHubClient method needs a wrapper", name)
+	}
+	mt := m.Type()
+	args := make([]reflect.Value, mt.NumIn())
+	for i := range args {
+		at := mt.In(i)
+		if at.Kind() == reflect.Pointer {
+			args[i] = reflect.New(at.Elem())
+			continue
+		}
+		args[i] = reflect.Zero(at)
+	}
+	m.Call(args)
 }
 
 // mustHeadSHA resolves a branch tip or fails the test.

--- a/tests/sim/simgh/helpers_test.go
+++ b/tests/sim/simgh/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os/exec"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -32,15 +33,33 @@ func skipIfNoGit(t *testing.T) {
 // produces reads from the injected clock, so a test can place label
 // applications at exact instants — which is what the engine's timeout-anchored
 // gates need.
-type fakeClock struct{ t time.Time }
+//
+// It is mutex-guarded because Clock's contract requires it (see sim.go): Now is
+// called from every worker goroutine — on every timestamped model read, on
+// every schedule drain, and on every call the instrumentation layer intercepts
+// — while Advance writes. An unguarded time.Time field would be a data race
+// the moment a scenario advanced the clock with anything in flight, which is
+// how a harness driving Engine.Run() necessarily uses it.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
 
 func newFakeClock() *fakeClock {
 	return &fakeClock{t: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)}
 }
 
-func (c *fakeClock) Now() time.Time { return c.t }
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
 
-func (c *fakeClock) Advance(d time.Duration) { c.t = c.t.Add(d) }
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
 
 // newSim builds a Sim with a fake clock over a temp base dir.
 func newSim(t *testing.T) (*Sim, *fakeClock) {

--- a/tests/sim/simgh/instrumented.go
+++ b/tests/sim/simgh/instrumented.go
@@ -145,10 +145,27 @@ func (in *Instrumented) ProbeProjectBoard(owner, repo string, projectNum int, ow
 		})
 }
 
+// FetchItemDetails is the one wrapper whose owner and repo are not separate
+// parameters: gh.ProjectItem.Repo is the composite "owner/repo". They are split
+// here so Args.Repo carries the bare repository name, as it does in all
+// fifty-nine other wrappers.
+//
+// This matters rather than being tidiness. FetchItemDetails is the call the
+// settle scans retry — it is R3's motivating target — so it is the method a
+// scenario is most likely to narrow a FailWhen on. A predicate written
+// `a.Repo == "widgets"` against a composite would simply never match, and a
+// fault that never fires is a scenario that passes having tested nothing.
+//
+// A value that does not split (no separator) is left in Repo whole, matching
+// the model's own tolerance: the log is a debugging aid and must not lose
+// information it cannot parse.
 func (in *Instrumented) FetchItemDetails(item *gh.ProjectItem) error {
 	args := Args{}
 	if item != nil {
 		args = Args{Repo: item.Repo, Number: item.Number, ID: item.ItemID}
+		if owner, repo, err := splitOwnerRepo(item.Repo); err == nil {
+			args.Owner, args.Repo = owner, repo
+		}
 	}
 	return do0(in, "FetchItemDetails", false, args, func() error { return in.sim.FetchItemDetails(item) })
 }

--- a/tests/sim/simgh/instrumented.go
+++ b/tests/sim/simgh/instrumented.go
@@ -1,0 +1,459 @@
+package simgh
+
+import (
+	"time"
+
+	"github.com/handarbeit/fabrik/engine"
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// This file is the instrumentation layer: a decorator around *Sim that adds
+// fault injection (fault.go) and the mutation log (mutationlog.go) without
+// changing a line of the model.
+//
+// # Why a decorator rather than inline instrumentation
+//
+// Threading a log write and a fault check through ~60 existing method bodies
+// would perturb every one of them, and nonvacuity.sh's mutations are
+// line-pattern-sensitive perl edits that the churn would break wholesale. The
+// wrapper isolates the new code entirely, and the compile-time interface
+// assertion below makes it grow in lockstep with engine.GitHubClient.
+//
+// # Why sim is a named field and never an embedded one
+//
+// This is the load-bearing detail of the whole design, and it is a one-word
+// change away from being destroyed.
+//
+// An *embedded* *Sim would promote all sixty methods, so
+// `var _ engine.GitHubClient = (*Instrumented)(nil)` would be satisfied *by
+// promotion* — a wrapper method you forgot to write, or one added to the
+// interface later, would compile cleanly and silently bypass both the fault
+// table and the log. The wrapper would appear to work and would quietly not
+// instrument whatever was missed, which is worse than no wrapper at all: every
+// scenario built on it would pass for the wrong reason.
+//
+// With a named field, the same omission is a compile error. That is the entire
+// reason to prefer a decorator here. Do not embed this field, however much
+// shorter it would make the file.
+//
+// # Locking
+//
+// Both new mutexes are acquired and released *before* control enters Sim, and
+// neither is ever held across a Sim call. They are therefore leaves in the
+// package's lock ordering and add no edge to the mu-before-gitMu invariant
+// documented in sim.go.
+
+// Instrumented wraps a Sim with fault injection and a mutation log. It
+// satisfies engine.GitHubClient, so the engine can be pointed at it in place
+// of the bare Sim.
+var _ engine.GitHubClient = (*Instrumented)(nil)
+
+// Instrumented is the controllable GitHub stand-in: a Sim plus the two
+// cross-cutting test instruments.
+type Instrumented struct {
+	// sim is deliberately a NAMED field, never embedded. See this file's doc
+	// comment — embedding it would satisfy the interface assertion above by
+	// method promotion and make a forgotten wrapper compile silently.
+	sim *Sim
+
+	faults *FaultTable
+	log    *MutationLog
+}
+
+// Instrument wraps a Sim. The Sim remains usable directly — Seed* calls go
+// through Sim() — but only calls made through the wrapper are faulted and
+// logged.
+func Instrument(s *Sim) *Instrumented {
+	return &Instrumented{
+		sim:    s,
+		faults: NewFaultTable(),
+		log:    NewMutationLog(),
+	}
+}
+
+// Sim returns the wrapped model, for the Seed* API and for Snapshot/Restore.
+func (in *Instrumented) Sim() *Sim { return in.sim }
+
+// Faults returns the fault table.
+func (in *Instrumented) Faults() *FaultTable { return in.faults }
+
+// Log returns the mutation log.
+func (in *Instrumented) Log() *MutationLog { return in.log }
+
+// --- interception helpers --------------------------------------------------
+//
+// Every wrapper below is one call to one of these. Keeping them mechanically
+// uniform is deliberate: a wrong method-name string is caught by
+// TestEveryInterfaceMethodIsInstrumented, but a wrong Args field is caught
+// only by review, and review of sixty near-identical lines only works if they
+// really are near-identical.
+
+// do0 intercepts a method returning only an error.
+func do0(in *Instrumented, method string, mutation bool, args Args, fn func() error) error {
+	seq := in.log.reserve(method, mutation, args, in.sim.now())
+	if err := in.faults.next(method, args); err != nil {
+		in.log.complete(seq, err, true)
+		return err
+	}
+	err := fn()
+	in.log.complete(seq, err, false)
+	return err
+}
+
+// do1 intercepts a method returning one value and an error.
+func do1[T any](in *Instrumented, method string, mutation bool, args Args, fn func() (T, error)) (T, error) {
+	seq := in.log.reserve(method, mutation, args, in.sim.now())
+	if err := in.faults.next(method, args); err != nil {
+		var zero T
+		in.log.complete(seq, err, true)
+		return zero, err
+	}
+	v, err := fn()
+	in.log.complete(seq, err, false)
+	return v, err
+}
+
+// do2 intercepts a method returning two values and an error.
+func do2[A, B any](in *Instrumented, method string, mutation bool, args Args, fn func() (A, B, error)) (A, B, error) {
+	seq := in.log.reserve(method, mutation, args, in.sim.now())
+	if err := in.faults.next(method, args); err != nil {
+		var zeroA A
+		var zeroB B
+		in.log.complete(seq, err, true)
+		return zeroA, zeroB, err
+	}
+	a, b, err := fn()
+	in.log.complete(seq, err, false)
+	return a, b, err
+}
+
+// There is deliberately no do3: no method on engine.GitHubClient returns three
+// values plus an error. An unused helper could not be exercised, so the
+// non-vacuity sweep could not prove it does anything.
+
+// --- board -----------------------------------------------------------------
+
+func (in *Instrumented) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+	return do1(in, "FetchProjectBoard", false, Args{Owner: owner, Repo: repo, Values: []string{ownerType}},
+		func() (*gh.ProjectBoard, error) { return in.sim.FetchProjectBoard(owner, repo, projectNum, ownerType) })
+}
+
+func (in *Instrumented) ProbeProjectBoard(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+	return do2(in, "ProbeProjectBoard", false, Args{Owner: owner, Repo: repo, Values: []string{ownerType}},
+		func() ([]gh.BoardProbeItem, string, error) { return in.sim.ProbeProjectBoard(owner, repo, projectNum, ownerType) })
+}
+
+func (in *Instrumented) FetchItemDetails(item *gh.ProjectItem) error {
+	args := Args{}
+	if item != nil {
+		args = Args{Repo: item.Repo, Number: item.Number, ID: item.ItemID}
+	}
+	return do0(in, "FetchItemDetails", false, args, func() error { return in.sim.FetchItemDetails(item) })
+}
+
+func (in *Instrumented) FetchStatusField(projectID string) (*gh.StatusField, error) {
+	return do1(in, "FetchStatusField", false, Args{ID: projectID},
+		func() (*gh.StatusField, error) { return in.sim.FetchStatusField(projectID) })
+}
+
+func (in *Instrumented) UpdateProjectItemStatus(projectID, itemID, statusFieldID, statusOptionID string) error {
+	return do0(in, "UpdateProjectItemStatus", true, Args{ID: projectID, Values: []string{itemID, statusFieldID, statusOptionID}},
+		func() error { return in.sim.UpdateProjectItemStatus(projectID, itemID, statusFieldID, statusOptionID) })
+}
+
+func (in *Instrumented) ArchiveProjectItem(projectID, itemID string) error {
+	return do0(in, "ArchiveProjectItem", true, Args{ID: projectID, Values: []string{itemID}},
+		func() error { return in.sim.ArchiveProjectItem(projectID, itemID) })
+}
+
+func (in *Instrumented) FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error) {
+	return do1(in, "FetchProjectItem", false, Args{Owner: owner, Repo: repo, Number: issueNumber},
+		func() (*gh.ProjectItem, error) { return in.sim.FetchProjectItem(owner, repo, issueNumber) })
+}
+
+func (in *Instrumented) FetchProjectItemStatus(itemID string) (string, error) {
+	return do1(in, "FetchProjectItemStatus", false, Args{ID: itemID},
+		func() (string, error) { return in.sim.FetchProjectItemStatus(itemID) })
+}
+
+func (in *Instrumented) FetchProjectItemStatusBatch(projectID string) (map[string]string, error) {
+	return do1(in, "FetchProjectItemStatusBatch", false, Args{ID: projectID},
+		func() (map[string]string, error) { return in.sim.FetchProjectItemStatusBatch(projectID) })
+}
+
+func (in *Instrumented) FetchProjectUpdatedAt(projectID string) (time.Time, error) {
+	return do1(in, "FetchProjectUpdatedAt", false, Args{ID: projectID},
+		func() (time.Time, error) { return in.sim.FetchProjectUpdatedAt(projectID) })
+}
+
+func (in *Instrumented) LookupIssueProjectItem(projectID, repo string, issueNumber int) (string, string, error) {
+	return do2(in, "LookupIssueProjectItem", false, Args{Repo: repo, Number: issueNumber, ID: projectID},
+		func() (string, string, error) { return in.sim.LookupIssueProjectItem(projectID, repo, issueNumber) })
+}
+
+func (in *Instrumented) AddProjectV2ItemById(projectID, contentNodeID string) (string, error) {
+	return do1(in, "AddProjectV2ItemById", true, Args{ID: projectID, Values: []string{contentNodeID}},
+		func() (string, error) { return in.sim.AddProjectV2ItemById(projectID, contentNodeID) })
+}
+
+// --- labels ----------------------------------------------------------------
+
+func (in *Instrumented) FetchLabels(owner, repo string, issueNumber int) ([]string, error) {
+	return do1(in, "FetchLabels", false, Args{Owner: owner, Repo: repo, Number: issueNumber},
+		func() ([]string, error) { return in.sim.FetchLabels(owner, repo, issueNumber) })
+}
+
+func (in *Instrumented) AddLabelToIssue(owner, repo string, issueNumber int, labelName string) error {
+	return do0(in, "AddLabelToIssue", true, Args{Owner: owner, Repo: repo, Number: issueNumber, Label: labelName},
+		func() error { return in.sim.AddLabelToIssue(owner, repo, issueNumber, labelName) })
+}
+
+func (in *Instrumented) RemoveLabelFromIssue(owner, repo string, issueNumber int, labelName string) error {
+	return do0(in, "RemoveLabelFromIssue", true, Args{Owner: owner, Repo: repo, Number: issueNumber, Label: labelName},
+		func() error { return in.sim.RemoveLabelFromIssue(owner, repo, issueNumber, labelName) })
+}
+
+func (in *Instrumented) FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
+	return do1(in, "FetchLabelAppliedAt", false, Args{Owner: owner, Repo: repo, Number: issueNumber, Label: labelName},
+		func() (time.Time, error) { return in.sim.FetchLabelAppliedAt(owner, repo, issueNumber, labelName) })
+}
+
+func (in *Instrumented) SeedLabels(owner, repo string, stageNames []string, lockedUser string) error {
+	return do0(in, "SeedLabels", true, Args{Owner: owner, Repo: repo, Values: append(cloneStrings(stageNames), lockedUser)},
+		func() error { return in.sim.SeedLabels(owner, repo, stageNames, lockedUser) })
+}
+
+// --- comments --------------------------------------------------------------
+
+func (in *Instrumented) AddComment(owner, repo string, issueNumber int, body string) (int, error) {
+	return do1(in, "AddComment", true, Args{Owner: owner, Repo: repo, Number: issueNumber, Body: body},
+		func() (int, error) { return in.sim.AddComment(owner, repo, issueNumber, body) })
+}
+
+func (in *Instrumented) AddCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
+	return do0(in, "AddCommentReaction", true, Args{Owner: owner, Repo: repo, Number: commentDatabaseID, Values: []string{content}},
+		func() error { return in.sim.AddCommentReaction(owner, repo, commentDatabaseID, content) })
+}
+
+func (in *Instrumented) AddPRReviewCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
+	return do0(in, "AddPRReviewCommentReaction", true, Args{Owner: owner, Repo: repo, Number: commentDatabaseID, Values: []string{content}},
+		func() error { return in.sim.AddPRReviewCommentReaction(owner, repo, commentDatabaseID, content) })
+}
+
+func (in *Instrumented) UpdateComment(owner, repo string, commentDatabaseID int, body string) error {
+	return do0(in, "UpdateComment", true, Args{Owner: owner, Repo: repo, Number: commentDatabaseID, Body: body},
+		func() error { return in.sim.UpdateComment(owner, repo, commentDatabaseID, body) })
+}
+
+func (in *Instrumented) ResolveReviewThread(threadID string) error {
+	return do0(in, "ResolveReviewThread", true, Args{ID: threadID},
+		func() error { return in.sim.ResolveReviewThread(threadID) })
+}
+
+// --- issues ----------------------------------------------------------------
+
+func (in *Instrumented) GetIssueBody(owner, repo string, issueNumber int) (string, error) {
+	return do1(in, "GetIssueBody", false, Args{Owner: owner, Repo: repo, Number: issueNumber},
+		func() (string, error) { return in.sim.GetIssueBody(owner, repo, issueNumber) })
+}
+
+func (in *Instrumented) UpdateIssueBody(owner, repo string, issueNumber int, body string) error {
+	return do0(in, "UpdateIssueBody", true, Args{Owner: owner, Repo: repo, Number: issueNumber, Body: body},
+		func() error { return in.sim.UpdateIssueBody(owner, repo, issueNumber, body) })
+}
+
+func (in *Instrumented) CloseIssue(owner, repo string, issueNumber int) error {
+	return do0(in, "CloseIssue", true, Args{Owner: owner, Repo: repo, Number: issueNumber},
+		func() error { return in.sim.CloseIssue(owner, repo, issueNumber) })
+}
+
+func (in *Instrumented) CreateIssue(owner, repo, title, body string, assignees []string) (int, string, error) {
+	return do2(in, "CreateIssue", true, Args{Owner: owner, Repo: repo, Body: body, Values: append([]string{title}, assignees...)},
+		func() (int, string, error) { return in.sim.CreateIssue(owner, repo, title, body, assignees) })
+}
+
+func (in *Instrumented) FetchIssue(owner, repo string, issueNumber int) (*gh.IssueData, error) {
+	return do1(in, "FetchIssue", false, Args{Owner: owner, Repo: repo, Number: issueNumber},
+		func() (*gh.IssueData, error) { return in.sim.FetchIssue(owner, repo, issueNumber) })
+}
+
+func (in *Instrumented) AddBlockedByIssue(issueNodeID, blockerNodeID string) error {
+	return do0(in, "AddBlockedByIssue", true, Args{ID: issueNodeID, Values: []string{blockerNodeID}},
+		func() error { return in.sim.AddBlockedByIssue(issueNodeID, blockerNodeID) })
+}
+
+// --- pull requests ---------------------------------------------------------
+
+func (in *Instrumented) FindPRForIssue(owner, repo string, issueNumber int) (int, error) {
+	return do1(in, "FindPRForIssue", false, Args{Owner: owner, Repo: repo, Number: issueNumber},
+		func() (int, error) { return in.sim.FindPRForIssue(owner, repo, issueNumber) })
+}
+
+func (in *Instrumented) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+	return do1(in, "FetchLinkedPR", false, Args{Owner: owner, Repo: repo, Number: issueNumber},
+		func() (*gh.PRDetails, error) { return in.sim.FetchLinkedPR(owner, repo, issueNumber) })
+}
+
+func (in *Instrumented) FetchPRMergeableFields(owner, repo string, prNumber int) (*bool, string, error) {
+	return do2(in, "FetchPRMergeableFields", false, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() (*bool, string, error) { return in.sim.FetchPRMergeableFields(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) FetchPRMergeable(owner, repo string, prNumber int) (*bool, error) {
+	return do1(in, "FetchPRMergeable", false, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() (*bool, error) { return in.sim.FetchPRMergeable(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) FetchPRMerged(owner, repo string, prNumber int) (bool, error) {
+	return do1(in, "FetchPRMerged", false, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() (bool, error) { return in.sim.FetchPRMerged(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) FetchPRMergeableState(owner, repo string, prNumber int) (string, error) {
+	return do1(in, "FetchPRMergeableState", false, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() (string, error) { return in.sim.FetchPRMergeableState(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) FetchPRDetails(owner, repo string, prNumber int) (*gh.PRDetails, error) {
+	return do1(in, "FetchPRDetails", false, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() (*gh.PRDetails, error) { return in.sim.FetchPRDetails(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error) {
+	return do1(in, "FetchPRClosingIssues", false, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() ([]int, error) { return in.sim.FetchPRClosingIssues(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
+	return do1(in, "FetchPRsForSHA", false, Args{Owner: owner, Repo: repo, SHA: sha},
+		func() ([]int, error) { return in.sim.FetchPRsForSHA(owner, repo, sha) })
+}
+
+func (in *Instrumented) GetPRBase(owner, repo string, prNumber int) (string, error) {
+	return do1(in, "GetPRBase", false, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() (string, error) { return in.sim.GetPRBase(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) UpdatePRBase(owner, repo string, prNumber int, newBase string) error {
+	return do0(in, "UpdatePRBase", true, Args{Owner: owner, Repo: repo, Number: prNumber, Values: []string{newBase}},
+		func() error { return in.sim.UpdatePRBase(owner, repo, prNumber, newBase) })
+}
+
+func (in *Instrumented) CreateDraftPR(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+	return do1(in, "CreateDraftPR", true, Args{Owner: owner, Repo: repo, Number: issueNumber, Body: body, Values: []string{title, head, base}},
+		func() (int, error) { return in.sim.CreateDraftPR(owner, repo, title, head, base, body, issueNumber) })
+}
+
+func (in *Instrumented) CreatePR(owner, repo, title, head, base, body string) (int, error) {
+	return do1(in, "CreatePR", true, Args{Owner: owner, Repo: repo, Body: body, Values: []string{title, head, base}},
+		func() (int, error) { return in.sim.CreatePR(owner, repo, title, head, base, body) })
+}
+
+func (in *Instrumented) ListPRs(owner, repo string) ([]gh.PRDetails, error) {
+	return do1(in, "ListPRs", false, Args{Owner: owner, Repo: repo},
+		func() ([]gh.PRDetails, error) { return in.sim.ListPRs(owner, repo) })
+}
+
+func (in *Instrumented) MarkPRReady(owner, repo string, prNumber int) error {
+	return do0(in, "MarkPRReady", true, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() error { return in.sim.MarkPRReady(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) MergePR(owner, repo string, prNumber int) error {
+	return do0(in, "MergePR", true, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() error { return in.sim.MergePR(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) EnablePullRequestAutoMerge(owner, repo string, prNumber int, strategy string) error {
+	return do0(in, "EnablePullRequestAutoMerge", true, Args{Owner: owner, Repo: repo, Number: prNumber, Values: []string{strategy}},
+		func() error { return in.sim.EnablePullRequestAutoMerge(owner, repo, prNumber, strategy) })
+}
+
+func (in *Instrumented) DisablePullRequestAutoMerge(owner, repo string, prNumber int) error {
+	return do0(in, "DisablePullRequestAutoMerge", true, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() error { return in.sim.DisablePullRequestAutoMerge(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) EnqueuePullRequest(owner, repo string, prNumber int, expectedHeadOID string) error {
+	return do0(in, "EnqueuePullRequest", true, Args{Owner: owner, Repo: repo, Number: prNumber, SHA: expectedHeadOID},
+		func() error { return in.sim.EnqueuePullRequest(owner, repo, prNumber, expectedHeadOID) })
+}
+
+func (in *Instrumented) DequeuePullRequest(owner, repo string, prNumber int) error {
+	return do0(in, "DequeuePullRequest", true, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() error { return in.sim.DequeuePullRequest(owner, repo, prNumber) })
+}
+
+// --- reviews ---------------------------------------------------------------
+
+func (in *Instrumented) FetchPRReviews(owner, repo string, prNumber int) ([]gh.PRReview, error) {
+	return do1(in, "FetchPRReviews", false, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() ([]gh.PRReview, error) { return in.sim.FetchPRReviews(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) FetchPRReviewRequests(owner, repo string, prNumber int) ([]gh.ReviewRequest, error) {
+	return do1(in, "FetchPRReviewRequests", false, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() ([]gh.ReviewRequest, error) { return in.sim.FetchPRReviewRequests(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) FetchPRReviewDecision(owner, repo string, prNumber int) (string, error) {
+	return do1(in, "FetchPRReviewDecision", false, Args{Owner: owner, Repo: repo, Number: prNumber},
+		func() (string, error) { return in.sim.FetchPRReviewDecision(owner, repo, prNumber) })
+}
+
+func (in *Instrumented) AddReviewRequest(owner, repo string, prNumber int, reviewers []string) error {
+	return do0(in, "AddReviewRequest", true, Args{Owner: owner, Repo: repo, Number: prNumber, Values: cloneStrings(reviewers)},
+		func() error { return in.sim.AddReviewRequest(owner, repo, prNumber, reviewers) })
+}
+
+func (in *Instrumented) DeleteReviewRequest(owner, repo string, prNumber int, reviewers []string) error {
+	return do0(in, "DeleteReviewRequest", true, Args{Owner: owner, Repo: repo, Number: prNumber, Values: cloneStrings(reviewers)},
+		func() error { return in.sim.DeleteReviewRequest(owner, repo, prNumber, reviewers) })
+}
+
+// --- CI --------------------------------------------------------------------
+
+func (in *Instrumented) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error) {
+	return do1(in, "FetchCheckRuns", false, Args{Owner: owner, Repo: repo, SHA: sha},
+		func() ([]gh.CheckRun, error) { return in.sim.FetchCheckRuns(owner, repo, sha) })
+}
+
+func (in *Instrumented) FetchCombinedStatus(owner, repo, ref string) ([]gh.CommitStatus, error) {
+	return do1(in, "FetchCombinedStatus", false, Args{Owner: owner, Repo: repo, SHA: ref},
+		func() ([]gh.CommitStatus, error) { return in.sim.FetchCombinedStatus(owner, repo, ref) })
+}
+
+func (in *Instrumented) FetchCommitsBehind(owner, repo, base, head string) (int, error) {
+	return do1(in, "FetchCommitsBehind", false, Args{Owner: owner, Repo: repo, Values: []string{base, head}},
+		func() (int, error) { return in.sim.FetchCommitsBehind(owner, repo, base, head) })
+}
+
+// --- misc ------------------------------------------------------------------
+
+func (in *Instrumented) FetchLatestRelease(owner, repo string) (*gh.LatestRelease, error) {
+	return do1(in, "FetchLatestRelease", false, Args{Owner: owner, Repo: repo},
+		func() (*gh.LatestRelease, error) { return in.sim.FetchLatestRelease(owner, repo) })
+}
+
+func (in *Instrumented) FetchRepoAccess(owner, repo string) (gh.RepoAccess, error) {
+	return do1(in, "FetchRepoAccess", false, Args{Owner: owner, Repo: repo},
+		func() (gh.RepoAccess, error) { return in.sim.FetchRepoAccess(owner, repo) })
+}
+
+func (in *Instrumented) DeleteForwardingHooks(owner, repo string) error {
+	return do0(in, "DeleteForwardingHooks", true, Args{Owner: owner, Repo: repo},
+		func() error { return in.sim.DeleteForwardingHooks(owner, repo) })
+}
+
+// RateLimitStats is logged but never faulted: it is the one interface method
+// with no error return, so there is no channel through which a fault could
+// surface. Registering one panics (see fault.go). This wrapper still exists —
+// and must — because leaving it out would fall through to nothing at all: with
+// sim held as a named field there is no promotion to fall back on, so the
+// omission would not compile. That is the property this design is built for.
+func (in *Instrumented) RateLimitStats() (gh.RateLimitStats, gh.RateLimitStats) {
+	seq := in.log.reserve("RateLimitStats", false, Args{}, in.sim.now())
+	rest, graphql := in.sim.RateLimitStats()
+	in.log.complete(seq, nil, false)
+	return rest, graphql
+}

--- a/tests/sim/simgh/instrumented.go
+++ b/tests/sim/simgh/instrumented.go
@@ -140,7 +140,9 @@ func (in *Instrumented) FetchProjectBoard(owner, repo string, projectNum int, ow
 
 func (in *Instrumented) ProbeProjectBoard(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
 	return do2(in, "ProbeProjectBoard", false, Args{Owner: owner, Repo: repo, Values: []string{ownerType}},
-		func() ([]gh.BoardProbeItem, string, error) { return in.sim.ProbeProjectBoard(owner, repo, projectNum, ownerType) })
+		func() ([]gh.BoardProbeItem, string, error) {
+			return in.sim.ProbeProjectBoard(owner, repo, projectNum, ownerType)
+		})
 }
 
 func (in *Instrumented) FetchItemDetails(item *gh.ProjectItem) error {

--- a/tests/sim/simgh/instrumented_concurrency_test.go
+++ b/tests/sim/simgh/instrumented_concurrency_test.go
@@ -1,0 +1,208 @@
+package simgh
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// R6/AC8: the mutation log and the fault table are written from every engine
+// worker goroutine on every call, and the log in particular is the most likely
+// place in this package to introduce its first data race.
+//
+// Operation counts stay modest, following concurrency_test.go's convention:
+// the model's cost is dominated by git worktree churn, and a bigger fan-out
+// buys no additional confidence about the two mutexes actually under test.
+
+// TestLogAndFaultsAreConcurrencySafe hammers both instruments from several
+// goroutines at once, mixing reads, mutations, faulted calls and log queries.
+// Run under -race, a missing lock surfaces here.
+func TestLogAndFaultsAreConcurrencySafe(t *testing.T) {
+	const (
+		workers        = 8
+		callsPerWorker = 12
+	)
+
+	in, _ := newInstrumented(t)
+	// Every worker gets its own issue, so the model-level contention is real
+	// but the assertions below stay per-issue and exact.
+	for w := 0; w < workers; w++ {
+		in.Sim().SeedIssue("acme/widgets", IssueSeed{
+			Number: 100 + w,
+			Title:  fmt.Sprintf("worker %d", w),
+			Status: "Implement",
+		})
+	}
+	if err := in.Sim().Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	// A fault narrowed to one worker's issue: the fault table is consulted on
+	// every call from every goroutine, and its per-method call counter is
+	// shared, so this exercises the narrowing path under contention too.
+	in.Faults().FailWhen("AddLabelToIssue",
+		func(a Args) bool { return a.Number == 100 },
+		Always, ErrRateLimit())
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			issue := 100 + w
+			for i := 0; i < callsPerWorker; i++ {
+				label := fmt.Sprintf("worker-%d-call-%d", w, i)
+				// Mutation (faulted for worker 0), read, and a concurrent
+				// query of the log itself — the query path takes the same
+				// mutex the writers do.
+				_ = in.AddLabelToIssue("acme", "widgets", issue, label)
+				_, _ = in.FetchLabels("acme", "widgets", issue)
+				_ = in.Log().Len()
+				_ = in.Faults().CallCount("AddLabelToIssue")
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	entries := in.Log().Entries()
+	wantTotal := workers * callsPerWorker * 2
+	if len(entries) != wantTotal {
+		t.Fatalf("log has %d entries, want %d — a concurrent append was lost or duplicated", len(entries), wantTotal)
+	}
+
+	// No entry may be left pending: every reserved slot must have been
+	// completed by the goroutine that took it.
+	for _, e := range entries {
+		if e.Pending {
+			t.Fatalf("entry %d left pending after all workers finished: %s", e.Seq, e)
+		}
+	}
+
+	// Sequence numbers must be a dense permutation of 0..n-1 — no gaps, no
+	// duplicates. That is the property a racy append would break.
+	seen := make([]bool, len(entries))
+	for i, e := range entries {
+		if e.Seq != i {
+			t.Fatalf("entry at index %d carries Seq %d; the log is not densely numbered", i, e.Seq)
+		}
+		if seen[e.Seq] {
+			t.Fatalf("sequence %d appears twice", e.Seq)
+		}
+		seen[e.Seq] = true
+	}
+
+	// Every call appears exactly once, attributed to the right issue.
+	for w := 0; w < workers; w++ {
+		issue := 100 + w
+		byIssue := in.Log().ByIssue(issue)
+		if len(byIssue) != callsPerWorker*2 {
+			t.Errorf("issue %d has %d entries, want %d", issue, len(byIssue), callsPerWorker*2)
+		}
+		for i := 0; i < callsPerWorker; i++ {
+			label := fmt.Sprintf("worker-%d-call-%d", w, i)
+			matches := in.Log().Find(LabelAdded(issue, label))
+			if len(matches) != 1 {
+				t.Errorf("label %s appears in %d entries, want 1", label, len(matches))
+			}
+		}
+	}
+
+	// The narrowed fault fired for exactly one worker's calls and no others.
+	injected := in.Log().Find(WasInjected())
+	if len(injected) != callsPerWorker {
+		t.Errorf("%d injected failures, want %d (worker 0's mutations only)", len(injected), callsPerWorker)
+	}
+	for _, e := range injected {
+		if e.Args.Number != 100 {
+			t.Errorf("the narrowed fault fired on issue %d", e.Args.Number)
+		}
+	}
+	if got := in.Faults().CallCount("AddLabelToIssue"); got != workers*callsPerWorker {
+		t.Errorf("CallCount = %d, want %d", got, workers*callsPerWorker)
+	}
+}
+
+// A single goroutine's calls must be in exact order in the log, whatever else
+// is happening concurrently. That is the ordering guarantee every real
+// assertion relies on — ADR-060's "awaiting-done first" is one worker's
+// sequential code — and the two-phase append is what provides it.
+func TestOrderingWithinAGoroutineIsExactUnderContention(t *testing.T) {
+	const (
+		noisemakers = 6
+		steps       = 10
+	)
+
+	in, _ := newInstrumented(t)
+	in.Sim().SeedIssue("acme/widgets", IssueSeed{Number: 200, Title: "ordered", Status: "Implement"})
+	for w := 0; w < noisemakers; w++ {
+		in.Sim().SeedIssue("acme/widgets", IssueSeed{Number: 300 + w, Title: "noise", Status: "Implement"})
+	}
+	if err := in.Sim().Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	stop := make(chan struct{})
+	var noise sync.WaitGroup
+	for w := 0; w < noisemakers; w++ {
+		noise.Add(1)
+		go func(w int) {
+			defer noise.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = in.AddLabelToIssue("acme", "widgets", 300+w, fmt.Sprintf("n-%d-%d", w, i))
+			}
+		}(w)
+	}
+
+	// The observed goroutine: a strict sequence the log must reproduce.
+	for i := 0; i < steps; i++ {
+		if err := in.AddLabelToIssue("acme", "widgets", 200, fmt.Sprintf("step-%d", i)); err != nil {
+			t.Fatalf("step %d: %v", i, err)
+		}
+	}
+	close(stop)
+	noise.Wait()
+
+	var lastSeq = -1
+	for i := 0; i < steps; i++ {
+		seq, err := in.Log().IndexOf(LabelAdded(200, fmt.Sprintf("step-%d", i)))
+		if err != nil {
+			t.Fatalf("step %d missing from the log: %v", i, err)
+		}
+		if seq <= lastSeq {
+			t.Fatalf("step %d logged at sequence %d, not after step %d's %d — ordering within one goroutine is not exact",
+				i, seq, i-1, lastSeq)
+		}
+		lastSeq = seq
+	}
+}
+
+// Snapshot's own instruments must survive being taken while the log is being
+// written — Entries() copies under the lock, so a snapshot concurrent with
+// traffic is safe even though the two halves may disagree about a call that
+// landed between them (documented in snapshot.go).
+func TestSnapshotIsSafeWhileTheLogIsBeingWritten(t *testing.T) {
+	in, _ := newInstrumented(t)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 40; i++ {
+			_, _ = in.FetchLabels("acme", "widgets", 7)
+		}
+	}()
+
+	staging := t.TempDir()
+	for i := 0; i < 3; i++ {
+		if _, err := in.Snapshot(staging); err != nil {
+			t.Errorf("Snapshot during concurrent traffic: %v", err)
+			break
+		}
+	}
+	wg.Wait()
+}

--- a/tests/sim/simgh/instrumented_concurrency_test.go
+++ b/tests/sim/simgh/instrumented_concurrency_test.go
@@ -2,6 +2,7 @@ package simgh
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -201,20 +202,32 @@ func TestAdvancingTheClockUnderTrafficIsRaceFree(t *testing.T) {
 	// literal key is enough here — this test is about the clock, not about git.
 	const sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	// A scheduled step so the drain path — which reads the clock while holding
-	// mu — is exercised alongside the log's own read of it.
-	in.Sim().SeedCheckRunsAfter("acme/widgets", sha, 30*time.Minute,
+	// mu — is exercised alongside the log's own read of it. Its instant sits
+	// inside the advance loop below, so it lands while the workers are running
+	// rather than after they stop.
+	in.Sim().SeedCheckRunsAfter("acme/widgets", sha, time.Minute,
 		gh.CheckRun{ID: 700, Name: "build", Status: "completed", Conclusion: "failure"})
 	if err := in.Sim().Err(); err != nil {
 		t.Fatalf("seeding: %v", err)
 	}
 
+	// The advances must genuinely overlap the reads. Without a barrier the main
+	// goroutine finishes its whole loop before the workers are scheduled, and
+	// nothing ever accesses the clock concurrently — the test then passes with
+	// an unguarded clock roughly half the time, which is worse than not having
+	// it. Every worker signals once it is in its loop, and the advances are
+	// spread with Gosched so they interleave rather than burst.
 	stop := make(chan struct{})
-	var wg sync.WaitGroup
+	var running, wg sync.WaitGroup
+	running.Add(workers)
 	for w := 0; w < workers; w++ {
 		wg.Add(1)
 		go func(w int) {
 			defer wg.Done()
 			for i := 0; ; i++ {
+				if i == 0 {
+					running.Done()
+				}
 				select {
 				case <-stop:
 					return
@@ -225,9 +238,11 @@ func TestAdvancingTheClockUnderTrafficIsRaceFree(t *testing.T) {
 			}
 		}(w)
 	}
+	running.Wait()
 
-	for i := 0; i < 20; i++ {
-		clk.Advance(5 * time.Minute)
+	for i := 0; i < 200; i++ {
+		clk.Advance(time.Second)
+		runtime.Gosched()
 	}
 	close(stop)
 	wg.Wait()

--- a/tests/sim/simgh/instrumented_concurrency_test.go
+++ b/tests/sim/simgh/instrumented_concurrency_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
 )
 
 // R6/AC8: the mutation log and the fault table are written from every engine
@@ -178,6 +181,65 @@ func TestOrderingWithinAGoroutineIsExactUnderContention(t *testing.T) {
 				i, seq, i-1, lastSeq)
 		}
 		lastSeq = seq
+	}
+}
+
+// Advancing the clock while workers are in flight must not race.
+//
+// This is how a harness driving Engine.Run() necessarily uses the clock: there
+// is no instant at which nothing is running, so "advance, then observe" is
+// always concurrent with somebody's read. The instrumentation layer widened the
+// exposure sharply — Now is read on every intercepted call, not only on the
+// model reads that stamp a timestamp — and a schedule drain reads it too, so an
+// unguarded clock would race from an arbitrary worker, far from the Advance
+// that caused it. Run under -race, which is what makes this test mean anything.
+func TestAdvancingTheClockUnderTrafficIsRaceFree(t *testing.T) {
+	const workers = 6
+
+	in, clk := newInstrumented(t)
+	// Check runs are keyed by SHA string alone, and a drain is repo-wide, so a
+	// literal key is enough here — this test is about the clock, not about git.
+	const sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	// A scheduled step so the drain path — which reads the clock while holding
+	// mu — is exercised alongside the log's own read of it.
+	in.Sim().SeedCheckRunsAfter("acme/widgets", sha, 30*time.Minute,
+		gh.CheckRun{ID: 700, Name: "build", Status: "completed", Conclusion: "failure"})
+	if err := in.Sim().Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _ = in.FetchCheckRuns("acme", "widgets", sha)
+				_ = in.AddLabelToIssue("acme", "widgets", 7, fmt.Sprintf("t-%d-%d", w, i))
+			}
+		}(w)
+	}
+
+	for i := 0; i < 20; i++ {
+		clk.Advance(5 * time.Minute)
+	}
+	close(stop)
+	wg.Wait()
+
+	// And the step still landed exactly once, rather than being applied
+	// repeatedly by the racing readers.
+	runs, err := in.FetchCheckRuns("acme", "widgets", sha)
+	if err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	if len(runs) != 1 || checkVerdict(runs[0]) != "failure" {
+		t.Errorf("after the advance, check runs = %+v, want the single scheduled failure", runs)
 	}
 }
 

--- a/tests/sim/simgh/model.go
+++ b/tests/sim/simgh/model.go
@@ -41,6 +41,12 @@ type repoState struct {
 	checkRuns      map[string][]gh.CheckRun
 	commitStatuses map[string][]gh.CommitStatus
 
+	// ciSchedule holds pending clock-driven mutations to checkRuns and
+	// commitStatuses: "this SHA goes red at T". Applied lazily by drainCI on
+	// every read of either collection, so a scenario expresses a CI transition
+	// as an instant rather than as a read count. See schedule.go.
+	ciSchedule schedule[*repoState]
+
 	// requiredContexts maps a branch name to the set of check/status context
 	// names branch protection requires on that branch. This is what makes the
 	// blocked/unstable distinction reachable: a red *required* context yields
@@ -162,6 +168,14 @@ type prRecord struct {
 
 	reviews        []gh.PRReview
 	reviewRequests []gh.ReviewRequest
+
+	// reviewSchedule holds pending clock-driven mutations to reviews and
+	// reviewRequests: "the reviewer responds at T". Applied lazily by
+	// drainReviews on every read of either collection — and by
+	// AddReviewRequest/DeleteReviewRequest before they mutate, so an engine
+	// withdrawal cannot be undone by a step that was already due. See
+	// schedule.go.
+	reviewSchedule schedule[*prRecord]
 
 	// resolvedThreads counts review threads marked resolved, surfaced as
 	// ProjectItem.LinkedPRResolvedThreadCount for the engine's progress

--- a/tests/sim/simgh/mutationlog.go
+++ b/tests/sim/simgh/mutationlog.go
@@ -1,0 +1,364 @@
+package simgh
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// This file is the mutation log: an ordered, queryable record of what the
+// engine did to the model.
+//
+// # It records attempts, not mutations
+//
+// The name is R4's, but the contract is wider than the name suggests: **every
+// intercepted call gets an entry, whether it succeeded, failed inside the
+// model, or was failed by the fault injector**, and reads are recorded
+// alongside mutations. That is not incidental — a log of mutations that
+// happened could not show "N failed attempts followed by the success", which
+// is the whole point of asserting against an injected fault. Entry.Mutation
+// separates the two populations, and Mutations() is the view R4's ordering
+// questions are asked of.
+//
+// # Two consumers
+//
+// Scenarios asserting ordering guarantees — several of the engine's contracts
+// are ordering claims rather than state claims (ADR-060 specifies that
+// fabrik:awaiting-done is the *very first* mutation after the markers are
+// parsed, so the decision survives a failure of everything that follows), and
+// no amount of reading terminal labels can assert that. And the harness,
+// printing recent activity when an AdvanceUntil exhausts: a deterministic bed
+// that fails without saying what happened costs more to debug than the live
+// bed it replaces.
+//
+// # Ordering contract
+//
+// Entries are appended in two phases: a slot is reserved *before* the
+// underlying call and completed *after* it. Appending only on return would let
+// two concurrent calls be logged in the opposite order from the one in which
+// they reached the model. Reserving first makes ordering:
+//
+//   - **exact within a goroutine** — which is what every real ordering
+//     assertion is, since ADR-060's guarantee is one worker's sequential code;
+//   - **reserve-order, best effort, across goroutines** — two workers whose
+//     calls interleave inside the model are ordered by which reserved its slot
+//     first, which is as close to a happens-before as an out-of-band log can
+//     get.
+//
+// Recorded in FIDELITY.md rather than left implicit, because a cross-goroutine
+// ordering assertion that looks exact and is not is a flaky test waiting to
+// happen.
+//
+// # Locking
+//
+// MutationLog owns its own mutex and never holds it across a call into Sim.
+// It is therefore a leaf in the package's lock ordering: it may be acquired
+// while no Sim lock is held (which is the only way Instrumented uses it), and
+// Sim's own code never touches it. See sim.go's package doc.
+
+// Args carries the identifying arguments of an intercepted call. Its fields
+// are deliberately generic rather than per-method, so all sixty wrappers stay
+// mechanically uniform and a diff scan is enough to review them.
+//
+// Zero values mean "not applicable to this method", not "empty" — a query
+// filtering on Number == 0 matches every non-issue-scoped call.
+type Args struct {
+	Owner string
+	Repo  string
+	// Number is the issue or PR number the call targets, 0 when the method is
+	// not issue- or PR-scoped.
+	Number int
+	// Label is the label name for label mutations.
+	Label string
+	// SHA is a commit SHA or a ref (FetchCombinedStatus accepts either).
+	SHA string
+	// ID is whichever opaque identifier the method takes: project ID, item ID,
+	// status field/option ID, review thread ID, or node ID. Methods taking two
+	// (UpdateProjectItemStatus) put the primary one here and the rest in Values.
+	ID string
+	// Body is a comment or issue body.
+	Body string
+	// Values holds any remaining call-specific strings — reviewer logins, a
+	// status option ID, a branch name, a merge strategy.
+	Values []string
+}
+
+// String renders the arguments compactly for harness debugging output. Only
+// the fields the call actually set appear.
+func (a Args) String() string {
+	var parts []string
+	if a.Owner != "" || a.Repo != "" {
+		parts = append(parts, a.Owner+"/"+a.Repo)
+	}
+	if a.Number != 0 {
+		parts = append(parts, fmt.Sprintf("#%d", a.Number))
+	}
+	if a.Label != "" {
+		parts = append(parts, "label="+a.Label)
+	}
+	if a.SHA != "" {
+		parts = append(parts, "sha="+a.SHA)
+	}
+	if a.ID != "" {
+		parts = append(parts, "id="+a.ID)
+	}
+	if len(a.Values) > 0 {
+		parts = append(parts, strings.Join(a.Values, ","))
+	}
+	if a.Body != "" {
+		parts = append(parts, fmt.Sprintf("body=%dB", len(a.Body)))
+	}
+	return strings.Join(parts, " ")
+}
+
+// Entry is one intercepted call.
+type Entry struct {
+	// Seq is the entry's position in reserve order, starting at 0. It is also
+	// its index in the slice Entries returns.
+	Seq int
+	// Method is the engine.GitHubClient method name, e.g. "AddLabelToIssue".
+	Method string
+	Args   Args
+	// Mutation distinguishes state-changing calls from reads.
+	Mutation bool
+	// At is the injected clock's reading when the slot was reserved.
+	At time.Time
+	// Err is the call's error, nil on success.
+	Err error
+	// Injected reports that Err came from the fault table rather than from the
+	// model — the difference between "the scenario made this fail" and "the
+	// model refused it".
+	Injected bool
+	// Pending reports that the slot was reserved but never completed: the
+	// goroutine is still inside the call, or it panicked. A completed sweep
+	// with pending entries left is a bug in the wrapper, and the concurrency
+	// test asserts against it.
+	Pending bool
+}
+
+// Failed reports whether the call returned an error, from either source.
+func (e Entry) Failed() bool { return e.Err != nil }
+
+// String renders one entry as a single line for harness debugging output.
+func (e Entry) String() string {
+	kind := "read"
+	if e.Mutation {
+		kind = "mutate"
+	}
+	outcome := "ok"
+	switch {
+	case e.Pending:
+		outcome = "pending"
+	case e.Injected:
+		outcome = "INJECTED: " + e.Err.Error()
+	case e.Err != nil:
+		outcome = "err: " + e.Err.Error()
+	}
+	return fmt.Sprintf("%4d %-6s %-30s %-40s %s", e.Seq, kind, e.Method, e.Args.String(), outcome)
+}
+
+// MutationLog is the ordered record. The zero value is ready to use.
+type MutationLog struct {
+	mu      sync.Mutex
+	entries []Entry
+}
+
+// NewMutationLog returns an empty log.
+func NewMutationLog() *MutationLog { return &MutationLog{} }
+
+// reserve appends a pending entry and returns its sequence number. It is the
+// first half of the two-phase append described in this file's doc comment.
+func (l *MutationLog) reserve(method string, mutation bool, args Args, at time.Time) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	seq := len(l.entries)
+	l.entries = append(l.entries, Entry{
+		Seq:      seq,
+		Method:   method,
+		Args:     args,
+		Mutation: mutation,
+		At:       at,
+		Pending:  true,
+	})
+	return seq
+}
+
+// complete fills in a reserved slot's outcome.
+func (l *MutationLog) complete(seq int, err error, injected bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if seq < 0 || seq >= len(l.entries) {
+		// Unreachable through Instrumented, which always passes back the
+		// sequence reserve just returned. Panicking rather than ignoring it
+		// keeps a future caller from silently losing an outcome.
+		panic(fmt.Sprintf("simgh: MutationLog.complete: sequence %d out of range (len %d)", seq, len(l.entries)))
+	}
+	l.entries[seq].Err = err
+	l.entries[seq].Injected = injected
+	l.entries[seq].Pending = false
+}
+
+// Entries returns every entry in reserve order.
+func (l *MutationLog) Entries() []Entry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]Entry, len(l.entries))
+	copy(out, l.entries)
+	return out
+}
+
+// Len reports how many calls have been intercepted.
+func (l *MutationLog) Len() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.entries)
+}
+
+// Reset empties the log. Sequence numbers restart at 0, so an index captured
+// before a reset is meaningless after one.
+func (l *MutationLog) Reset() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = nil
+}
+
+// Find returns every entry matching pred, in order.
+func (l *MutationLog) Find(pred func(Entry) bool) []Entry {
+	var out []Entry
+	for _, e := range l.Entries() {
+		if pred(e) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Mutations returns only the state-changing calls — R4's view of the log,
+// with reads filtered out.
+func (l *MutationLog) Mutations() []Entry {
+	return l.Find(func(e Entry) bool { return e.Mutation })
+}
+
+// ByMethod returns every call to the named method.
+func (l *MutationLog) ByMethod(method string) []Entry {
+	return l.Find(MethodIs(method))
+}
+
+// ByIssue returns every call carrying the given issue or PR number.
+func (l *MutationLog) ByIssue(number int) []Entry {
+	return l.Find(func(e Entry) bool { return e.Args.Number == number })
+}
+
+// Tail returns the last n entries, or all of them when there are fewer. This
+// is what the harness prints when an AdvanceUntil exhausts.
+func (l *MutationLog) Tail(n int) []Entry {
+	all := l.Entries()
+	if n <= 0 || n >= len(all) {
+		return all
+	}
+	return all[len(all)-n:]
+}
+
+// Dump renders the last n entries as newline-separated lines, for a failure
+// message.
+func (l *MutationLog) Dump(n int) string {
+	entries := l.Tail(n)
+	if len(entries) == 0 {
+		return "(mutation log empty)"
+	}
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		lines = append(lines, e.String())
+	}
+	return strings.Join(lines, "\n")
+}
+
+// IndexOf returns the sequence number of the first entry matching pred.
+//
+// It errors rather than returning a sentinel when nothing matches, for the
+// same reason Precedes does: a predicate that matches nothing is almost always
+// a mis-specified query, and answering it with a number would let the caller
+// carry on as though it had found something.
+func (l *MutationLog) IndexOf(pred func(Entry) bool) (int, error) {
+	for _, e := range l.Entries() {
+		if pred(e) {
+			return e.Seq, nil
+		}
+	}
+	return -1, fmt.Errorf("simgh: mutation log has no entry matching the predicate (%d entries recorded)", l.Len())
+}
+
+// Precedes reports whether the first entry matching a comes before the first
+// entry matching b.
+//
+// It returns an error when *either* predicate matches nothing. Answering false
+// in that case would be the canonical false pass for an ordering assertion: a
+// test asserting "the fabrik:awaiting-done add precedes the status update"
+// would pass unchanged after the awaiting-done add stopped happening at all,
+// which is precisely the regression the assertion exists to catch.
+func (l *MutationLog) Precedes(a, b func(Entry) bool) (bool, error) {
+	ai, err := l.IndexOf(a)
+	if err != nil {
+		return false, fmt.Errorf("simgh: Precedes: first predicate: %w", err)
+	}
+	bi, err := l.IndexOf(b)
+	if err != nil {
+		return false, fmt.Errorf("simgh: Precedes: second predicate: %w", err)
+	}
+	return ai < bi, nil
+}
+
+// --- predicate helpers -----------------------------------------------------
+//
+// These exist so ordering assertions read as claims about the engine rather
+// than as struct-field comparisons. They compose with Find, IndexOf and
+// Precedes.
+
+// MethodIs matches every call to the named method.
+func MethodIs(method string) func(Entry) bool {
+	return func(e Entry) bool { return e.Method == method }
+}
+
+// OnIssue matches every call carrying the given issue or PR number.
+func OnIssue(number int) func(Entry) bool {
+	return func(e Entry) bool { return e.Args.Number == number }
+}
+
+// LabelAdded matches the AddLabelToIssue call that applied label to number.
+func LabelAdded(number int, label string) func(Entry) bool {
+	return And(MethodIs("AddLabelToIssue"), OnIssue(number), func(e Entry) bool { return e.Args.Label == label })
+}
+
+// LabelRemoved matches the RemoveLabelFromIssue call that removed label from
+// number.
+func LabelRemoved(number int, label string) func(Entry) bool {
+	return And(MethodIs("RemoveLabelFromIssue"), OnIssue(number), func(e Entry) bool { return e.Args.Label == label })
+}
+
+// Succeeded matches entries whose call returned no error.
+func Succeeded() func(Entry) bool {
+	return func(e Entry) bool { return !e.Pending && e.Err == nil }
+}
+
+// Errored matches entries whose call returned an error, from either source.
+func Errored() func(Entry) bool {
+	return func(e Entry) bool { return e.Err != nil }
+}
+
+// WasInjected matches entries the fault table failed.
+func WasInjected() func(Entry) bool {
+	return func(e Entry) bool { return e.Injected }
+}
+
+// And composes predicates conjunctively.
+func And(preds ...func(Entry) bool) func(Entry) bool {
+	return func(e Entry) bool {
+		for _, p := range preds {
+			if !p(e) {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/tests/sim/simgh/mutationlog_test.go
+++ b/tests/sim/simgh/mutationlog_test.go
@@ -171,6 +171,47 @@ func TestLogQueriesByIssueAndTail(t *testing.T) {
 	}
 }
 
+// Args.Repo must carry the bare repository name for *every* method, so one
+// FailWhen predicate or log query works across all of them.
+//
+// FetchItemDetails is the only wrapper that has to derive owner and repo rather
+// than being handed them, because gh.ProjectItem.Repo is the composite
+// "owner/repo" — and it is also the call the settle scans retry, so it is the
+// likeliest target of a narrowed fault. The reflection-driven completeness
+// tests invoke it with a zero-valued item and so cannot see this at all.
+func TestFetchItemDetailsSplitsTheCompositeRepo(t *testing.T) {
+	in, _ := newInstrumented(t)
+
+	item, err := in.FetchProjectItem("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchProjectItem: %v", err)
+	}
+	if item.Repo != "acme/widgets" {
+		t.Fatalf("ProjectItem.Repo = %q, want the composite form this test exists to split", item.Repo)
+	}
+	in.Log().Reset()
+
+	if err := in.FetchItemDetails(item); err != nil {
+		t.Fatalf("FetchItemDetails: %v", err)
+	}
+	entries := in.Log().ByMethod("FetchItemDetails")
+	if len(entries) != 1 {
+		t.Fatalf("logged %d FetchItemDetails entries, want 1", len(entries))
+	}
+	if got := entries[0].Args; got.Owner != "acme" || got.Repo != "widgets" {
+		t.Errorf("Args = {Owner:%q Repo:%q}, want {acme widgets} — a composite here would make a "+
+			"FailWhen narrowed on Repo silently never match", got.Owner, got.Repo)
+	}
+
+	// And the narrowing a settle-scan scenario would actually write must fire.
+	in.Faults().FailWhen("FetchItemDetails",
+		func(a Args) bool { return a.Repo == "widgets" && a.Number == 7 },
+		Always, ErrRateLimit())
+	if err := in.FetchItemDetails(item); err == nil {
+		t.Error("a fault narrowed on the bare repo name did not fire on FetchItemDetails")
+	}
+}
+
 // Sequence numbers are the log's ordering, so they must be dense and
 // monotonic from zero — Precedes compares them directly.
 func TestLogSequencesAreDenseAndMonotonic(t *testing.T) {

--- a/tests/sim/simgh/mutationlog_test.go
+++ b/tests/sim/simgh/mutationlog_test.go
@@ -1,0 +1,339 @@
+package simgh
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// statusMove resolves the identifiers UpdateProjectItemStatus needs and moves
+// the board's single card to the named column through the instrumented client.
+func statusMove(t *testing.T, in *Instrumented, column string) {
+	t.Helper()
+	item := firstItem(t, in.Sim())
+	field, err := in.Sim().FetchStatusField(item.projectID)
+	if err != nil {
+		t.Fatalf("FetchStatusField: %v", err)
+	}
+	if err := in.UpdateProjectItemStatus(item.projectID, item.itemID, field.FieldID, field.Options[column]); err != nil {
+		t.Fatalf("UpdateProjectItemStatus(%s): %v", column, err)
+	}
+}
+
+// TestMutationLogAnswersAnOrderingQuery is AC6.
+//
+// The guarantee it stands in for is ADR-060's: fabrik:awaiting-done is applied
+// as the *very first* mutation after the markers are parsed, so the decision
+// survives a failure of everything that follows. That is an ordering claim, and
+// no amount of reading terminal labels can assert it — both orders leave the
+// same final state.
+//
+// The second half is what makes the first non-vacuous: the same query run
+// against the opposite order must return the opposite answer.
+func TestMutationLogAnswersAnOrderingQuery(t *testing.T) {
+	labelFirst := LabelAdded(7, "fabrik:awaiting-done")
+	statusUpdate := MethodIs("UpdateProjectItemStatus")
+
+	t.Run("label before status", func(t *testing.T) {
+		in, _ := newInstrumented(t)
+		if err := in.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-done"); err != nil {
+			t.Fatalf("AddLabelToIssue: %v", err)
+		}
+		statusMove(t, in, "Done")
+
+		got, err := in.Log().Precedes(labelFirst, statusUpdate)
+		if err != nil {
+			t.Fatalf("Precedes: %v", err)
+		}
+		if !got {
+			t.Errorf("Precedes(awaiting-done add, status update) = false, want true\nlog:\n%s", in.Log().Dump(20))
+		}
+	})
+
+	t.Run("status before label", func(t *testing.T) {
+		in, _ := newInstrumented(t)
+		statusMove(t, in, "Done")
+		if err := in.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-done"); err != nil {
+			t.Fatalf("AddLabelToIssue: %v", err)
+		}
+
+		got, err := in.Log().Precedes(labelFirst, statusUpdate)
+		if err != nil {
+			t.Fatalf("Precedes: %v", err)
+		}
+		if got {
+			t.Errorf("Precedes(awaiting-done add, status update) = true after reordering, want false\nlog:\n%s", in.Log().Dump(20))
+		}
+	})
+}
+
+// A predicate matching nothing must be an error, not a false. Answering false
+// would make "the awaiting-done add precedes the status update" keep passing
+// after the awaiting-done add stopped happening at all — precisely the
+// regression the assertion exists to catch.
+func TestPrecedesErrorsWhenAPredicateMatchesNothing(t *testing.T) {
+	in, _ := newInstrumented(t)
+	if err := in.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-done"); err != nil {
+		t.Fatalf("AddLabelToIssue: %v", err)
+	}
+
+	t.Run("first predicate unmatched", func(t *testing.T) {
+		_, err := in.Log().Precedes(MethodIs("ArchiveProjectItem"), LabelAdded(7, "fabrik:awaiting-done"))
+		if err == nil {
+			t.Fatal("Precedes returned nil error for a predicate matching nothing")
+		}
+		if !strings.Contains(err.Error(), "first predicate") {
+			t.Errorf("error %q does not say which predicate failed", err)
+		}
+	})
+
+	t.Run("second predicate unmatched", func(t *testing.T) {
+		_, err := in.Log().Precedes(LabelAdded(7, "fabrik:awaiting-done"), MethodIs("ArchiveProjectItem"))
+		if err == nil {
+			t.Fatal("Precedes returned nil error for a predicate matching nothing")
+		}
+		if !strings.Contains(err.Error(), "second predicate") {
+			t.Errorf("error %q does not say which predicate failed", err)
+		}
+	})
+
+	t.Run("IndexOf too", func(t *testing.T) {
+		if _, err := in.Log().IndexOf(MethodIs("ArchiveProjectItem")); err == nil {
+			t.Fatal("IndexOf returned nil error for a predicate matching nothing")
+		}
+	})
+}
+
+// The log records reads as well as mutations — its contract is "every
+// intercepted call", not "every mutation". Mutations() is the narrower view
+// R4's ordering questions are asked of.
+func TestLogRecordsReadsAndMutationsSeparately(t *testing.T) {
+	in, _ := newInstrumented(t)
+
+	if _, err := in.FetchLabels("acme", "widgets", 7); err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if err := in.AddLabelToIssue("acme", "widgets", 7, "fabrik:paused"); err != nil {
+		t.Fatalf("AddLabelToIssue: %v", err)
+	}
+	if _, err := in.FetchLabels("acme", "widgets", 7); err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+
+	if got := in.Log().Len(); got != 3 {
+		t.Fatalf("log has %d entries, want 3\n%s", got, in.Log().Dump(20))
+	}
+	muts := in.Log().Mutations()
+	if len(muts) != 1 || muts[0].Method != "AddLabelToIssue" {
+		t.Errorf("Mutations() = %v, want exactly the AddLabelToIssue entry", muts)
+	}
+	reads := in.Log().ByMethod("FetchLabels")
+	if len(reads) != 2 {
+		t.Errorf("ByMethod(FetchLabels) returned %d entries, want 2", len(reads))
+	}
+	for _, e := range reads {
+		if e.Mutation {
+			t.Errorf("FetchLabels entry marked as a mutation: %s", e)
+		}
+	}
+}
+
+func TestLogQueriesByIssueAndTail(t *testing.T) {
+	in, _ := newInstrumented(t)
+	in.Sim().SeedIssue("acme/widgets", IssueSeed{Number: 8, Title: "other", Status: "Implement"})
+	if err := in.Sim().Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	for _, n := range []int{7, 8, 7} {
+		if err := in.AddLabelToIssue("acme", "widgets", n, "fabrik:paused"); err != nil {
+			t.Fatalf("AddLabelToIssue(#%d): %v", n, err)
+		}
+	}
+
+	if got := len(in.Log().ByIssue(7)); got != 2 {
+		t.Errorf("ByIssue(7) returned %d entries, want 2", got)
+	}
+	if got := len(in.Log().ByIssue(8)); got != 1 {
+		t.Errorf("ByIssue(8) returned %d entries, want 1", got)
+	}
+
+	tail := in.Log().Tail(2)
+	if len(tail) != 2 {
+		t.Fatalf("Tail(2) returned %d entries, want 2", len(tail))
+	}
+	if tail[0].Seq != 1 || tail[1].Seq != 2 {
+		t.Errorf("Tail(2) returned sequences %d,%d, want 1,2", tail[0].Seq, tail[1].Seq)
+	}
+	if got := len(in.Log().Tail(99)); got != 3 {
+		t.Errorf("Tail(99) returned %d entries, want all 3", got)
+	}
+}
+
+// Sequence numbers are the log's ordering, so they must be dense and
+// monotonic from zero — Precedes compares them directly.
+func TestLogSequencesAreDenseAndMonotonic(t *testing.T) {
+	in, _ := newInstrumented(t)
+	for i := 0; i < 5; i++ {
+		if _, err := in.FetchLabels("acme", "widgets", 7); err != nil {
+			t.Fatalf("FetchLabels: %v", err)
+		}
+	}
+	for i, e := range in.Log().Entries() {
+		if e.Seq != i {
+			t.Fatalf("entry at index %d has Seq %d", i, e.Seq)
+		}
+		if e.Pending {
+			t.Fatalf("entry %d is still pending after the call returned: %s", i, e)
+		}
+	}
+}
+
+func TestLogReset(t *testing.T) {
+	in, _ := newInstrumented(t)
+	if _, err := in.FetchLabels("acme", "widgets", 7); err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	in.Log().Reset()
+	if got := in.Log().Len(); got != 0 {
+		t.Fatalf("Len() = %d after Reset, want 0", got)
+	}
+	if _, err := in.FetchLabels("acme", "widgets", 7); err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if got := in.Log().Entries()[0].Seq; got != 0 {
+		t.Errorf("first entry after Reset has Seq %d, want 0", got)
+	}
+}
+
+// An entry must carry the error the model returned, not just the fact that
+// something went wrong — the harness prints these when an AdvanceUntil
+// exhausts, and "something failed" is not a debugging aid.
+func TestLogRecordsModelErrors(t *testing.T) {
+	in, _ := newInstrumented(t)
+	if _, err := in.FetchLabels("acme", "nosuch", 7); err == nil {
+		t.Fatal("FetchLabels on an unseeded repo returned no error")
+	}
+	entries := in.Log().ByMethod("FetchLabels")
+	if len(entries) != 1 {
+		t.Fatalf("got %d FetchLabels entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Err == nil {
+		t.Fatal("entry recorded no error for a failed call")
+	}
+	if e.Injected {
+		t.Error("a model-side failure was recorded as injected")
+	}
+	if !strings.Contains(e.String(), "err:") {
+		t.Errorf("Entry.String() = %q, want it to show the error", e.String())
+	}
+}
+
+// The log's timestamps come from the injected clock, like every other
+// time-bearing value in the package. A wall-clock read here would make an
+// entry's At incomparable with the label applied-at values the engine's gates
+// anchor on.
+func TestLogTimestampsComeFromTheInjectedClock(t *testing.T) {
+	in, clk := newInstrumented(t)
+	before := clk.Now()
+	if err := in.AddLabelToIssue("acme", "widgets", 7, "a"); err != nil {
+		t.Fatalf("AddLabelToIssue: %v", err)
+	}
+	clk.Advance(90 * time.Minute)
+	if err := in.AddLabelToIssue("acme", "widgets", 7, "b"); err != nil {
+		t.Fatalf("AddLabelToIssue: %v", err)
+	}
+
+	entries := in.Log().Entries()
+	if !entries[0].At.Equal(before) {
+		t.Errorf("first entry At = %v, want the clock's reading %v", entries[0].At, before)
+	}
+	if got := entries[1].At.Sub(entries[0].At); got != 90*time.Minute {
+		t.Errorf("entries are %v apart, want 90m — the log is not reading the injected clock", got)
+	}
+}
+
+// TestEveryInterfaceMethodIsInstrumented is the drift detector for the
+// decorator, and the reason *Sim is held as a named field rather than embedded.
+//
+// The compile-time assertion in instrumented.go proves *Instrumented satisfies
+// engine.GitHubClient; it cannot prove each method actually goes through the
+// wrapper. This does: it invokes all sixty by reflection and asserts each
+// produced exactly one log entry named for itself. A wrapper that delegated
+// without logging, or logged under a copy-pasted neighbour's name, fails here.
+func TestEveryInterfaceMethodIsInstrumented(t *testing.T) {
+	names := InterfaceMethods()
+	if len(names) < 60 {
+		t.Fatalf("reflection found only %d engine.GitHubClient methods; the interface should have ~60", len(names))
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			in, _ := newInstrumented(t)
+			callInterfaceMethod(t, in, name)
+
+			entries := in.Log().Entries()
+			if len(entries) != 1 {
+				t.Fatalf("calling %s produced %d log entries, want exactly 1\n%s", name, len(entries), in.Log().Dump(10))
+			}
+			if entries[0].Method != name {
+				t.Errorf("calling %s logged method %q — a copy-pasted method name in the wrapper", name, entries[0].Method)
+			}
+			if entries[0].Pending {
+				t.Errorf("calling %s left its log entry pending", name)
+			}
+		})
+	}
+}
+
+// Mutation classification is not derivable by reflection, so it is asserted
+// against an explicit list. A read misclassified as a mutation would pollute
+// Mutations(), which is the view every R4 ordering assertion is built on.
+func TestMutationFlagMatchesTheInterfaceSemantics(t *testing.T) {
+	wantMutations := map[string]bool{
+		"AddBlockedByIssue": true, "AddComment": true, "AddCommentReaction": true,
+		"AddLabelToIssue": true, "AddPRReviewCommentReaction": true, "AddProjectV2ItemById": true,
+		"AddReviewRequest": true, "ArchiveProjectItem": true, "CloseIssue": true,
+		"CreateDraftPR": true, "CreateIssue": true, "CreatePR": true,
+		"DeleteForwardingHooks": true, "DeleteReviewRequest": true,
+		"DequeuePullRequest": true, "DisablePullRequestAutoMerge": true,
+		"EnablePullRequestAutoMerge": true, "EnqueuePullRequest": true,
+		"MarkPRReady": true, "MergePR": true, "RemoveLabelFromIssue": true,
+		"ResolveReviewThread": true, "SeedLabels": true, "UpdateComment": true,
+		"UpdateIssueBody": true, "UpdatePRBase": true, "UpdateProjectItemStatus": true,
+	}
+
+	for _, name := range InterfaceMethods() {
+		t.Run(name, func(t *testing.T) {
+			in, _ := newInstrumented(t)
+			callInterfaceMethod(t, in, name)
+			entries := in.Log().Entries()
+			if len(entries) != 1 {
+				t.Fatalf("calling %s produced %d log entries, want 1", name, len(entries))
+			}
+			if got := entries[0].Mutation; got != wantMutations[name] {
+				t.Errorf("%s logged Mutation=%v, want %v", name, got, wantMutations[name])
+			}
+		})
+	}
+}
+
+// complete's out-of-range guard is unreachable through Instrumented, which
+// always hands back the sequence reserve returned. Asserting it panics keeps a
+// future direct caller from silently discarding an outcome.
+func TestCompleteRejectsAnUnknownSequence(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("complete with an out-of-range sequence did not panic")
+		}
+	}()
+	NewMutationLog().complete(42, errors.New("boom"), false)
+}
+
+func TestDumpOfAnEmptyLogIsReadable(t *testing.T) {
+	if got := NewMutationLog().Dump(10); !strings.Contains(got, "empty") {
+		t.Errorf("Dump on an empty log = %q, want it to say so", got)
+	}
+}

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -650,6 +650,11 @@ mutate "IndexOf answers -1 instead of erroring on an unmatched predicate" \
   'TestPrecedesErrorsWhenAPredicateMatchesNothing' \
   'mutationlog.go::s{return -1, fmt\.Errorf\("simgh: mutation log has no entry matching the predicate \(%d entries recorded\)", l\.Len\(\)\)}{return -1, nil}'
 
+mutate "FetchItemDetails logs the composite owner/repo as the bare repo name" \
+  'TestFetchItemDetailsSplitsTheCompositeRepo' \
+  'instrumented.go::s{\t\tif owner, repo, err := splitOwnerRepo\(item\.Repo\); err == nil \{\n\t\t\targs\.Owner, args\.Repo = owner, repo\n\t\t\}\n}{}'
+
+
 # --- R5: snapshot and restore (#1457) ---------------------------------------
 
 mutate "labelAppliedAt is not carried across a restore" \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -676,9 +676,12 @@ mutate "copyDir silently skips a non-regular file" \
   'TestCopyDirRefusesNonRegularFiles' \
   'snapshot.go::s{\t\t\treturn fmt\.Errorf\("simgh: copying %s: mode %v is neither a regular file nor a directory; "\+\n\t\t\t\t"a bare repository should contain only those", path, info\.Mode\(\)\)}{\t\t\treturn nil}'
 
+# Neutralised by pointing the remove at a path that never exists, rather than
+# by deleting the block: deleting it would leave the errors import unused, and
+# a mutation that does not compile is one the sweep never ran.
 mutate "copyFile cannot overwrite git's read-only objects" \
   'TestSnapshotAndRestoreAreIdempotentOverAnExistingDirectory' \
-  'snapshot.go::s{\tif err := os\.Remove\(dst\); err != nil && !errors\.Is\(err, fs\.ErrNotExist\) \{\n\t\treturn fmt\.Errorf\("simgh: replacing %s: %w", dst, err\)\n\t\}\n}{}'
+  'snapshot.go::s{\tif err := os\.Remove\(dst\); err != nil && !errors\.Is\(err, fs\.ErrNotExist\) \{}{\tif err := os.Remove(dst + ".nonexistent"); err != nil \&\& !errors.Is(err, fs.ErrNotExist) \{}'
 
 mutate "RestoreInstrumented accepts a snapshot carrying no instruments" \
   'TestRestoreInstrumentedRefusesABareSnapshot' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -654,6 +654,13 @@ mutate "FetchItemDetails logs the composite owner/repo as the bare repo name" \
   'TestFetchItemDetailsSplitsTheCompositeRepo' \
   'instrumented.go::s{\t\tif owner, repo, err := splitOwnerRepo\(item\.Repo\); err == nil \{\n\t\t\targs\.Owner, args\.Repo = owner, repo\n\t\t\}\n}{}'
 
+# The instrumentation layer reads the clock on every intercepted call, so an
+# unguarded test clock races the moment a scenario advances it with anything in
+# flight — which is how a harness driving Engine.Run() necessarily uses it.
+mutate_race "the injected clock is unguarded (expects a data race on advance)" \
+  'TestAdvancingTheClockUnderTrafficIsRaceFree' \
+  'helpers_test.go::s{^\tmu sync\.Mutex$}{\tmu noopClockMutex}m' \
+  'helpers_test.go::s{^func newFakeClock\(\)}{type noopClockMutex struct{}\n\nfunc (noopClockMutex) Lock()   {}\nfunc (noopClockMutex) Unlock() {}\n\nvar _ = sync.Mutex{}\n\nfunc newFakeClock()}m'
 
 # --- R5: snapshot and restore (#1457) ---------------------------------------
 

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -510,6 +510,188 @@ mutate "SeedBlockedBy does not stamp the issue" \
   'TestSeedBlockedByDedupesAndStamps' \
   'seed.go::s{iss\.blockedBy = append\(iss\.blockedBy, gh\.Dependency\{Number: blockerNumber, Repo: repoField\}\)\n\tiss\.updatedAt = s\.now\(\)}{iss.blockedBy = append(iss.blockedBy, gh.Dependency\{Number: blockerNumber, Repo: repoField\})}'
 
+# --- R2: clock-driven schedules (#1457) -------------------------------------
+#
+# The drain accessors are the whole sequencing mechanism, and each read path
+# calls one. TestScheduleVisibleThroughEveryReadPath builds a fresh Sim per
+# path precisely so a single deleted drain is catchable — draining is a write,
+# so a shared Sim would let one path's drain cover for another's.
+
+mutate "scheduled CI steps never drain" \
+  'TestScheduledCheckRunTransitionIsClockDriven|TestScheduleVisibleThroughEveryReadPath' \
+  'schedule.go::s{func \(s \*Sim\) drainCI\(r \*repoState\) \{ r\.ciSchedule\.drain\(s\.now\(\), r\) \}}{func (s *Sim) drainCI(r *repoState) \{ _ = r \}}'
+
+mutate "scheduled review steps never drain" \
+  'TestScheduledReviewArrivesOnTheClock|TestScheduleVisibleThroughEveryReadPath' \
+  'schedule.go::s{func \(s \*Sim\) drainReviews\(pr \*prRecord\) \{ pr\.reviewSchedule\.drain\(s\.now\(\), pr\) \}}{func (s *Sim) drainReviews(pr *prRecord) \{ _ = pr \}}'
+
+mutate "a step scheduled for exactly now does not fire" \
+  'TestScheduledCheckRunTransitionIsClockDriven' \
+  'schedule.go::s{if step\.at\.After\(now\) \{}{if !step.at.Before(now) \{}'
+
+mutate "steps apply in seeding order rather than time order" \
+  'TestStepsApplyInTimeThenSeedingOrder' \
+  'schedule.go::s{\tfor i > 0 && sc\.steps\[i-1\]\.at\.After\(at\) \{\n\t\ti--\n\t\}\n}{}'
+
+mutate "a fired step stays queued and re-applies on every read" \
+  'TestScheduledCommitStatusIsClockDriven' \
+  'schedule.go::s{\tremaining := make\(\[\]scheduleStep\[T\], len\(sc\.steps\)-applied\)\n\tcopy\(remaining, sc\.steps\[applied:\]\)\n\tsc\.steps = remaining\n}{}'
+
+mutate "FetchCheckRuns does not drain" \
+  'TestScheduleVisibleThroughEveryReadPath' \
+  'ci.go::s{\ts\.drainCI\(r\)\n\truns := r\.checkRuns\[sha\]}{\truns := r.checkRuns[sha]}'
+
+mutate "FetchCombinedStatus does not drain" \
+  'TestScheduleVisibleThroughEveryReadPath' \
+  'ci.go::s{\t\ts\.drainCI\(r\)\n\t\tif direct, ok := r\.commitStatuses\[ref\]; ok \{}{\t\tif direct, ok := r.commitStatuses[ref]; ok \{}'
+
+mutate "the mergeable derivation does not drain" \
+  'TestScheduleVisibleThroughEveryReadPath' \
+  'prs.go::s{^\ts\.drainCI\(r\)$}{}m'
+
+mutate "the board projection does not drain" \
+  'TestScheduleVisibleThroughEveryReadPath' \
+  'board.go::s{\t\ts\.drainReviews\(linked\)\n\t\tlinkedHead = linked\.head\n\t\titem\.LinkedPRNumber}{\t\tlinkedHead = linked.head\n\t\titem.LinkedPRNumber}'
+
+mutate "the probe path does not drain" \
+  'TestScheduleVisibleThroughEveryReadPath' \
+  'board.go::s{\t\ts\.drainReviews\(linked\)\n\t\tlinkedHead = linked\.head\n\t\tprobe\.LinkedPRNumber}{\t\tlinkedHead = linked.head\n\t\tprobe.LinkedPRNumber}'
+
+mutate "FetchPRReviews does not drain" \
+  'TestScheduleVisibleThroughEveryReadPath' \
+  'reviews.go::s{\ts\.drainReviews\(pr\)\n\treturn latestReviewsByAuthor}{\treturn latestReviewsByAuthor}'
+
+mutate "FetchPRReviewRequests does not drain" \
+  'TestScheduleVisibleThroughEveryReadPath' \
+  'reviews.go::s{\ts\.drainReviews\(pr\)\n\tout := make\(\[\]gh\.ReviewRequest}{\tout := make([]gh.ReviewRequest}'
+
+mutate "FetchPRReviewDecision does not drain" \
+  'TestScheduleVisibleThroughEveryReadPath' \
+  'reviews.go::s{\ts\.drainReviews\(pr\)\n\trequired, ok := r\.requiredApprovals}{\trequired, ok := r.requiredApprovals}'
+
+mutate "a due step can undo an engine review withdrawal" \
+  'TestADueStepCannotUndoAnEngineWithdrawal' \
+  'reviews.go::s{\ts\.drainReviews\(pr\)\n\tkept := pr\.reviewRequests}{\tkept := pr.reviewRequests}'
+
+mutate "a scheduled check run appends instead of superseding by ID" \
+  'TestScheduledCheckRunTransitionIsClockDriven' \
+  'seed.go::s{\t\tif list\[i\]\.ID == run\.ID \{}{\t\tif false \&\& list[i].ID == run.ID \{}'
+
+mutate "an empty scheduled step is accepted" \
+  'TestAnEmptyScheduledStepIsASeedingError' \
+  'seed.go::s{\t\ts\.fail\("simgh: SeedCheckRunsAt\(%s, %s\): no check runs given; an empty step is unobservable", ownerRepo, sha\)\n\t\treturn s\n}{}'
+
+mutate "a scheduled review is not stamped with the step's instant" \
+  'TestScheduledReviewArrivesOnTheClock' \
+  'seed.go::s{\t\tif rev\.SubmittedAt\.IsZero\(\) \{\n\t\t\trev\.SubmittedAt = at\n\t\t\}\n}{}'
+
+mutate "SeedRateLimits accepts a remaining above the limit" \
+  'TestSeedRateLimits' \
+  'seed.go::s{if restRemaining > restLimit \|\| graphqlRemaining > graphqlLimit \{}{if false \{}'
+
+# --- R3: fault injection (#1457) --------------------------------------------
+#
+# The first of these is AC10's named case: an injector that silently succeeds
+# is the canonical false pass for fault-injection code, because every
+# assertion about "what happened when the call failed" is then made about a
+# call that did not fail.
+
+mutate "the fault injector silently succeeds" \
+  'TestFaultFailsNTimesThenSucceeds|TestAFaultedCallDoesNotReachTheModel|TestEveryInterfaceMethodIsFaultable' \
+  'instrumented.go::s{if err := in\.faults\.next\(method, args\); err != nil \{}{if err := in.faults.next(method, args); err != nil \&\& false \{}g'
+
+mutate "injected failures are not distinguished from model failures" \
+  'TestFaultFailsNTimesThenSucceeds|TestEveryInterfaceMethodIsFaultable' \
+  'instrumented.go::s{in\.log\.complete\(seq, err, true\)}{in.log.complete(seq, err, false)}g'
+
+mutate "FailNTimes never exhausts" \
+  'TestFaultFailsNTimesThenSucceeds|TestFailOnce' \
+  'fault.go::s{\t\tif r\.remaining > 0 \{\n\t\t\tr\.remaining--\n\t\t\}\n}{}'
+
+mutate "FailWhen ignores its match predicate" \
+  'TestFailWhenNarrowsByArguments' \
+  'fault.go::s{\t\tif r\.match != nil && !r\.match\(args\) \{\n\t\t\tcontinue\n\t\t\}\n}{}'
+
+mutate "FailOnCall fires on every call" \
+  'TestFailOnCallFiresOnlyOnTheKthCall' \
+  'fault.go::s{\t\t\tif n != r\.onCall \{}{\t\t\tif n != r.onCall \&\& false \{}'
+
+mutate "a fault on an unknown method is accepted" \
+  'TestRegisteringAFaultOnAnUnknownMethodPanics' \
+  'fault.go::s{if !interfaceMethodSet\[method\] \{}{if false \{}'
+
+mutate "a fault on RateLimitStats is accepted" \
+  'TestRegisteringAFaultOnRateLimitStatsPanics' \
+  'fault.go::s{if unfaultableMethods\[method\] \{}{if false \{}'
+
+mutate "a fault registered with a nil error is accepted" \
+  'TestRegisteringAFaultWithANilErrorPanics' \
+  'fault.go::s{\tif r\.err == nil \{}{\tif false \{}'
+
+# --- R4: mutation log (#1457) -----------------------------------------------
+
+mutate "the log records a model failure as a success" \
+  'TestLogRecordsModelErrors' \
+  'instrumented.go::s{\tv, err := fn\(\)\n\tin\.log\.complete\(seq, err, false\)}{\tv, err := fn()\n\tin.log.complete(seq, nil, false)}'
+
+mutate "log entries are not sequenced" \
+  'TestLogSequencesAreDenseAndMonotonic' \
+  'mutationlog.go::s{\t\tSeq:      seq,\n}{}'
+
+mutate "every intercepted call is recorded as a mutation" \
+  'TestLogRecordsReadsAndMutationsSeparately|TestMutationFlagMatchesTheInterfaceSemantics' \
+  'mutationlog.go::s{\t\tMutation: mutation,}{\t\tMutation: true,}'
+
+mutate "the log reads wall-clock time instead of the injected clock" \
+  'TestLogTimestampsComeFromTheInjectedClock' \
+  'instrumented.go::s{in\.sim\.now\(\)}{time.Now()}g'
+
+mutate "IndexOf answers -1 instead of erroring on an unmatched predicate" \
+  'TestPrecedesErrorsWhenAPredicateMatchesNothing' \
+  'mutationlog.go::s{return -1, fmt\.Errorf\("simgh: mutation log has no entry matching the predicate \(%d entries recorded\)", l\.Len\(\)\)}{return -1, nil}'
+
+# --- R5: snapshot and restore (#1457) ---------------------------------------
+
+mutate "labelAppliedAt is not carried across a restore" \
+  'TestSnapshotRestoreRoundTripsTheModel' \
+  'snapshot.go::s{\tfor k, v := range i\.labelAppliedAt \{\n\t\tout\.labelAppliedAt\[k\] = v\n\t\}\n}{}'
+
+mutate "the CI schedule is not carried across a restore" \
+  'TestRestoreResumesScheduledSequencesAtTheSamePosition' \
+  'snapshot.go::s{\t\tciSchedule:        r\.ciSchedule\.clone\(\),\n}{}'
+
+mutate "the review schedule is not carried across a restore" \
+  'TestRestoreResumesScheduledSequencesAtTheSamePosition' \
+  'snapshot.go::s{\t\treviewSchedule:          p\.reviewSchedule\.clone\(\),\n}{}'
+
+mutate "the recompute counter is not carried across a restore" \
+  'TestRestoreResumesTheRecomputeCounter' \
+  'snapshot.go::s{\t\tmergeableRecomputeReads: p\.mergeableRecomputeReads,\n}{}'
+
+mutate "restore does not repoint bareDir at the new baseDir" \
+  'TestRestoredModelIsIndependentOfTheOriginal' \
+  'snapshot.go::s{\t\trestored\.bareDir = s\.repoDir\(restored\.owner, restored\.repo\)\n\t\trestored\.worktreeRoot = restored\.bareDir \+ "\.worktrees"\n}{}'
+
+mutate "copyDir silently skips a non-regular file" \
+  'TestCopyDirRefusesNonRegularFiles' \
+  'snapshot.go::s{\t\t\treturn fmt\.Errorf\("simgh: copying %s: mode %v is neither a regular file nor a directory; "\+\n\t\t\t\t"a bare repository should contain only those", path, info\.Mode\(\)\)}{\t\t\treturn nil}'
+
+mutate "copyFile cannot overwrite git's read-only objects" \
+  'TestSnapshotAndRestoreAreIdempotentOverAnExistingDirectory' \
+  'snapshot.go::s{\tif err := os\.Remove\(dst\); err != nil && !errors\.Is\(err, fs\.ErrNotExist\) \{\n\t\treturn fmt\.Errorf\("simgh: replacing %s: %w", dst, err\)\n\t\}\n}{}'
+
+mutate "RestoreInstrumented accepts a snapshot carrying no instruments" \
+  'TestRestoreInstrumentedRefusesABareSnapshot' \
+  'snapshot.go::s{if !snap\.instrumented \{}{if false \{}'
+
+mutate "the fault schedule is not carried across a restore" \
+  'TestInstrumentedSnapshotCarriesFaultsAndLog' \
+  'snapshot.go::s{\tin\.faults\.restoreRules\(snap\.faultRules, snap\.faultCalls\)\n}{}'
+
+mutate "the mutation log is not carried across a restore" \
+  'TestInstrumentedSnapshotCarriesFaultsAndLog' \
+  'snapshot.go::s{\tin\.log\.restoreEntries\(snap\.logEntries\)\n}{}'
+
 echo
 status=0
 if [ ${#FAILED_TO_CATCH[@]} -ne 0 ]; then

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -348,6 +348,10 @@ func (s *Sim) deriveMergeableState(r *repoState, base string, facts gitFactsResu
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Any due CI step lands before the derivation reads the collections, so
+	// this read and FetchCheckRuns cannot disagree about the same SHA.
+	s.drainCI(r)
+
 	// GitHub reports "behind" only where branch protection requires the head
 	// to be up to date; without that setting a PR whose base has advanced is
 	// still "clean". Gating on the seeded requirement rather than on

--- a/tests/sim/simgh/reviews.go
+++ b/tests/sim/simgh/reviews.go
@@ -24,6 +24,7 @@ func (s *Sim) FetchPRReviews(owner, repo string, prNumber int) ([]gh.PRReview, e
 	if err != nil {
 		return nil, err
 	}
+	s.drainReviews(pr)
 	return latestReviewsByAuthor(pr.reviews), nil
 }
 
@@ -72,6 +73,7 @@ func (s *Sim) FetchPRReviewRequests(owner, repo string, prNumber int) ([]gh.Revi
 	if err != nil {
 		return nil, err
 	}
+	s.drainReviews(pr)
 	out := make([]gh.ReviewRequest, len(pr.reviewRequests))
 	copy(out, pr.reviewRequests)
 	return out, nil
@@ -86,6 +88,9 @@ func (s *Sim) AddReviewRequest(owner, repo string, prNumber int, reviewers []str
 	if err != nil {
 		return err
 	}
+	// Drain before mutating: a step already due must land before this
+	// withdrawal or addition, not after it. See schedule.go's drainReviews.
+	s.drainReviews(pr)
 	changed := false
 	for _, login := range reviewers {
 		already := false
@@ -121,6 +126,7 @@ func (s *Sim) DeleteReviewRequest(owner, repo string, prNumber int, reviewers []
 	if err != nil {
 		return err
 	}
+	s.drainReviews(pr)
 	kept := pr.reviewRequests[:0:0]
 	for _, existing := range pr.reviewRequests {
 		if !contains(reviewers, existing.Login) {
@@ -155,6 +161,7 @@ func (s *Sim) FetchPRReviewDecision(owner, repo string, prNumber int) (string, e
 	if err != nil {
 		return "", err
 	}
+	s.drainReviews(pr)
 	required, ok := r.requiredApprovals[pr.base]
 	if !ok {
 		// No review requirement configured on the base branch — GraphQL

--- a/tests/sim/simgh/schedule.go
+++ b/tests/sim/simgh/schedule.go
@@ -1,0 +1,149 @@
+package simgh
+
+import "time"
+
+// This file is the sequencing primitive: how a scripted surface returns a
+// different value after a given instant, so a scenario can express "CI is
+// pending for two polls, then fails" or "the reviewer responds on the third
+// poll" without wall-clock sleeping.
+//
+// # Why the clock and not a read count
+//
+// R2 offers either. Read count is the wrong mechanism here, and the reason is
+// not concurrency in the abstract — it is that **one poll is not one read.**
+// settleAwaitingCIScan primes the store with a live check-run read
+// (RefreshCheckRunsLive) precisely so a stale cached PENDING cannot wedge the
+// item, and the handler chain it then runs reaches checkCIGate, which reads
+// check-run state again: two reads of one SHA in a single poll, before
+// MaxConcurrent workers enter the picture at all. Worse, the first of those
+// reads is guarded on the engine having a boardcache wired, which is a harness
+// configuration decision, not an engine invariant.
+//
+// So "pending, pending, failure" expressed in read counts does not mean
+// "pending for two polls, then red" — it means "pending for the first two
+// reads, whenever those happen to occur", and the poll-to-read mapping is an
+// implementation detail of the very scan under test. That is a flaky-test
+// generator inside the layer built to eliminate flaky tests.
+//
+// Read-count sequencing survives in exactly one place: prRecord's
+// mergeableRecomputeReads, which models a genuine GitHub behaviour (a
+// recompute that resolves after some reads) rather than a test's notion of
+// elapsed time. Its reproducibility caveat is recorded in FIDELITY.md.
+//
+// # Steps are pending mutations applied on read, not a read filter
+//
+// When a step's time arrives, it *writes into the model*, and the write is
+// permanent. Two consequences, both deliberate:
+//
+//   - Repeated reads at one clock instant are stable. The step applies once,
+//     on the first read past its time; every later read sees the same model.
+//     A read filter recomputed per call would be equally stable, but only by
+//     accident of being pure — this is stable structurally.
+//
+//   - Engine mutations to the same surface remain observable afterwards. A
+//     filter that overrode reviewRequests would mask AddReviewRequest, which
+//     is the bot re-prompt ladder's own mutation (ADR-1283) — the engine would
+//     make a call, the model would accept it, and the next read would deny it
+//     ever happened.
+//
+// # Locking
+//
+// A schedule is part of the model, guarded by Sim.mu like everything else it
+// sits next to. drain must be called with mu held, and a step's apply function
+// therefore runs under mu — so no step may run git or take gitMu. Every step
+// this package constructs is a pure in-memory append or replace.
+
+// scheduleStep is one pending timed mutation of T.
+type scheduleStep[T any] struct {
+	at    time.Time
+	apply func(T)
+}
+
+// schedule is an ordered queue of pending timed mutations. The zero value is
+// an empty schedule.
+type schedule[T any] struct {
+	// steps is kept sorted by at, with insertion order preserved among steps
+	// sharing an instant — two steps scheduled for the same moment apply in
+	// the order they were seeded, which is the only ordering a scenario author
+	// can reason about.
+	steps []scheduleStep[T]
+}
+
+// add enqueues a step. Caller must hold mu.
+func (sc *schedule[T]) add(at time.Time, apply func(T)) {
+	i := len(sc.steps)
+	for i > 0 && sc.steps[i-1].at.After(at) {
+		i--
+	}
+	sc.steps = append(sc.steps, scheduleStep[T]{})
+	copy(sc.steps[i+1:], sc.steps[i:])
+	sc.steps[i] = scheduleStep[T]{at: at, apply: apply}
+}
+
+// drain applies every step whose time has arrived, in order, and removes them.
+// Reports whether anything was applied. Caller must hold mu.
+//
+// "Arrived" is at <= now, not at < now: a step scheduled for exactly the
+// current instant fires. A scenario advancing the clock by precisely the
+// interval it scheduled against is the common case, and the alternative would
+// make it silently a no-op.
+func (sc *schedule[T]) drain(now time.Time, target T) bool {
+	applied := 0
+	for _, step := range sc.steps {
+		if step.at.After(now) {
+			break
+		}
+		step.apply(target)
+		applied++
+	}
+	if applied == 0 {
+		return false
+	}
+	remaining := make([]scheduleStep[T], len(sc.steps)-applied)
+	copy(remaining, sc.steps[applied:])
+	sc.steps = remaining
+	return true
+}
+
+// pending reports how many steps have not yet fired. Caller must hold mu.
+func (sc *schedule[T]) pending() int { return len(sc.steps) }
+
+// clone deep-copies the queue for a snapshot. The apply closures are shared
+// rather than reconstructed — they capture only the values the scenario
+// seeded, and they take their target as a parameter, so a clone re-attached to
+// a *different* repoState or prRecord after a restore still mutates the right
+// one. That is why the target is a parameter rather than a captured pointer.
+// Caller must hold mu.
+func (sc *schedule[T]) clone() schedule[T] {
+	if len(sc.steps) == 0 {
+		return schedule[T]{}
+	}
+	out := make([]scheduleStep[T], len(sc.steps))
+	copy(out, sc.steps)
+	return schedule[T]{steps: out}
+}
+
+// drainCI applies every due check-run and commit-status step for a repo.
+//
+// Every read path that consults r.checkRuns or r.commitStatuses must call this
+// first — FetchCheckRuns, both branches of FetchCombinedStatus, and
+// deriveMergeableState ahead of contextsForSHA. Routing them all through one
+// accessor rather than inlining the drain is what keeps two reads of one model
+// from reporting two verdicts, the bug reviews.go already warns about one
+// layer up.
+//
+// Caller must hold mu.
+func (s *Sim) drainCI(r *repoState) { r.ciSchedule.drain(s.now(), r) }
+
+// drainReviews applies every due review and review-request step for a PR.
+//
+// Called by every read path consulting pr.reviews or pr.reviewRequests
+// (FetchPRReviews, FetchPRReviewRequests, FetchPRReviewDecision, and the board
+// projection's linked-PR fields) and also by AddReviewRequest and
+// DeleteReviewRequest before they mutate. Draining in the mutators is not
+// belt-and-braces: without it a step due *before* an engine withdrawal would
+// apply *after* it, re-adding a reviewer the engine had just removed and
+// inverting the order in which the two happened.
+//
+// Caller must hold mu.
+func (s *Sim) drainReviews(pr *prRecord) { pr.reviewSchedule.drain(s.now(), pr) }

--- a/tests/sim/simgh/schedule_test.go
+++ b/tests/sim/simgh/schedule_test.go
@@ -1,0 +1,564 @@
+package simgh
+
+import (
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// seedPRForScheduling builds a repo with a PR whose head and base both exist,
+// so every git-derived answer about it is real, and returns the head SHA.
+func seedPRForScheduling(t *testing.T) (*Sim, *fakeClock, string) {
+	t.Helper()
+	s, clk := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedProject("acme", 2, "Engineering", []string{"Backlog", "Implement", "Review", "Done"}).
+		SeedIssue("acme/widgets", IssueSeed{Number: 7, Title: "Add a thing", Status: "Implement"}).
+		SeedCommit("acme/widgets", "fabrik/issue-7", map[string]string{"a.txt": "a"}, "work").
+		SeedPR("acme/widgets", PRSeed{Number: 8, Title: "PR", Head: "fabrik/issue-7", IssueNumber: 7})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	return s, clk, mustHeadSHA(t, s, "acme/widgets", "fabrik/issue-7")
+}
+
+// TestScriptedCheckRunsAreKeyedBySHA is AC1: two SHAs carry two different
+// verdicts within one scenario.
+//
+// Per-SHA keying is what the merge train's bisection path consumes — it calls
+// FetchCheckRuns(owner, repo, sha) against each trial-branch head — so a
+// scenario declares a poison set and lets the real algorithm discover it.
+func TestScriptedCheckRunsAreKeyedBySHA(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedCheckRun("acme/widgets", "sha-good", gh.CheckRun{Name: "build", Conclusion: "success"}).
+		SeedCheckRun("acme/widgets", "sha-bad", gh.CheckRun{Name: "build", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	for _, tc := range []struct{ sha, want string }{
+		{"sha-good", "success"},
+		{"sha-bad", "failure"},
+	} {
+		runs, err := s.FetchCheckRuns("acme", "widgets", tc.sha)
+		if err != nil {
+			t.Fatalf("FetchCheckRuns(%s): %v", tc.sha, err)
+		}
+		if len(runs) != 1 {
+			t.Fatalf("FetchCheckRuns(%s) returned %d runs, want 1", tc.sha, len(runs))
+		}
+		if runs[0].Conclusion != tc.want {
+			t.Errorf("FetchCheckRuns(%s) conclusion = %q, want %q", tc.sha, runs[0].Conclusion, tc.want)
+		}
+	}
+
+	// An untouched SHA reports zero runs, not an error — GitHub's own answer
+	// for a commit no CI has reached.
+	runs, err := s.FetchCheckRuns("acme", "widgets", "sha-unknown")
+	if err != nil {
+		t.Fatalf("FetchCheckRuns(unknown): %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("an unseeded SHA reported %d runs, want 0", len(runs))
+	}
+}
+
+// TestScheduledCheckRunTransitionIsClockDriven is AC2.
+//
+// Three claims: the surface reports pending before the scheduled instant,
+// failure at and after it, and — the part read-count sequencing could not
+// deliver — the answer is *stable across repeated reads at a single clock
+// instant*. One poll is not one read: settleAwaitingCIScan's
+// RefreshCheckRunsLive and checkCIGate each read the same SHA within one poll,
+// so a sequence that advanced per read would not correspond to poll boundaries
+// at all.
+func TestScheduledCheckRunTransitionIsClockDriven(t *testing.T) {
+	s, clk, sha := seedPRForScheduling(t)
+
+	// The same check run, by ID, transitioning from in_progress to failure.
+	s.SeedCheckRun("acme/widgets", sha, gh.CheckRun{ID: 900, Name: "build", Status: "in_progress"}).
+		SeedCheckRunsAfter("acme/widgets", sha, 30*time.Minute,
+			gh.CheckRun{ID: 900, Name: "build", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	verdict := func() string {
+		t.Helper()
+		runs, err := s.FetchCheckRuns("acme", "widgets", sha)
+		if err != nil {
+			t.Fatalf("FetchCheckRuns: %v", err)
+		}
+		if len(runs) != 1 {
+			t.Fatalf("got %d runs, want 1 — the step should supersede by ID, not append", len(runs))
+		}
+		return checkVerdict(runs[0])
+	}
+
+	// Repeated reads before the instant: still pending, however many.
+	for i := 0; i < 5; i++ {
+		if got := verdict(); got != "pending" {
+			t.Fatalf("read %d before the scheduled instant = %q, want pending", i+1, got)
+		}
+	}
+
+	clk.Advance(29 * time.Minute)
+	if got := verdict(); got != "pending" {
+		t.Fatalf("one minute short of the scheduled instant = %q, want pending", got)
+	}
+
+	clk.Advance(time.Minute)
+	// Repeated reads at and after the instant: consistently failure. A step
+	// that applied per read rather than per instant would flap here.
+	for i := 0; i < 5; i++ {
+		if got := verdict(); got != "failure" {
+			t.Fatalf("read %d at the scheduled instant = %q, want failure", i+1, got)
+		}
+	}
+	clk.Advance(24 * time.Hour)
+	if got := verdict(); got != "failure" {
+		t.Fatalf("long after the scheduled instant = %q, want failure", got)
+	}
+}
+
+// A new ID appends rather than superseding — the rerun shape, which
+// production's latestCheckRunsByName reduces by keeping the highest ID.
+func TestScheduledCheckRunWithANewIDModelsARerun(t *testing.T) {
+	s, clk, sha := seedPRForScheduling(t)
+	s.SeedCheckRun("acme/widgets", sha, gh.CheckRun{ID: 900, Name: "build", Conclusion: "failure"}).
+		SeedCheckRunsAfter("acme/widgets", sha, time.Hour,
+			gh.CheckRun{ID: 901, Name: "build", Conclusion: "success"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	clk.Advance(time.Hour)
+	runs, err := s.FetchCheckRuns("acme", "widgets", sha)
+	if err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("got %d runs, want 2 — a new ID is a rerun, not a transition", len(runs))
+	}
+	// The reduction production performs keeps the newest run, so the PR is
+	// clean rather than blocked.
+	state, err := s.FetchPRMergeableState("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRMergeableState: %v", err)
+	}
+	if state != "clean" {
+		t.Errorf("mergeable state = %q after the passing rerun, want clean", state)
+	}
+}
+
+// TestScheduledCommitStatusIsClockDriven covers the classic Statuses API half
+// of the CI surface, kept genuinely separate from check runs because
+// production distinguishes them (ADR-933).
+func TestScheduledCommitStatusIsClockDriven(t *testing.T) {
+	s, clk, sha := seedPRForScheduling(t)
+	s.SeedCommitStatus("acme/widgets", sha, gh.CommitStatus{Context: "legacy-ci", State: "pending"}).
+		SeedCommitStatusesAfter("acme/widgets", sha, 15*time.Minute,
+			gh.CommitStatus{Context: "legacy-ci", State: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	latest := func() string {
+		t.Helper()
+		sts, err := s.FetchCombinedStatus("acme", "widgets", sha)
+		if err != nil {
+			t.Fatalf("FetchCombinedStatus: %v", err)
+		}
+		if len(sts) == 0 {
+			t.Fatal("no statuses")
+		}
+		return statusVerdict(sts[len(sts)-1])
+	}
+
+	if got := latest(); got != "pending" {
+		t.Fatalf("before the scheduled instant = %q, want pending", got)
+	}
+	clk.Advance(15 * time.Minute)
+	if got := latest(); got != "failure" {
+		t.Fatalf("at the scheduled instant = %q, want failure", got)
+	}
+}
+
+// TestEveryReviewStateIsSettableAndReadBack is AC3: each state the review gate
+// distinguishes round-trips.
+//
+// The requested-but-unresponded case is the load-bearing one — it is what
+// keeps fabrik:awaiting-review applied — and it lives on a different surface
+// (FetchPRReviewRequests) from the four verdicts, so it is asserted there.
+func TestEveryReviewStateIsSettableAndReadBack(t *testing.T) {
+	s, _, _ := seedPRForScheduling(t)
+	for _, state := range []string{"APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"} {
+		s.SeedReview("acme/widgets", 8, gh.PRReview{Author: "reviewer-" + state, State: state})
+	}
+	s.SeedReviewRequest("acme/widgets", 8, gh.ReviewRequest{Login: "unresponded-human"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	reviews, err := s.FetchPRReviews("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	got := make(map[string]string, len(reviews))
+	for _, rev := range reviews {
+		got[rev.Author] = rev.State
+	}
+	for _, state := range []string{"APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"} {
+		if got["reviewer-"+state] != state {
+			t.Errorf("review state %s read back as %q", state, got["reviewer-"+state])
+		}
+	}
+
+	reqs, err := s.FetchPRReviewRequests("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviewRequests: %v", err)
+	}
+	if len(reqs) != 1 || reqs[0].Login != "unresponded-human" {
+		t.Errorf("FetchPRReviewRequests = %+v, want the one outstanding human", reqs)
+	}
+}
+
+// TestScheduledReviewArrivesOnTheClock covers "no review, then a review at T"
+// — the shape the review gate's bot re-prompt ladder and its timeout depend
+// on. The derived reviewDecision must move with it, since it shares
+// latestReviewsByAuthor with FetchPRReviews and the two cannot be allowed to
+// disagree.
+func TestScheduledReviewArrivesOnTheClock(t *testing.T) {
+	s, clk, _ := seedPRForScheduling(t)
+	s.SeedRequiredApprovals("acme/widgets", "main", 1).
+		SeedReviewsAfter("acme/widgets", 8, 40*time.Minute,
+			gh.PRReview{Author: "human", State: "APPROVED"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	reviews, err := s.FetchPRReviews("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 0 {
+		t.Fatalf("got %d reviews before the scheduled instant, want 0", len(reviews))
+	}
+	decision, err := s.FetchPRReviewDecision("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviewDecision: %v", err)
+	}
+	if decision != "REVIEW_REQUIRED" {
+		t.Errorf("decision before the review = %q, want REVIEW_REQUIRED", decision)
+	}
+
+	clk.Advance(40 * time.Minute)
+
+	reviews, err = s.FetchPRReviews("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 1 || reviews[0].State != "APPROVED" {
+		t.Fatalf("got %+v after the scheduled instant, want one APPROVED review", reviews)
+	}
+	// SubmittedAt is the step's instant, not whenever the read happened to
+	// drain it.
+	if want := clk.Now(); !reviews[0].SubmittedAt.Equal(want) {
+		t.Errorf("SubmittedAt = %v, want the scheduled instant %v", reviews[0].SubmittedAt, want)
+	}
+	decision, err = s.FetchPRReviewDecision("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviewDecision: %v", err)
+	}
+	if decision != "APPROVED" {
+		t.Errorf("decision after the review = %q, want APPROVED", decision)
+	}
+}
+
+// A landed step must not mask later engine mutations to the same surface.
+//
+// AddReviewRequest is the bot re-prompt ladder's own mutation (ADR-1283): had
+// schedules been implemented as read filters, the engine would make the call,
+// the model would accept it, and the next read would deny it ever happened.
+func TestEngineMutationsRemainObservableAfterAStepLands(t *testing.T) {
+	s, clk, _ := seedPRForScheduling(t)
+	s.SeedReviewRequestsAfter("acme/widgets", 8, 10*time.Minute,
+		gh.ReviewRequest{Login: "scheduled-human"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	clk.Advance(10 * time.Minute)
+	if _, err := s.FetchPRReviewRequests("acme", "widgets", 8); err != nil {
+		t.Fatalf("FetchPRReviewRequests: %v", err)
+	}
+
+	if err := s.AddReviewRequest("acme", "widgets", 8, []string{"handarbeit-pruefer"}); err != nil {
+		t.Fatalf("AddReviewRequest: %v", err)
+	}
+	reqs, err := s.FetchPRReviewRequests("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviewRequests: %v", err)
+	}
+	if len(reqs) != 2 {
+		t.Fatalf("got %d requests, want both the scheduled one and the engine's: %+v", len(reqs), reqs)
+	}
+
+	// And a withdrawal must stick.
+	if err := s.DeleteReviewRequest("acme", "widgets", 8, []string{"scheduled-human"}); err != nil {
+		t.Fatalf("DeleteReviewRequest: %v", err)
+	}
+	reqs, err = s.FetchPRReviewRequests("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviewRequests: %v", err)
+	}
+	if len(reqs) != 1 || reqs[0].Login != "handarbeit-pruefer" {
+		t.Errorf("after withdrawing the scheduled reviewer: %+v, want only the engine's", reqs)
+	}
+}
+
+// A step that is already due when a mutator runs must land *before* it, not
+// after. Without the drain inside AddReviewRequest/DeleteReviewRequest, a
+// withdrawal would be silently undone by a step whose time had already come.
+func TestADueStepCannotUndoAnEngineWithdrawal(t *testing.T) {
+	s, clk, _ := seedPRForScheduling(t)
+	s.SeedReviewRequestsAfter("acme/widgets", 8, 10*time.Minute,
+		gh.ReviewRequest{Login: "scheduled-human"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	// Advance past the step's instant but never read the surface, so the step
+	// is due and undrained when the withdrawal arrives.
+	clk.Advance(10 * time.Minute)
+	if err := s.DeleteReviewRequest("acme", "widgets", 8, []string{"scheduled-human"}); err != nil {
+		t.Fatalf("DeleteReviewRequest: %v", err)
+	}
+
+	reqs, err := s.FetchPRReviewRequests("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviewRequests: %v", err)
+	}
+	if len(reqs) != 0 {
+		t.Errorf("got %+v, want none — the due step landed after the withdrawal instead of before it", reqs)
+	}
+}
+
+// TestScheduleVisibleThroughEveryReadPath is the guard against the bug this
+// design is most exposed to: a missed drain site making one read path disagree
+// with another about the same model. reviews.go already warns about that class
+// one layer up ("two reads of one model reporting two verdicts is a bug the
+// sim would be introducing"); a schedule multiplies the number of places it
+// can happen.
+func TestScheduleVisibleThroughEveryReadPath(t *testing.T) {
+	t.Run("CI paths", func(t *testing.T) {
+		s, clk, sha := seedPRForScheduling(t)
+		s.SeedRequiredContexts("acme/widgets", "main", []string{"build"}).
+			SeedCheckRun("acme/widgets", sha, gh.CheckRun{ID: 900, Name: "build", Conclusion: "success"}).
+			SeedCheckRunsAfter("acme/widgets", sha, time.Hour,
+				gh.CheckRun{ID: 900, Name: "build", Status: "completed", Conclusion: "failure"})
+		if err := s.Err(); err != nil {
+			t.Fatalf("seeding: %v", err)
+		}
+
+		clk.Advance(time.Hour)
+
+		// FetchCheckRuns — the direct read.
+		runs, err := s.FetchCheckRuns("acme", "widgets", sha)
+		if err != nil {
+			t.Fatalf("FetchCheckRuns: %v", err)
+		}
+		if len(runs) != 1 || checkVerdict(runs[0]) != "failure" {
+			t.Errorf("FetchCheckRuns = %+v, want one failing run", runs)
+		}
+
+		// deriveMergeableState via contextsForSHA — the derived read.
+		state, err := s.FetchPRMergeableState("acme", "widgets", 8)
+		if err != nil {
+			t.Fatalf("FetchPRMergeableState: %v", err)
+		}
+		if state != "blocked" {
+			t.Errorf("mergeable state = %q, want blocked — the derivation did not see the step", state)
+		}
+
+		// FetchPRDetails reaches the same derivation through a different entry.
+		details, err := s.FetchPRDetails("acme", "widgets", 8)
+		if err != nil {
+			t.Fatalf("FetchPRDetails: %v", err)
+		}
+		if details.MergeableState != "blocked" {
+			t.Errorf("FetchPRDetails MergeableState = %q, want blocked", details.MergeableState)
+		}
+	})
+
+	t.Run("review paths", func(t *testing.T) {
+		s, clk, _ := seedPRForScheduling(t)
+		s.SeedRequiredApprovals("acme/widgets", "main", 1).
+			SeedReviewsAfter("acme/widgets", 8, time.Hour, gh.PRReview{Author: "human", State: "CHANGES_REQUESTED"}).
+			SeedReviewRequestsAfter("acme/widgets", 8, time.Hour, gh.ReviewRequest{Login: "second-human"})
+		if err := s.Err(); err != nil {
+			t.Fatalf("seeding: %v", err)
+		}
+
+		clk.Advance(time.Hour)
+
+		reviews, err := s.FetchPRReviews("acme", "widgets", 8)
+		if err != nil {
+			t.Fatalf("FetchPRReviews: %v", err)
+		}
+		if len(reviews) != 1 {
+			t.Errorf("FetchPRReviews returned %d reviews, want 1", len(reviews))
+		}
+
+		decision, err := s.FetchPRReviewDecision("acme", "widgets", 8)
+		if err != nil {
+			t.Fatalf("FetchPRReviewDecision: %v", err)
+		}
+		if decision != "CHANGES_REQUESTED" {
+			t.Errorf("FetchPRReviewDecision = %q, want CHANGES_REQUESTED", decision)
+		}
+
+		reqs, err := s.FetchPRReviewRequests("acme", "widgets", 8)
+		if err != nil {
+			t.Fatalf("FetchPRReviewRequests: %v", err)
+		}
+		if len(reqs) != 1 {
+			t.Errorf("FetchPRReviewRequests returned %d, want 1", len(reqs))
+		}
+
+		// The board projection — the path the engine actually consumes most.
+		item := firstItemFull(t, s)
+		if len(item.LinkedPRReviews) != 1 {
+			t.Errorf("board projection LinkedPRReviews = %+v, want the scheduled review", item.LinkedPRReviews)
+		}
+		if len(item.LinkedPRReviewRequests) != 1 {
+			t.Errorf("board projection LinkedPRReviewRequests = %+v, want the scheduled request", item.LinkedPRReviewRequests)
+		}
+
+		// The probe path reads only updatedAt, but a due step bumps exactly
+		// that — and EffectiveUpdatedAt is how the engine decides an item is
+		// worth deep-fetching.
+		probes, _, err := s.ProbeProjectBoard("acme", "widgets", 2, "organization")
+		if err != nil {
+			t.Fatalf("ProbeProjectBoard: %v", err)
+		}
+		if len(probes) != 1 {
+			t.Fatalf("probe returned %d items, want 1", len(probes))
+		}
+		if probes[0].EffectiveUpdatedAt.Before(clk.Now()) {
+			t.Errorf("probe EffectiveUpdatedAt = %v, want it bumped to the step's instant %v",
+				probes[0].EffectiveUpdatedAt, clk.Now())
+		}
+	})
+}
+
+// Steps scheduled for the same instant apply in seeding order — the only
+// ordering a scenario author can reason about — and a batch of steps at
+// different instants applies in time order regardless of seeding order.
+func TestStepsApplyInTimeThenSeedingOrder(t *testing.T) {
+	s, clk, sha := seedPRForScheduling(t)
+	// Seeded out of time order deliberately.
+	s.SeedCheckRunsAfter("acme/widgets", sha, 2*time.Hour, gh.CheckRun{ID: 3, Name: "c", Conclusion: "success"}).
+		SeedCheckRunsAfter("acme/widgets", sha, time.Hour, gh.CheckRun{ID: 1, Name: "a", Conclusion: "success"}).
+		SeedCheckRunsAfter("acme/widgets", sha, time.Hour, gh.CheckRun{ID: 2, Name: "b", Conclusion: "success"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	clk.Advance(2 * time.Hour)
+	runs, err := s.FetchCheckRuns("acme", "widgets", sha)
+	if err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	var order []string
+	for _, run := range runs {
+		order = append(order, run.Name)
+	}
+	want := []string{"a", "b", "c"}
+	if len(order) != len(want) {
+		t.Fatalf("got %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("steps applied in order %v, want %v", order, want)
+		}
+	}
+}
+
+// An empty step could never be observed, so a scenario built on one would pass
+// without its sequence ever having existed.
+func TestAnEmptyScheduledStepIsASeedingError(t *testing.T) {
+	cases := []struct {
+		name string
+		seed func(*Sim)
+	}{
+		{"SeedCheckRunsAt", func(s *Sim) { s.SeedCheckRunsAt("acme/widgets", "sha", time.Now()) }},
+		{"SeedCommitStatusesAt", func(s *Sim) { s.SeedCommitStatusesAt("acme/widgets", "sha", time.Now()) }},
+		{"SeedReviewsAt", func(s *Sim) { s.SeedReviewsAt("acme/widgets", 8, time.Now()) }},
+		{"SeedReviewRequestsAt", func(s *Sim) { s.SeedReviewRequestsAt("acme/widgets", 8, time.Now()) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _, _ := seedPRForScheduling(t)
+			tc.seed(s)
+			if err := s.Err(); err == nil {
+				t.Fatalf("%s with no values recorded no seeding error", tc.name)
+			}
+		})
+	}
+}
+
+// SeedRateLimits is the controllability RateLimitStats needs, since fault
+// injection cannot fail a method with no error return.
+func TestSeedRateLimits(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRateLimits(5000, 100, 5000, 42)
+	if err := s.Err(); err != nil {
+		t.Fatalf("SeedRateLimits: %v", err)
+	}
+	rest, graphql := s.RateLimitStats()
+	if rest.Remaining != 100 || rest.Limit != 5000 || rest.Used != 4900 {
+		t.Errorf("rest = %+v, want limit 5000 remaining 100 used 4900", rest)
+	}
+	if graphql.Remaining != 42 || graphql.Used != 4958 {
+		t.Errorf("graphql = %+v, want remaining 42 used 4958", graphql)
+	}
+
+	// Remaining above the limit is not a budget GitHub could report.
+	s2, _ := newSim(t)
+	s2.SeedRateLimits(100, 200, 100, 100)
+	if err := s2.Err(); err == nil {
+		t.Error("SeedRateLimits accepted remaining > limit")
+	}
+}
+
+// mergeableRecomputeReads is the one surviving read-count sequence, kept
+// because it models a genuine GitHub behaviour rather than a test's notion of
+// elapsed time. Its reproducibility caveat — only one call site may read the
+// surface — is recorded in FIDELITY.md; this pins the mechanism itself.
+func TestReadCountSequencingSurvivesForTheRecomputeWindow(t *testing.T) {
+	s, _, _ := seedPRForScheduling(t)
+	s.SeedMergeableRecomputePending("acme/widgets", 8, 2)
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		mergeable, state, err := s.FetchPRMergeableFields("acme", "widgets", 8)
+		if err != nil {
+			t.Fatalf("read %d: %v", i+1, err)
+		}
+		if mergeable != nil || state != "unknown" {
+			t.Fatalf("read %d = (%v, %q), want (nil, unknown) inside the recompute window", i+1, mergeable, state)
+		}
+	}
+	mergeable, state, err := s.FetchPRMergeableFields("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("read 3: %v", err)
+	}
+	if mergeable == nil || !*mergeable || state != "clean" {
+		t.Errorf("read 3 = (%v, %q), want the real git-derived answer", mergeable, state)
+	}
+}

--- a/tests/sim/simgh/schedule_test.go
+++ b/tests/sim/simgh/schedule_test.go
@@ -165,7 +165,7 @@ func TestScheduledCommitStatusIsClockDriven(t *testing.T) {
 		t.Fatalf("seeding: %v", err)
 	}
 
-	latest := func() string {
+	read := func() []gh.CommitStatus {
 		t.Helper()
 		sts, err := s.FetchCombinedStatus("acme", "widgets", sha)
 		if err != nil {
@@ -174,6 +174,11 @@ func TestScheduledCommitStatusIsClockDriven(t *testing.T) {
 		if len(sts) == 0 {
 			t.Fatal("no statuses")
 		}
+		return sts
+	}
+	latest := func() string {
+		t.Helper()
+		sts := read()
 		return statusVerdict(sts[len(sts)-1])
 	}
 
@@ -183,6 +188,17 @@ func TestScheduledCommitStatusIsClockDriven(t *testing.T) {
 	clk.Advance(15 * time.Minute)
 	if got := latest(); got != "failure" {
 		t.Fatalf("at the scheduled instant = %q, want failure", got)
+	}
+
+	// The step must apply exactly once, however many times the surface is read
+	// afterwards. Statuses accumulate rather than superseding by ID, so a step
+	// that stayed queued after firing would append a duplicate on every read —
+	// which is what "one poll is not one read" would turn into an ever-growing
+	// collection. This is AC2's stability requirement in its most direct form.
+	for i := 0; i < 4; i++ {
+		if got := len(read()); got != 2 {
+			t.Fatalf("read %d returned %d statuses, want 2 — the step re-applied", i+1, got)
+		}
 	}
 }
 
@@ -352,48 +368,107 @@ func TestADueStepCannotUndoAnEngineWithdrawal(t *testing.T) {
 // one layer up ("two reads of one model reporting two verdicts is a bug the
 // sim would be introducing"); a schedule multiplies the number of places it
 // can happen.
+//
+// **Every case builds its own Sim.** That is not tidiness — it is what makes
+// the test able to fail. Draining is a *write*, so if these cases shared one
+// Sim the first read would apply the step and every later case would see it
+// whether or not its own path drains. Deleting a drain would leave the test
+// green, and the guard would be guarding nothing. One Sim per case makes the
+// path under test the first read of the scheduled surface, so a nonvacuity
+// mutation per drain site is individually catchable.
 func TestScheduleVisibleThroughEveryReadPath(t *testing.T) {
-	t.Run("CI paths", func(t *testing.T) {
+	// seedCI builds a repo whose one required check passes now and fails an
+	// hour in, plus a classic status doing the same, with the clock already
+	// advanced past both.
+	seedCI := func(t *testing.T) (*Sim, string) {
+		t.Helper()
 		s, clk, sha := seedPRForScheduling(t)
 		s.SeedRequiredContexts("acme/widgets", "main", []string{"build"}).
 			SeedCheckRun("acme/widgets", sha, gh.CheckRun{ID: 900, Name: "build", Conclusion: "success"}).
 			SeedCheckRunsAfter("acme/widgets", sha, time.Hour,
-				gh.CheckRun{ID: 900, Name: "build", Status: "completed", Conclusion: "failure"})
+				gh.CheckRun{ID: 900, Name: "build", Status: "completed", Conclusion: "failure"}).
+			SeedCommitStatusesAfter("acme/widgets", sha, time.Hour,
+				gh.CommitStatus{Context: "legacy", State: "failure"})
 		if err := s.Err(); err != nil {
 			t.Fatalf("seeding: %v", err)
 		}
-
 		clk.Advance(time.Hour)
+		return s, sha
+	}
 
-		// FetchCheckRuns — the direct read.
-		runs, err := s.FetchCheckRuns("acme", "widgets", sha)
-		if err != nil {
-			t.Fatalf("FetchCheckRuns: %v", err)
-		}
-		if len(runs) != 1 || checkVerdict(runs[0]) != "failure" {
-			t.Errorf("FetchCheckRuns = %+v, want one failing run", runs)
-		}
-
+	ciPaths := map[string]func(t *testing.T, s *Sim, sha string){
+		// The direct read.
+		"FetchCheckRuns": func(t *testing.T, s *Sim, sha string) {
+			runs, err := s.FetchCheckRuns("acme", "widgets", sha)
+			if err != nil {
+				t.Fatalf("FetchCheckRuns: %v", err)
+			}
+			if len(runs) != 1 || checkVerdict(runs[0]) != "failure" {
+				t.Errorf("FetchCheckRuns = %+v, want one failing run", runs)
+			}
+		},
+		// The classic Statuses API, addressed by SHA — the first of
+		// FetchCombinedStatus's two read sections.
+		"FetchCombinedStatus by SHA": func(t *testing.T, s *Sim, sha string) {
+			sts, err := s.FetchCombinedStatus("acme", "widgets", sha)
+			if err != nil {
+				t.Fatalf("FetchCombinedStatus: %v", err)
+			}
+			if len(sts) != 1 || statusVerdict(sts[0]) != "failure" {
+				t.Errorf("FetchCombinedStatus(sha) = %+v, want one failing status", sts)
+			}
+		},
+		// The same endpoint addressed by branch, which falls through to the
+		// second section after resolving the ref.
+		"FetchCombinedStatus by branch": func(t *testing.T, s *Sim, _ string) {
+			sts, err := s.FetchCombinedStatus("acme", "widgets", "fabrik/issue-7")
+			if err != nil {
+				t.Fatalf("FetchCombinedStatus: %v", err)
+			}
+			if len(sts) != 1 || statusVerdict(sts[0]) != "failure" {
+				t.Errorf("FetchCombinedStatus(branch) = %+v, want one failing status", sts)
+			}
+		},
 		// deriveMergeableState via contextsForSHA — the derived read.
-		state, err := s.FetchPRMergeableState("acme", "widgets", 8)
-		if err != nil {
-			t.Fatalf("FetchPRMergeableState: %v", err)
-		}
-		if state != "blocked" {
-			t.Errorf("mergeable state = %q, want blocked — the derivation did not see the step", state)
-		}
+		"FetchPRMergeableState": func(t *testing.T, s *Sim, _ string) {
+			state, err := s.FetchPRMergeableState("acme", "widgets", 8)
+			if err != nil {
+				t.Fatalf("FetchPRMergeableState: %v", err)
+			}
+			if state != "blocked" {
+				t.Errorf("mergeable state = %q, want blocked — the derivation did not see the step", state)
+			}
+		},
+		"FetchPRMergeableFields": func(t *testing.T, s *Sim, _ string) {
+			_, state, err := s.FetchPRMergeableFields("acme", "widgets", 8)
+			if err != nil {
+				t.Fatalf("FetchPRMergeableFields: %v", err)
+			}
+			if state != "blocked" {
+				t.Errorf("mergeable state = %q, want blocked", state)
+			}
+		},
+		"FetchPRDetails": func(t *testing.T, s *Sim, _ string) {
+			details, err := s.FetchPRDetails("acme", "widgets", 8)
+			if err != nil {
+				t.Fatalf("FetchPRDetails: %v", err)
+			}
+			if details.MergeableState != "blocked" {
+				t.Errorf("FetchPRDetails MergeableState = %q, want blocked", details.MergeableState)
+			}
+		},
+	}
+	for name, check := range ciPaths {
+		t.Run("CI/"+name, func(t *testing.T) {
+			s, sha := seedCI(t)
+			check(t, s, sha)
+		})
+	}
 
-		// FetchPRDetails reaches the same derivation through a different entry.
-		details, err := s.FetchPRDetails("acme", "widgets", 8)
-		if err != nil {
-			t.Fatalf("FetchPRDetails: %v", err)
-		}
-		if details.MergeableState != "blocked" {
-			t.Errorf("FetchPRDetails MergeableState = %q, want blocked", details.MergeableState)
-		}
-	})
-
-	t.Run("review paths", func(t *testing.T) {
+	// seedReviews schedules both a review and a reviewer request an hour out,
+	// with the clock already advanced past them.
+	seedReviews := func(t *testing.T) (*Sim, time.Time) {
+		t.Helper()
 		s, clk, _ := seedPRForScheduling(t)
 		s.SeedRequiredApprovals("acme/widgets", "main", 1).
 			SeedReviewsAfter("acme/widgets", 8, time.Hour, gh.PRReview{Author: "human", State: "CHANGES_REQUESTED"}).
@@ -401,57 +476,80 @@ func TestScheduleVisibleThroughEveryReadPath(t *testing.T) {
 		if err := s.Err(); err != nil {
 			t.Fatalf("seeding: %v", err)
 		}
-
 		clk.Advance(time.Hour)
+		return s, clk.Now()
+	}
 
-		reviews, err := s.FetchPRReviews("acme", "widgets", 8)
-		if err != nil {
-			t.Fatalf("FetchPRReviews: %v", err)
-		}
-		if len(reviews) != 1 {
-			t.Errorf("FetchPRReviews returned %d reviews, want 1", len(reviews))
-		}
-
-		decision, err := s.FetchPRReviewDecision("acme", "widgets", 8)
-		if err != nil {
-			t.Fatalf("FetchPRReviewDecision: %v", err)
-		}
-		if decision != "CHANGES_REQUESTED" {
-			t.Errorf("FetchPRReviewDecision = %q, want CHANGES_REQUESTED", decision)
-		}
-
-		reqs, err := s.FetchPRReviewRequests("acme", "widgets", 8)
-		if err != nil {
-			t.Fatalf("FetchPRReviewRequests: %v", err)
-		}
-		if len(reqs) != 1 {
-			t.Errorf("FetchPRReviewRequests returned %d, want 1", len(reqs))
-		}
-
+	reviewPaths := map[string]func(t *testing.T, s *Sim, now time.Time){
+		"FetchPRReviews": func(t *testing.T, s *Sim, _ time.Time) {
+			reviews, err := s.FetchPRReviews("acme", "widgets", 8)
+			if err != nil {
+				t.Fatalf("FetchPRReviews: %v", err)
+			}
+			if len(reviews) != 1 {
+				t.Errorf("FetchPRReviews returned %d reviews, want 1", len(reviews))
+			}
+		},
+		"FetchPRReviewDecision": func(t *testing.T, s *Sim, _ time.Time) {
+			decision, err := s.FetchPRReviewDecision("acme", "widgets", 8)
+			if err != nil {
+				t.Fatalf("FetchPRReviewDecision: %v", err)
+			}
+			if decision != "CHANGES_REQUESTED" {
+				t.Errorf("FetchPRReviewDecision = %q, want CHANGES_REQUESTED", decision)
+			}
+		},
+		"FetchPRReviewRequests": func(t *testing.T, s *Sim, _ time.Time) {
+			reqs, err := s.FetchPRReviewRequests("acme", "widgets", 8)
+			if err != nil {
+				t.Fatalf("FetchPRReviewRequests: %v", err)
+			}
+			if len(reqs) != 1 {
+				t.Errorf("FetchPRReviewRequests returned %d, want 1", len(reqs))
+			}
+		},
 		// The board projection — the path the engine actually consumes most.
-		item := firstItemFull(t, s)
-		if len(item.LinkedPRReviews) != 1 {
-			t.Errorf("board projection LinkedPRReviews = %+v, want the scheduled review", item.LinkedPRReviews)
-		}
-		if len(item.LinkedPRReviewRequests) != 1 {
-			t.Errorf("board projection LinkedPRReviewRequests = %+v, want the scheduled request", item.LinkedPRReviewRequests)
-		}
-
+		"FetchProjectBoard": func(t *testing.T, s *Sim, _ time.Time) {
+			item := firstItemFull(t, s)
+			if len(item.LinkedPRReviews) != 1 {
+				t.Errorf("board projection LinkedPRReviews = %+v, want the scheduled review", item.LinkedPRReviews)
+			}
+			if len(item.LinkedPRReviewRequests) != 1 {
+				t.Errorf("board projection LinkedPRReviewRequests = %+v, want the scheduled request", item.LinkedPRReviewRequests)
+			}
+		},
+		"FetchProjectItem": func(t *testing.T, s *Sim, _ time.Time) {
+			item, err := s.FetchProjectItem("acme", "widgets", 7)
+			if err != nil {
+				t.Fatalf("FetchProjectItem: %v", err)
+			}
+			if len(item.LinkedPRReviews) != 1 {
+				t.Errorf("FetchProjectItem LinkedPRReviews = %+v, want the scheduled review", item.LinkedPRReviews)
+			}
+		},
 		// The probe path reads only updatedAt, but a due step bumps exactly
 		// that — and EffectiveUpdatedAt is how the engine decides an item is
 		// worth deep-fetching.
-		probes, _, err := s.ProbeProjectBoard("acme", "widgets", 2, "organization")
-		if err != nil {
-			t.Fatalf("ProbeProjectBoard: %v", err)
-		}
-		if len(probes) != 1 {
-			t.Fatalf("probe returned %d items, want 1", len(probes))
-		}
-		if probes[0].EffectiveUpdatedAt.Before(clk.Now()) {
-			t.Errorf("probe EffectiveUpdatedAt = %v, want it bumped to the step's instant %v",
-				probes[0].EffectiveUpdatedAt, clk.Now())
-		}
-	})
+		"ProbeProjectBoard": func(t *testing.T, s *Sim, now time.Time) {
+			probes, _, err := s.ProbeProjectBoard("acme", "widgets", 2, "organization")
+			if err != nil {
+				t.Fatalf("ProbeProjectBoard: %v", err)
+			}
+			if len(probes) != 1 {
+				t.Fatalf("probe returned %d items, want 1", len(probes))
+			}
+			if probes[0].EffectiveUpdatedAt.Before(now) {
+				t.Errorf("probe EffectiveUpdatedAt = %v, want it bumped to the step's instant %v",
+					probes[0].EffectiveUpdatedAt, now)
+			}
+		},
+	}
+	for name, check := range reviewPaths {
+		t.Run("reviews/"+name, func(t *testing.T) {
+			s, now := seedReviews(t)
+			check(t, s, now)
+		})
+	}
 }
 
 // Steps scheduled for the same instant apply in seeding order — the only

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -19,11 +19,21 @@ import (
 //		SeedIssue("acme/widgets", simgh.IssueSeed{Number: 7, Title: "…", Status: "Implement"})
 //	if err := s.Err(); err != nil { t.Fatal(err) }
 //
-// Seeding constructs *static initial state only*. There is deliberately no way
-// here to script a sequence of future responses, inject a fault, or replay a
-// mutation log — those are a separate layer (#1457) that will build on these
-// same objects. Keeping seeding static is what lets that layer be added
-// without breaking this API.
+// Most Seed* methods construct *static initial state*: the board as it stands
+// when the scenario begins. Alongside them are the Seed*At / Seed*After
+// methods, which enqueue a mutation for a future instant on the injected clock
+// — "this SHA goes red at T", "the reviewer responds forty minutes in". They
+// are the same seeding idiom (sticky error, chainable) and write into the same
+// objects; what differs is *when* the write lands. See schedule.go for why
+// sequencing is clock-driven rather than read-count-driven, and FIDELITY.md
+// for what a scheduled surface lets a scenario construct that real GitHub
+// never would.
+//
+// Fault injection and the mutation log are deliberately *not* here. They are
+// cross-cutting concerns over every interface method, and live in the
+// instrumentation layer (instrumented.go, fault.go, mutationlog.go) which
+// decorates a Sim rather than modifying it. Wrap a seeded Sim with Instrument
+// to get them.
 
 // IssueSeed describes an issue to create.
 type IssueSeed struct {
@@ -800,6 +810,261 @@ func (s *Sim) SeedMergeQueueEnabled(ownerRepo string, enabled bool) *Sim {
 	defer s.mu.Unlock()
 	r.mergeQueueEnabled = enabled
 	return s
+}
+
+// SeedRateLimits overrides the static budgets RateLimitStats reports, after
+// construction and chainably (WithClock's sibling WithRateLimits does the same
+// at construction).
+//
+// This is the controllability the rate-limit surface actually needs.
+// RateLimitStats is the one interface method with no error return, so fault
+// injection cannot fail it — registering a fault against it panics rather than
+// sitting silently inert (see fault.go). What the engine consumes from it is
+// budget *ratios* (engine/backoff.go), so scripting the numbers is what makes
+// its thresholds reachable. Recorded in FIDELITY.md.
+func (s *Sim) SeedRateLimits(restLimit, restRemaining, graphqlLimit, graphqlRemaining int) *Sim {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if restRemaining > restLimit || graphqlRemaining > graphqlLimit {
+		s.fail("simgh: SeedRateLimits: remaining (%d rest, %d graphql) cannot exceed the limit (%d rest, %d graphql)",
+			restRemaining, graphqlRemaining, restLimit, graphqlLimit)
+		return s
+	}
+	s.restRate = rateBudget{limit: restLimit, remaining: restRemaining, used: restLimit - restRemaining, resetIn: time.Hour}
+	s.graphqlRate = rateBudget{limit: graphqlLimit, remaining: graphqlRemaining, used: graphqlLimit - graphqlRemaining, resetIn: time.Hour}
+	return s
+}
+
+// --- scheduled seeding -----------------------------------------------------
+//
+// The Seed*At / Seed*After methods enqueue a mutation for a future instant on
+// the injected clock instead of applying it now. The step lands on the first
+// read of that surface at or after its time, and the write is permanent — see
+// schedule.go for why that shape rather than a read filter, and why the clock
+// rather than a read count.
+//
+// Every one of them refuses an empty step: a scheduled mutation that changes
+// nothing could never be observed, so a scenario built on one would pass
+// without its sequence ever having existed.
+
+// SeedCheckRunsAt schedules check runs to land on a SHA at instant at.
+//
+// A run whose ID matches one already recorded for that SHA **supersedes it in
+// place**, which is how a scenario models one check *transitioning* (queued →
+// in_progress → failure): pass the same explicit ID each time. A run with a
+// new or auto-assigned ID is appended, which models a *rerun* — the shape
+// production's latestCheckRunsByName reduces by keeping the highest ID.
+//
+// Unlike SeedCheckRun, reusing an existing ID here is allowed rather than a
+// seeding error, precisely because the transition case needs it.
+func (s *Sim) SeedCheckRunsAt(ownerRepo, sha string, at time.Time, runs ...gh.CheckRun) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(runs) == 0 {
+		s.fail("simgh: SeedCheckRunsAt(%s, %s): no check runs given; an empty step is unobservable", ownerRepo, sha)
+		return s
+	}
+	prepared := make([]gh.CheckRun, 0, len(runs))
+	for _, run := range runs {
+		prepared = append(prepared, s.reserveCheckRunID(run))
+	}
+	r.ciSchedule.add(at, func(rs *repoState) {
+		for _, run := range prepared {
+			rs.checkRuns[sha] = upsertCheckRun(rs.checkRuns[sha], run)
+		}
+	})
+	return s
+}
+
+// SeedCheckRunsAfter is SeedCheckRunsAt relative to the clock's current
+// reading.
+func (s *Sim) SeedCheckRunsAfter(ownerRepo, sha string, d time.Duration, runs ...gh.CheckRun) *Sim {
+	return s.SeedCheckRunsAt(ownerRepo, sha, s.now().Add(d), runs...)
+}
+
+// SeedCommitStatusesAt schedules classic commit statuses to land on a SHA at
+// instant at.
+//
+// Statuses are appended rather than superseded by context, because that is
+// already how the classic Statuses API behaves and how contextsForSHA reduces
+// them: the last one posted for a context wins. Posting a second status for
+// the same context is therefore the transition, with no ID bookkeeping needed.
+func (s *Sim) SeedCommitStatusesAt(ownerRepo, sha string, at time.Time, statuses ...gh.CommitStatus) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(statuses) == 0 {
+		s.fail("simgh: SeedCommitStatusesAt(%s, %s): no statuses given; an empty step is unobservable", ownerRepo, sha)
+		return s
+	}
+	pending := make([]gh.CommitStatus, len(statuses))
+	copy(pending, statuses)
+	r.ciSchedule.add(at, func(rs *repoState) {
+		rs.commitStatuses[sha] = append(rs.commitStatuses[sha], pending...)
+	})
+	return s
+}
+
+// SeedCommitStatusesAfter is SeedCommitStatusesAt relative to the clock's
+// current reading.
+func (s *Sim) SeedCommitStatusesAfter(ownerRepo, sha string, d time.Duration, statuses ...gh.CommitStatus) *Sim {
+	return s.SeedCommitStatusesAt(ownerRepo, sha, s.now().Add(d), statuses...)
+}
+
+// SeedReviewsAt schedules submitted reviews to land on a PR at instant at —
+// "the reviewer responds forty minutes in".
+//
+// Reviews append, matching SeedReview and real GitHub: a submission never
+// erases an earlier one, and latestReviewsByAuthor does the collapsing on
+// read. A review whose SubmittedAt is zero is stamped with the step's instant
+// rather than with the clock's reading when the step happens to be drained, so
+// the value does not depend on which read triggered it.
+func (s *Sim) SeedReviewsAt(ownerRepo string, prNumber int, at time.Time, reviews ...gh.PRReview) *Sim {
+	pr, ok := s.prForSeed(ownerRepo, prNumber)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(reviews) == 0 {
+		s.fail("simgh: SeedReviewsAt(%s#%d): no reviews given; an empty step is unobservable", ownerRepo, prNumber)
+		return s
+	}
+	pending := make([]gh.PRReview, 0, len(reviews))
+	for _, rev := range reviews {
+		if rev.SubmittedAt.IsZero() {
+			rev.SubmittedAt = at
+		}
+		pending = append(pending, rev)
+	}
+	pr.reviewSchedule.add(at, func(p *prRecord) {
+		p.reviews = append(p.reviews, pending...)
+		p.updatedAt = laterOf(p.updatedAt, at)
+	})
+	return s
+}
+
+// SeedReviewsAfter is SeedReviewsAt relative to the clock's current reading.
+func (s *Sim) SeedReviewsAfter(ownerRepo string, prNumber int, d time.Duration, reviews ...gh.PRReview) *Sim {
+	return s.SeedReviewsAt(ownerRepo, prNumber, s.now().Add(d), reviews...)
+}
+
+// SeedReviewRequestsAt schedules reviewer requests to appear on a PR at
+// instant at.
+//
+// Requests are added, not replaced, and an already-outstanding login is
+// skipped — the same rule AddReviewRequest applies, so a step and an engine
+// re-request cannot produce a duplicate entry between them. The step is not
+// authoritative over the list: a reviewer the engine has since withdrawn
+// (DeleteReviewRequest, the bot re-prompt ladder's own mutation) is genuinely
+// gone, and this will re-add them only if its own time had not yet come.
+func (s *Sim) SeedReviewRequestsAt(ownerRepo string, prNumber int, at time.Time, requests ...gh.ReviewRequest) *Sim {
+	pr, ok := s.prForSeed(ownerRepo, prNumber)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(requests) == 0 {
+		s.fail("simgh: SeedReviewRequestsAt(%s#%d): no requests given; an empty step is unobservable", ownerRepo, prNumber)
+		return s
+	}
+	pending := make([]gh.ReviewRequest, 0, len(requests))
+	for _, req := range requests {
+		if !req.IsBot {
+			req.IsBot = gh.IsBotLogin(req.Login)
+		}
+		pending = append(pending, req)
+	}
+	pr.reviewSchedule.add(at, func(p *prRecord) {
+		changed := false
+		for _, req := range pending {
+			already := false
+			for _, existing := range p.reviewRequests {
+				if existing.Login == req.Login {
+					already = true
+					break
+				}
+			}
+			if already {
+				continue
+			}
+			p.reviewRequests = append(p.reviewRequests, req)
+			changed = true
+		}
+		if changed {
+			p.updatedAt = laterOf(p.updatedAt, at)
+		}
+	})
+	return s
+}
+
+// SeedReviewRequestsAfter is SeedReviewRequestsAt relative to the clock's
+// current reading.
+func (s *Sim) SeedReviewRequestsAfter(ownerRepo string, prNumber int, d time.Duration, requests ...gh.ReviewRequest) *Sim {
+	return s.SeedReviewRequestsAt(ownerRepo, prNumber, s.now().Add(d), requests...)
+}
+
+// reserveCheckRunID assigns an ID when unset and keeps the auto-assign counter
+// ahead of every explicit one, so a later ID: 0 seed cannot collide with an ID
+// chosen by hand.
+//
+// Unlike SeedCheckRun's inline version it tolerates an ID that already exists,
+// because reusing one is exactly how a scheduled step models a run
+// transitioning rather than a rerun. Caller must hold mu.
+func (s *Sim) reserveCheckRunID(run gh.CheckRun) gh.CheckRun {
+	if run.ID == 0 {
+		run.ID = s.nextCheckRunID
+		s.nextCheckRunID++
+	} else if run.ID >= s.nextCheckRunID {
+		s.nextCheckRunID = run.ID + 1
+	}
+	s.seededCheckRunIDs[run.ID] = true
+	if run.Status == "" {
+		if run.Conclusion == "" {
+			run.Status = "in_progress"
+		} else {
+			run.Status = "completed"
+		}
+	}
+	return run
+}
+
+// upsertCheckRun replaces the entry sharing run's ID, or appends when there is
+// none. Replacing in place preserves position, so a transition does not
+// reorder the collection under a caller reading it raw.
+func upsertCheckRun(list []gh.CheckRun, run gh.CheckRun) []gh.CheckRun {
+	for i := range list {
+		if list[i].ID == run.ID {
+			list[i] = run
+			return list
+		}
+	}
+	return append(list, run)
+}
+
+// prForSeed looks up a PR for a chained Seed* call, recording a sticky error
+// and reporting false when the repo or the PR is missing.
+func (s *Sim) prForSeed(ownerRepo string, prNumber int) (*prRecord, bool) {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return nil, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	pr, ok := r.prs[prNumber]
+	if !ok {
+		s.fail("simgh: PR %s#%d not found", ownerRepo, prNumber)
+		return nil, false
+	}
+	return pr, true
 }
 
 // repoForSeed looks up a repo for a chained Seed* call, recording a sticky

--- a/tests/sim/simgh/sim.go
+++ b/tests/sim/simgh/sim.go
@@ -41,6 +41,48 @@
 // write the result back. A violation of this ordering surfaces only as an
 // intermittent deadlock or -race failure, so it is enforced by review.
 //
+// The instrumentation layer adds two more mutexes — MutationLog's and
+// FaultTable's — and they add no edge to that ordering, because both are
+// acquired and released *before* control enters Sim and neither is ever held
+// across a Sim call. They are leaves. Sim's own code never touches them.
+//
+// # The instrumentation layer
+//
+// A faithful model is a GitHub stand-in; three further capabilities make it a
+// test instrument. Two are cross-cutting and live in a decorator, one is part
+// of the model itself.
+//
+//   - Clock-driven schedules (schedule.go, and the Seed*At / Seed*After methods
+//     in seed.go) enqueue a mutation for a future instant on the injected
+//     clock. A step is a *pending mutation applied on read*, not a read filter:
+//     when its time arrives it writes into the model permanently, so repeated
+//     reads at one instant are stable and later engine mutations to the same
+//     surface stay observable. Sequencing is clock-driven rather than
+//     read-count-driven because one poll is not one read — see schedule.go's
+//     file comment for the full reasoning.
+//
+//   - Fault injection (fault.go) makes any engine.GitHubClient method fail on
+//     demand. The error shape is the caller's choice and it matters: the engine
+//     classifies rate-limit shapes specially, so use the ghfault constructors.
+//     RateLimitStats is the one method it cannot fail — no error return — and
+//     registering a fault against it panics rather than sitting inert.
+//
+//   - The mutation log (mutationlog.go) records every intercepted call with its
+//     outcome, in order. Attempts, not just mutations: "N failures then the
+//     success" is unexpressible otherwise. Ordering is exact within a goroutine
+//     and reserve-order across goroutines; both halves of that contract are in
+//     FIDELITY.md, because a cross-goroutine ordering assertion that looks
+//     exact and is not is a flaky test waiting to happen.
+//
+// Wrap a seeded Sim with Instrument to get the latter two. The wrapper holds
+// its *Sim as a NAMED field, never an embedded one — see instrumented.go for
+// why that one word is load-bearing.
+//
+// Snapshot/Restore (snapshot.go) round-trip the model, the backing git
+// repositories, the fault schedule and the log, so a restart scenario can
+// discard the engine and rebuild against exactly the state GitHub would have
+// retained.
+//
 // # Adding a method
 //
 // Sim pins itself to engine.GitHubClient with a compile-time assertion, so any
@@ -52,6 +94,12 @@
 // FIDELITY.md. Do not add a stub that returns an error — an unimplemented
 // method that compiles is exactly the silent-green failure mode this layer
 // must not introduce.
+//
+// Instrumented pins itself the same way, and because it holds its *Sim as a
+// named field the new method must be wrapped there too or the build breaks.
+// Add the wrapper alongside its neighbours in instrumented.go; the
+// reflection-driven tests in mutationlog_test.go and fault_test.go will then
+// confirm it is actually instrumented and actually faultable.
 package simgh
 
 import (

--- a/tests/sim/simgh/sim.go
+++ b/tests/sim/simgh/sim.go
@@ -122,6 +122,21 @@ var _ engine.GitHubClient = (*Sim)(nil)
 // time-anchored gates (the review-gate timeout, the CI settle scan, the
 // Done-archive scan, all of which key off FetchLabelAppliedAt) without
 // wall-clock waiting.
+//
+// # An implementation must be safe for concurrent use
+//
+// Now is called from every engine worker goroutine, on every model read that
+// touches a timestamp, on every drain of a schedule (schedule.go), and on
+// every call intercepted by the instrumentation layer. Meanwhile the whole
+// point of a controllable clock is that the scenario *advances* it — and a
+// harness driving Engine.Run() advances it with workers in flight, because
+// there is no moment at which nothing is running.
+//
+// So an advanceable Clock must guard its own state. A plain time.Time field
+// written by Advance and read by Now is a data race that -race will report
+// from an arbitrary worker, far from the Advance that caused it. realClock is
+// trivially safe; the test clock in helpers_test.go carries a mutex for this
+// reason.
 type Clock interface {
 	Now() time.Time
 }

--- a/tests/sim/simgh/snapshot.go
+++ b/tests/sim/simgh/snapshot.go
@@ -155,10 +155,14 @@ func snapshotRepoGit(r *repoState, stagingDir string) error {
 	r.gitMu.Lock()
 	defer r.gitMu.Unlock()
 
-	// Defensive, and deliberately not fatal: a repo with no worktrees to prune
-	// still succeeds, and a prune failure should not lose an otherwise good
-	// snapshot. What it buys is that stale entries — which hold absolute paths
-	// into a baseDir the restore will not have — do not travel forward.
+	// Defensive, and deliberately fatal. What the prune buys is that stale
+	// worktree admin entries — which hold absolute paths into a baseDir the
+	// restore will not have — do not travel forward into the copy. A repo with
+	// no worktrees to prune succeeds trivially, so the only way this fails is
+	// that git itself could not run, and a snapshot copied without the prune
+	// having happened is precisely the one whose restore breaks later, on a
+	// git operation, in a way that reads as a model bug. Failing here names
+	// the cause; deferring it hides it.
 	if _, err := runGit(r.bareDir, "worktree", "prune"); err != nil {
 		return fmt.Errorf("simgh: Snapshot: pruning worktrees for %s/%s: %w", r.owner, r.repo, err)
 	}

--- a/tests/sim/simgh/snapshot.go
+++ b/tests/sim/simgh/snapshot.go
@@ -1,0 +1,632 @@
+package simgh
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// This file is snapshot and restore: round-tripping the whole model so a
+// restart scenario can discard the engine and rebuild it against exactly the
+// state GitHub would have retained.
+//
+// # What "restore" means
+//
+// The durable-state contract Fabrik rests on is that GitHub-side state
+// survives a restart and in-memory state does not — the rocket reaction is
+// durable "already processed", labels are state, processedSet is not. Restore
+// is what makes that testable: the engine dies and comes back, and the world
+// did *not* reset.
+//
+// That is why the fault schedule and the mutation log round-trip too, not just
+// the model. A recovery scenario running against a persistently-failing GitHub
+// needs the failure to persist across the restart, and the log is the test's
+// audit record — an ordering assertion may legitimately span the restart.
+//
+// # What does not round-trip, and why
+//
+// The Clock. It is never model-owned, and serialising it would break that; it
+// is re-supplied to Restore as an Option, exactly as to New. Everything else
+// is enumerated in snapshotFieldRegistry below, whose completeness is asserted
+// by reflection in snapshot_test.go — a field added to model.go and not
+// handled here fails that test rather than silently vanishing across a
+// restart, where it would masquerade as an engine defect.
+//
+// # Git state
+//
+// Each backing bare repository is copied as a directory tree, under the repo's
+// gitMu and after a defensive `git worktree prune`. The prune matters: git's
+// worktree admin entries live inside bareDir and carry *absolute* paths into
+// the throwaway checkouts under the old baseDir, and t.TempDir() guarantees a
+// restored Sim's baseDir differs every time. A stale entry copied forward
+// would point at a directory that no longer exists.
+//
+// # Quiescence
+//
+// Snapshot copies git state and model state in two phases and does not hold
+// one lock across both — it cannot, without violating the package's
+// mu-before-gitMu invariant. Call it when no engine goroutine is running, the
+// way a restart scenario naturally would. A snapshot taken mid-flight is not
+// torn in any dangerous sense (each half is internally consistent), but the
+// two halves may disagree about a mutation that landed between them.
+
+// Snapshot is a restorable copy of a Sim's entire state. Treat it as opaque;
+// it is reusable, so one snapshot can seed several restores.
+type Snapshot struct {
+	// gitDir is the staging directory holding a copy of every backing bare
+	// repository, laid out owner/repo.git exactly as under a live baseDir.
+	gitDir string
+
+	repos             map[string]*repoState
+	projects          map[string]*projectState
+	defaultProjectKey string
+
+	nextCommentDatabaseID int
+	nextCheckRunID        int64
+	seededCheckRunIDs     map[int64]bool
+
+	restRate    rateBudget
+	graphqlRate rateBudget
+
+	seedErr error
+
+	// instrumented is set only by Instrumented.Snapshot. RestoreInstrumented
+	// refuses a snapshot taken from a bare Sim rather than silently handing
+	// back an empty fault table — a scenario that expected its persistent
+	// failure to survive the restart would otherwise see GitHub quietly heal.
+	instrumented bool
+	faultRules   map[string][]*faultRule
+	faultCalls   map[string]int
+	logEntries   []Entry
+}
+
+// GitDir reports the staging directory holding the snapshot's copied
+// repositories, for a test that wants to inspect or assert against them.
+func (s *Snapshot) GitDir() string { return s.gitDir }
+
+// Snapshot copies the model and every backing repository into stagingDir,
+// which must already exist and be empty of anything the snapshot would
+// collide with — tests pass t.TempDir(). Ownership of stagingDir stays with
+// the caller, so cleanup is never ambiguous.
+func (s *Sim) Snapshot(stagingDir string) (*Snapshot, error) {
+	if stagingDir == "" {
+		return nil, fmt.Errorf("simgh: Snapshot: stagingDir must be non-empty")
+	}
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		return nil, fmt.Errorf("simgh: Snapshot: creating staging dir: %w", err)
+	}
+
+	// Phase 1: the repositories, each under its own gitMu. mu is taken only to
+	// read the repo list, and released before any git runs — the package's
+	// invariant forbids holding it across a subprocess call.
+	s.mu.Lock()
+	repos := make([]*repoState, 0, len(s.repos))
+	for _, r := range s.repos {
+		repos = append(repos, r)
+	}
+	s.mu.Unlock()
+
+	for _, r := range repos {
+		if err := snapshotRepoGit(r, stagingDir); err != nil {
+			return nil, err
+		}
+	}
+
+	// Phase 2: the in-memory model.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	snap := &Snapshot{
+		gitDir:                stagingDir,
+		repos:                 make(map[string]*repoState, len(s.repos)),
+		projects:              make(map[string]*projectState, len(s.projects)),
+		nextCommentDatabaseID: s.nextCommentDatabaseID,
+		nextCheckRunID:        s.nextCheckRunID,
+		seededCheckRunIDs:     make(map[int64]bool, len(s.seededCheckRunIDs)),
+		restRate:              s.restRate,
+		graphqlRate:           s.graphqlRate,
+		seedErr:               s.seedErr,
+	}
+	for k, r := range s.repos {
+		snap.repos[k] = cloneRepoState(r)
+	}
+	for k, p := range s.projects {
+		snap.projects[k] = cloneProjectState(p)
+	}
+	for id := range s.seededCheckRunIDs {
+		snap.seededCheckRunIDs[id] = true
+	}
+	if s.defaultProject != nil {
+		snap.defaultProjectKey = projectKey(s.defaultProject.owner, s.defaultProject.num)
+	}
+	return snap, nil
+}
+
+// snapshotRepoGit prunes stale worktree admin entries and copies one bare
+// repository into the staging directory.
+func snapshotRepoGit(r *repoState, stagingDir string) error {
+	r.gitMu.Lock()
+	defer r.gitMu.Unlock()
+
+	// Defensive, and deliberately not fatal: a repo with no worktrees to prune
+	// still succeeds, and a prune failure should not lose an otherwise good
+	// snapshot. What it buys is that stale entries — which hold absolute paths
+	// into a baseDir the restore will not have — do not travel forward.
+	if _, err := runGit(r.bareDir, "worktree", "prune"); err != nil {
+		return fmt.Errorf("simgh: Snapshot: pruning worktrees for %s/%s: %w", r.owner, r.repo, err)
+	}
+
+	dst := filepath.Join(stagingDir, r.owner, r.repo+".git")
+	if err := copyDir(r.bareDir, dst); err != nil {
+		return fmt.Errorf("simgh: Snapshot: copying %s/%s: %w", r.owner, r.repo, err)
+	}
+	return nil
+}
+
+// Restore rebuilds a Sim from a snapshot, with its backing repositories copied
+// into a fresh baseDir. Options are applied exactly as by New — in particular
+// WithClock, since the clock is never model-owned and is not carried by the
+// snapshot.
+//
+// The snapshot is left intact and may be restored again.
+func Restore(snap *Snapshot, baseDir string, opts ...Option) (*Sim, error) {
+	if snap == nil {
+		return nil, fmt.Errorf("simgh: Restore: nil snapshot")
+	}
+	s := New(baseDir, opts...)
+	if err := s.ensureBaseDir(); err != nil {
+		return nil, err
+	}
+
+	s.nextCommentDatabaseID = snap.nextCommentDatabaseID
+	s.nextCheckRunID = snap.nextCheckRunID
+	s.restRate = snap.restRate
+	s.graphqlRate = snap.graphqlRate
+	s.seedErr = snap.seedErr
+	for id := range snap.seededCheckRunIDs {
+		s.seededCheckRunIDs[id] = true
+	}
+
+	for k, r := range snap.repos {
+		restored := cloneRepoState(r)
+		// The on-disk paths are the one thing that must not survive verbatim:
+		// they are absolute, and the restore target is a different directory.
+		restored.bareDir = s.repoDir(restored.owner, restored.repo)
+		restored.worktreeRoot = restored.bareDir + ".worktrees"
+		s.repos[k] = restored
+
+		src := filepath.Join(snap.gitDir, restored.owner, restored.repo+".git")
+		if err := copyDir(src, restored.bareDir); err != nil {
+			return nil, fmt.Errorf("simgh: Restore: copying %s: %w", k, err)
+		}
+	}
+	for k, p := range snap.projects {
+		s.projects[k] = cloneProjectState(p)
+	}
+	if snap.defaultProjectKey != "" {
+		s.defaultProject = s.projects[snap.defaultProjectKey]
+	}
+	return s, nil
+}
+
+// Snapshot copies the wrapped model plus the fault schedule and the mutation
+// log. See the file doc for why the two instruments travel with the model.
+func (in *Instrumented) Snapshot(stagingDir string) (*Snapshot, error) {
+	snap, err := in.sim.Snapshot(stagingDir)
+	if err != nil {
+		return nil, err
+	}
+	snap.instrumented = true
+	snap.faultRules, snap.faultCalls = in.faults.snapshotRules()
+	snap.logEntries = in.log.Entries()
+	return snap, nil
+}
+
+// RestoreInstrumented rebuilds an Instrumented client from a snapshot taken by
+// Instrumented.Snapshot.
+//
+// It refuses a snapshot taken from a bare Sim rather than handing back an
+// empty fault table: a scenario restarting against a persistently-failing
+// GitHub would otherwise see it quietly heal, and would pass by testing the
+// recovery it was meant to prove impossible.
+func RestoreInstrumented(snap *Snapshot, baseDir string, opts ...Option) (*Instrumented, error) {
+	if snap == nil {
+		return nil, fmt.Errorf("simgh: RestoreInstrumented: nil snapshot")
+	}
+	if !snap.instrumented {
+		return nil, fmt.Errorf("simgh: RestoreInstrumented: snapshot was taken by Sim.Snapshot, " +
+			"so it carries no fault schedule or mutation log; take it with Instrumented.Snapshot")
+	}
+	sim, err := Restore(snap, baseDir, opts...)
+	if err != nil {
+		return nil, err
+	}
+	in := Instrument(sim)
+	in.faults.restoreRules(snap.faultRules, snap.faultCalls)
+	in.log.restoreEntries(snap.logEntries)
+	return in, nil
+}
+
+// --- deep copies -----------------------------------------------------------
+
+func cloneRepoState(r *repoState) *repoState {
+	out := &repoState{
+		owner:             r.owner,
+		repo:              r.repo,
+		bareDir:           r.bareDir,
+		worktreeRoot:      r.worktreeRoot,
+		defaultBranch:     r.defaultBranch,
+		issues:            make(map[int]*issueRecord, len(r.issues)),
+		prs:               make(map[int]*prRecord, len(r.prs)),
+		checkRuns:         make(map[string][]gh.CheckRun, len(r.checkRuns)),
+		commitStatuses:    make(map[string][]gh.CommitStatus, len(r.commitStatuses)),
+		ciSchedule:        r.ciSchedule.clone(),
+		requiredContexts:  make(map[string][]string, len(r.requiredContexts)),
+		requireUpToDate:   make(map[string]bool, len(r.requireUpToDate)),
+		requiredApprovals: make(map[string]int, len(r.requiredApprovals)),
+		labelVocab:        make(map[string]bool, len(r.labelVocab)),
+		access:            r.access,
+		mergeQueueEnabled: r.mergeQueueEnabled,
+		nextNumber:        r.nextNumber,
+	}
+	for k, v := range r.issues {
+		out.issues[k] = cloneIssueRecord(v)
+	}
+	for k, v := range r.prs {
+		out.prs[k] = clonePRRecord(v)
+	}
+	for k, v := range r.checkRuns {
+		out.checkRuns[k] = append([]gh.CheckRun(nil), v...)
+	}
+	for k, v := range r.commitStatuses {
+		out.commitStatuses[k] = append([]gh.CommitStatus(nil), v...)
+	}
+	for k, v := range r.requiredContexts {
+		out.requiredContexts[k] = cloneStrings(v)
+	}
+	for k, v := range r.requireUpToDate {
+		out.requireUpToDate[k] = v
+	}
+	for k, v := range r.requiredApprovals {
+		out.requiredApprovals[k] = v
+	}
+	for k, v := range r.labelVocab {
+		out.labelVocab[k] = v
+	}
+	if r.latestRelease != nil {
+		rel := *r.latestRelease
+		rel.Assets = append([]gh.ReleaseAsset(nil), r.latestRelease.Assets...)
+		out.latestRelease = &rel
+	}
+	return out
+}
+
+func cloneIssueRecord(i *issueRecord) *issueRecord {
+	out := &issueRecord{
+		number:         i.number,
+		title:          i.title,
+		body:           i.body,
+		state:          i.state,
+		author:         i.author,
+		labels:         cloneStrings(i.labels),
+		assignees:      cloneStrings(i.assignees),
+		labelAppliedAt: make(map[string]time.Time, len(i.labelAppliedAt)),
+		blockedBy:      append([]gh.Dependency(nil), i.blockedBy...),
+		createdAt:      i.createdAt,
+		updatedAt:      i.updatedAt,
+	}
+	for k, v := range i.labelAppliedAt {
+		out.labelAppliedAt[k] = v
+	}
+	out.comments = cloneComments(i.comments)
+	return out
+}
+
+func clonePRRecord(p *prRecord) *prRecord {
+	out := &prRecord{
+		number:                  p.number,
+		title:                   p.title,
+		body:                    p.body,
+		head:                    p.head,
+		base:                    p.base,
+		state:                   p.state,
+		draft:                   p.draft,
+		merged:                  p.merged,
+		author:                  p.author,
+		labels:                  cloneStrings(p.labels),
+		issueNumber:             p.issueNumber,
+		comments:                cloneComments(p.comments),
+		reviewThreadComment:     cloneComments(p.reviewThreadComment),
+		reviews:                 append([]gh.PRReview(nil), p.reviews...),
+		reviewRequests:          append([]gh.ReviewRequest(nil), p.reviewRequests...),
+		reviewSchedule:          p.reviewSchedule.clone(),
+		resolvedThreads:         p.resolvedThreads,
+		autoMergeEnabled:        p.autoMergeEnabled,
+		autoMergeStrategy:       p.autoMergeStrategy,
+		inMergeQueue:            p.inMergeQueue,
+		mergeableRecomputeReads: p.mergeableRecomputeReads,
+		createdAt:               p.createdAt,
+		updatedAt:               p.updatedAt,
+	}
+	if p.queueEntry != nil {
+		entry := *p.queueEntry
+		out.queueEntry = &entry
+	}
+	return out
+}
+
+func cloneComments(in []*commentRecord) []*commentRecord {
+	if in == nil {
+		return nil
+	}
+	out := make([]*commentRecord, 0, len(in))
+	for _, c := range in {
+		dup := *c
+		dup.reactions = make(map[string]int, len(c.reactions))
+		for k, v := range c.reactions {
+			dup.reactions[k] = v
+		}
+		out = append(out, &dup)
+	}
+	return out
+}
+
+func cloneProjectState(p *projectState) *projectState {
+	out := &projectState{
+		id:                 p.id,
+		owner:              p.owner,
+		num:                p.num,
+		title:              p.title,
+		statusFieldID:      p.statusFieldID,
+		statusOptions:      make(map[string]string, len(p.statusOptions)),
+		orderedStatusNames: cloneStrings(p.orderedStatusNames),
+		items:              make(map[string]*itemState, len(p.items)),
+		itemOrder:          cloneStrings(p.itemOrder),
+		updatedAt:          p.updatedAt,
+	}
+	for k, v := range p.statusOptions {
+		out.statusOptions[k] = v
+	}
+	for k, v := range p.items {
+		dup := *v
+		out.items[k] = &dup
+	}
+	return out
+}
+
+// restoreEntries replaces the log's contents, renumbering nothing: sequence
+// numbers survive the restart, so an ordering assertion may span it.
+func (l *MutationLog) restoreEntries(entries []Entry) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = make([]Entry, len(entries))
+	copy(l.entries, entries)
+}
+
+// --- directory copy --------------------------------------------------------
+
+// copyDir recursively copies src to dst, creating dst.
+//
+// Hand-rolled rather than os.CopyFS so it fails loudly on anything that is not
+// a regular file or a directory. A bare repository contains neither symlinks
+// nor devices, so encountering one means either an assumption has broken or
+// something is in the tree that should not be — and silently skipping it would
+// corrupt the restore in a way that only surfaces as an inexplicable git
+// failure much later.
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		switch {
+		case d.IsDir():
+			// The owner write bit is forced on: a directory copied without it
+			// could not receive its own children.
+			return os.MkdirAll(target, info.Mode().Perm()|0o700)
+		case info.Mode().IsRegular():
+			return copyFile(path, target, info.Mode().Perm())
+		default:
+			return fmt.Errorf("simgh: copying %s: mode %v is neither a regular file nor a directory; "+
+				"a bare repository should contain only those", path, info.Mode())
+		}
+	})
+}
+
+// copyFile copies one regular file, preserving its permission bits.
+func copyFile(src, dst string, perm fs.FileMode) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	// Replace rather than truncate-in-place. Git writes its loose objects and
+	// packs read-only (0444), so opening an existing one for writing fails
+	// outright — which makes a second snapshot into the same staging
+	// directory, or a restore into a directory that already holds a copy, fail
+	// on the first object it meets. Removing first is what makes both
+	// idempotent.
+	if err := os.Remove(dst); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("simgh: replacing %s: %w", dst, err)
+	}
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// A close error on a write handle can be the only report of a failed
+		// flush, so it must not be discarded.
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("simgh: closing %s: %w", dst, cerr)
+		}
+	}()
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("simgh: copying %s to %s: %w", src, dst, err)
+	}
+	return nil
+}
+
+// --- field registry --------------------------------------------------------
+//
+// Every field of every model type, with what Snapshot/Restore does about it.
+// snapshot_test.go reflects over the types and asserts the registry names
+// exactly the fields that exist — so adding a field to model.go without
+// deciding its disposition here fails the test rather than silently vanishing
+// across a restart, where it would look like an engine defect.
+
+type fieldDisposition string
+
+const (
+	// fieldCopied travels with the snapshot.
+	fieldCopied fieldDisposition = "copied"
+	// fieldRebuilt is recomputed from the restore target rather than carried —
+	// the absolute on-disk paths, which must not survive verbatim.
+	fieldRebuilt fieldDisposition = "rebuilt at restore"
+	// fieldSkipped is deliberately not carried: mutexes, and the Clock, which
+	// is re-supplied as an Option.
+	fieldSkipped fieldDisposition = "deliberately not carried"
+)
+
+var snapshotFieldRegistry = map[string]map[string]fieldDisposition{
+	"Sim": {
+		"baseDir":               fieldRebuilt,
+		"clock":                 fieldSkipped,
+		"seedRepoMu":            fieldSkipped,
+		"mu":                    fieldSkipped,
+		"repos":                 fieldCopied,
+		"projects":              fieldCopied,
+		"defaultProject":        fieldCopied,
+		"nextCommentDatabaseID": fieldCopied,
+		"nextCheckRunID":        fieldCopied,
+		"seededCheckRunIDs":     fieldCopied,
+		"restRate":              fieldCopied,
+		"graphqlRate":           fieldCopied,
+		"seedErr":               fieldCopied,
+	},
+	"repoState": {
+		"owner":             fieldCopied,
+		"repo":              fieldCopied,
+		"bareDir":           fieldRebuilt,
+		"worktreeRoot":      fieldRebuilt,
+		"defaultBranch":     fieldCopied,
+		"gitMu":             fieldSkipped,
+		"issues":            fieldCopied,
+		"prs":               fieldCopied,
+		"checkRuns":         fieldCopied,
+		"commitStatuses":    fieldCopied,
+		"ciSchedule":        fieldCopied,
+		"requiredContexts":  fieldCopied,
+		"requireUpToDate":   fieldCopied,
+		"requiredApprovals": fieldCopied,
+		"labelVocab":        fieldCopied,
+		"access":            fieldCopied,
+		"latestRelease":     fieldCopied,
+		"mergeQueueEnabled": fieldCopied,
+		"nextNumber":        fieldCopied,
+	},
+	"issueRecord": {
+		"number":         fieldCopied,
+		"title":          fieldCopied,
+		"body":           fieldCopied,
+		"state":          fieldCopied,
+		"author":         fieldCopied,
+		"labels":         fieldCopied,
+		"assignees":      fieldCopied,
+		"labelAppliedAt": fieldCopied,
+		"comments":       fieldCopied,
+		"blockedBy":      fieldCopied,
+		"createdAt":      fieldCopied,
+		"updatedAt":      fieldCopied,
+	},
+	"prRecord": {
+		"number":                  fieldCopied,
+		"title":                   fieldCopied,
+		"body":                    fieldCopied,
+		"head":                    fieldCopied,
+		"base":                    fieldCopied,
+		"state":                   fieldCopied,
+		"draft":                   fieldCopied,
+		"merged":                  fieldCopied,
+		"author":                  fieldCopied,
+		"labels":                  fieldCopied,
+		"issueNumber":             fieldCopied,
+		"comments":                fieldCopied,
+		"reviewThreadComment":     fieldCopied,
+		"reviews":                 fieldCopied,
+		"reviewRequests":          fieldCopied,
+		"reviewSchedule":          fieldCopied,
+		"resolvedThreads":         fieldCopied,
+		"autoMergeEnabled":        fieldCopied,
+		"autoMergeStrategy":       fieldCopied,
+		"inMergeQueue":            fieldCopied,
+		"queueEntry":              fieldCopied,
+		"mergeableRecomputeReads": fieldCopied,
+		"createdAt":               fieldCopied,
+		"updatedAt":               fieldCopied,
+	},
+	"commentRecord": {
+		"databaseID":     fieldCopied,
+		"author":         fieldCopied,
+		"body":           fieldCopied,
+		"createdAt":      fieldCopied,
+		"reactions":      fieldCopied,
+		"fromPR":         fieldCopied,
+		"reviewThreadID": fieldCopied,
+		"path":           fieldCopied,
+		"line":           fieldCopied,
+		"originalLine":   fieldCopied,
+		"diffHunk":       fieldCopied,
+		"isOutdated":     fieldCopied,
+		"threadResolved": fieldCopied,
+	},
+	"projectState": {
+		"id":                 fieldCopied,
+		"owner":              fieldCopied,
+		"num":                fieldCopied,
+		"title":              fieldCopied,
+		"statusFieldID":      fieldCopied,
+		"statusOptions":      fieldCopied,
+		"orderedStatusNames": fieldCopied,
+		"items":              fieldCopied,
+		"itemOrder":          fieldCopied,
+		"updatedAt":          fieldCopied,
+	},
+	"itemState": {
+		"itemID":    fieldCopied,
+		"ownerRepo": fieldCopied,
+		"number":    fieldCopied,
+		"isPR":      fieldCopied,
+		"status":    fieldCopied,
+		"archived":  fieldCopied,
+		"updatedAt": fieldCopied,
+	},
+}
+
+// snapshotRegisteredTypes ties each registry entry to the type it describes,
+// so the completeness test can reflect over it.
+var snapshotRegisteredTypes = map[string]reflect.Type{
+	"Sim":           reflect.TypeOf(Sim{}),
+	"repoState":     reflect.TypeOf(repoState{}),
+	"issueRecord":   reflect.TypeOf(issueRecord{}),
+	"prRecord":      reflect.TypeOf(prRecord{}),
+	"commentRecord": reflect.TypeOf(commentRecord{}),
+	"projectState":  reflect.TypeOf(projectState{}),
+	"itemState":     reflect.TypeOf(itemState{}),
+}

--- a/tests/sim/simgh/snapshot_test.go
+++ b/tests/sim/simgh/snapshot_test.go
@@ -45,11 +45,15 @@ func seedRichSim(t *testing.T) (*Sim, *fakeClock, string) {
 	s.SeedRequiredContexts("acme/widgets", "main", []string{"build"}).
 		SeedCheckRun("acme/widgets", sha, gh.CheckRun{ID: 900, Name: "build", Conclusion: "success"}).
 		SeedCommitStatus("acme/widgets", sha, gh.CommitStatus{Context: "legacy", State: "success"}).
-		// Two steps: one due within the test's reach, one far out so it is
-		// still undrained when the snapshot is taken.
+		// Three steps: one due within the test's reach, and one on each
+		// schedule far enough out that it is still undrained when the snapshot
+		// is taken. Both schedules need a surviving step, or a restore that
+		// dropped one of the two would go unnoticed.
 		SeedCheckRunsAfter("acme/widgets", sha, time.Hour,
 			gh.CheckRun{ID: 900, Name: "build", Status: "completed", Conclusion: "failure"}).
-		SeedReviewsAfter("acme/widgets", 8, 2*time.Hour, gh.PRReview{Author: "late", State: "CHANGES_REQUESTED"})
+		SeedReviewsAfter("acme/widgets", 8, 2*time.Hour, gh.PRReview{Author: "late", State: "CHANGES_REQUESTED"}).
+		SeedCheckRunsAfter("acme/widgets", sha, 3*time.Hour,
+			gh.CheckRun{ID: 901, Name: "lint", Conclusion: "failure"})
 	if err := s.Err(); err != nil {
 		t.Fatalf("seeding: %v", err)
 	}
@@ -257,7 +261,19 @@ func TestRestoreResumesScheduledSequencesAtTheSamePosition(t *testing.T) {
 		t.Fatalf("FetchPRReviews: %v", err)
 	}
 	if len(reviews) != 2 {
-		t.Errorf("got %d reviews after the pending step's instant, want 2 — the step did not survive the restore", len(reviews))
+		t.Errorf("got %d reviews after the pending step's instant, want 2 — the review schedule did not survive the restore", len(reviews))
+	}
+
+	// The CI schedule has its own pending step, further out. Both schedules
+	// are separate fields, so a restore that carried one and dropped the other
+	// would look correct from the review side alone.
+	restoredClock.Advance(time.Hour)
+	runs, err = restored.FetchCheckRuns("acme", "widgets", sha)
+	if err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Errorf("got %d check runs after the pending CI step's instant, want 2 — the CI schedule did not survive the restore", len(runs))
 	}
 }
 

--- a/tests/sim/simgh/snapshot_test.go
+++ b/tests/sim/simgh/snapshot_test.go
@@ -337,6 +337,23 @@ func TestRestoredModelIsIndependentOfTheOriginal(t *testing.T) {
 	if contains(restLabels, "only-in-original") {
 		t.Error("a mutation on the original Sim was visible on the restored one")
 	}
+
+	// Git state must be independent too, not merely the in-memory model. A
+	// restore that carried bareDir forward verbatim instead of repointing it
+	// at the new baseDir would leave both Sims driving one physical
+	// repository — and every in-memory assertion above would still pass,
+	// because those paths are the only thing shared.
+	mainBefore := mustHeadSHA(t, s, "acme/widgets", "main")
+	restored.SeedRequireUpToDate("acme/widgets", "main", false)
+	if err := restored.Err(); err != nil {
+		t.Fatalf("SeedRequireUpToDate on the restored Sim: %v", err)
+	}
+	if err := restored.MergePR("acme", "widgets", 8); err != nil {
+		t.Fatalf("MergePR on the restored Sim: %v", err)
+	}
+	if got := mustHeadSHA(t, s, "acme/widgets", "main"); got != mainBefore {
+		t.Error("merging on the restored Sim moved the original's main — both point at one repository")
+	}
 }
 
 // One snapshot must seed several restores — a scenario may want to branch off

--- a/tests/sim/simgh/snapshot_test.go
+++ b/tests/sim/simgh/snapshot_test.go
@@ -1,0 +1,538 @@
+package simgh
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// seedRichSim builds a model touching every collection Snapshot has to carry:
+// issues with labels and comments and reactions, a PR with reviews, requests,
+// review threads, check runs, commit statuses, branch protection, a recompute
+// window, a merge-queue entry, a release, and both an undrained and a soon-due
+// schedule step.
+func seedRichSim(t *testing.T) (*Sim, *fakeClock, string) {
+	t.Helper()
+	s, clk := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedProject("acme", 2, "Engineering", []string{"Backlog", "Implement", "Review", "Done"}).
+		SeedIssue("acme/widgets", IssueSeed{
+			Number: 7, Title: "Add a thing", Body: "spec", Author: "human",
+			Labels: []string{"fabrik:awaiting-ci"}, Assignees: []string{"bot"}, Status: "Implement",
+		}).
+		SeedComment("acme/widgets", 7, "human", "please hurry").
+		SeedCommit("acme/widgets", "fabrik/issue-7", map[string]string{"a.txt": "a"}, "work").
+		SeedPR("acme/widgets", PRSeed{Number: 8, Title: "PR", Body: "body", Head: "fabrik/issue-7", IssueNumber: 7}).
+		SeedReview("acme/widgets", 8, gh.PRReview{Author: "human", State: "APPROVED"}).
+		SeedReviewRequest("acme/widgets", 8, gh.ReviewRequest{Login: "second-human"}).
+		SeedReviewThreadComment("acme/widgets", 8, "human", "nit", "a.txt", 1).
+		SeedRequiredApprovals("acme/widgets", "main", 1).
+		SeedRequireUpToDate("acme/widgets", "main", true).
+		SeedRepoAccess("acme/widgets", gh.RepoAccess{CanPush: true}).
+		SeedLatestRelease("acme/widgets", gh.LatestRelease{TagName: "v1.2.3"}).
+		SeedMergeQueueEnabled("acme/widgets", true).
+		SeedRateLimits(5000, 321, 5000, 654)
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	sha := mustHeadSHA(t, s, "acme/widgets", "fabrik/issue-7")
+	s.SeedRequiredContexts("acme/widgets", "main", []string{"build"}).
+		SeedCheckRun("acme/widgets", sha, gh.CheckRun{ID: 900, Name: "build", Conclusion: "success"}).
+		SeedCommitStatus("acme/widgets", sha, gh.CommitStatus{Context: "legacy", State: "success"}).
+		// Two steps: one due within the test's reach, one far out so it is
+		// still undrained when the snapshot is taken.
+		SeedCheckRunsAfter("acme/widgets", sha, time.Hour,
+			gh.CheckRun{ID: 900, Name: "build", Status: "completed", Conclusion: "failure"}).
+		SeedReviewsAfter("acme/widgets", 8, 2*time.Hour, gh.PRReview{Author: "late", State: "CHANGES_REQUESTED"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	return s, clk, sha
+}
+
+// readModel captures everything a restored Sim must reproduce. Comparing the
+// whole projection rather than a handful of fields is what makes "every read
+// returns what it returned before" an assertion rather than a claim.
+type modelReading struct {
+	board        *gh.ProjectBoard
+	labels       []string
+	issueBody    string
+	prDetails    *gh.PRDetails
+	checkRuns    []gh.CheckRun
+	statuses     []gh.CommitStatus
+	reviews      []gh.PRReview
+	requests     []gh.ReviewRequest
+	decision     string
+	mergeState   string
+	restLimit    gh.RateLimitStats
+	release      *gh.LatestRelease
+	labelApplied time.Time
+}
+
+func readModel(t *testing.T, s *Sim, sha string) modelReading {
+	t.Helper()
+	var m modelReading
+	var err error
+	if m.board, err = s.FetchProjectBoard("acme", "widgets", 2, "organization"); err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if m.labels, err = s.FetchLabels("acme", "widgets", 7); err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if m.issueBody, err = s.GetIssueBody("acme", "widgets", 7); err != nil {
+		t.Fatalf("GetIssueBody: %v", err)
+	}
+	if m.prDetails, err = s.FetchPRDetails("acme", "widgets", 8); err != nil {
+		t.Fatalf("FetchPRDetails: %v", err)
+	}
+	if m.checkRuns, err = s.FetchCheckRuns("acme", "widgets", sha); err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	if m.statuses, err = s.FetchCombinedStatus("acme", "widgets", sha); err != nil {
+		t.Fatalf("FetchCombinedStatus: %v", err)
+	}
+	if m.reviews, err = s.FetchPRReviews("acme", "widgets", 8); err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if m.requests, err = s.FetchPRReviewRequests("acme", "widgets", 8); err != nil {
+		t.Fatalf("FetchPRReviewRequests: %v", err)
+	}
+	if m.decision, err = s.FetchPRReviewDecision("acme", "widgets", 8); err != nil {
+		t.Fatalf("FetchPRReviewDecision: %v", err)
+	}
+	if m.mergeState, err = s.FetchPRMergeableState("acme", "widgets", 8); err != nil {
+		t.Fatalf("FetchPRMergeableState: %v", err)
+	}
+	m.restLimit, _ = s.RateLimitStats()
+	if m.release, err = s.FetchLatestRelease("acme", "widgets"); err != nil {
+		t.Fatalf("FetchLatestRelease: %v", err)
+	}
+	if m.labelApplied, err = s.FetchLabelAppliedAt("acme", "widgets", 7, "fabrik:awaiting-ci"); err != nil {
+		t.Fatalf("FetchLabelAppliedAt: %v", err)
+	}
+	return m
+}
+
+// TestSnapshotRestoreRoundTripsTheModel is the first half of AC7: after a
+// restore into a fresh baseDir, every read returns what it returned before.
+func TestSnapshotRestoreRoundTripsTheModel(t *testing.T) {
+	s, clk, sha := seedRichSim(t)
+	before := readModel(t, s, sha)
+
+	snap, err := s.Snapshot(t.TempDir())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	// A fresh baseDir every time, exactly as a real restart scenario would —
+	// which is also what would expose a stale absolute path in git's worktree
+	// admin entries.
+	restored, err := Restore(snap, t.TempDir(), WithClock(clk))
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	after := readModel(t, restored, sha)
+	if !reflect.DeepEqual(before, after) {
+		t.Errorf("restored model differs from the original\nbefore: %+v\nafter:  %+v", before, after)
+	}
+}
+
+// Git-derived answers must be recomputed against the copied repository, not
+// replayed from a cached value — this is what would actually fail if a stale
+// worktree admin entry survived the copy, or if the objects did not.
+func TestRestoredGitStateAnswersMergeabilityForReal(t *testing.T) {
+	s, clk, _ := seedRichSim(t)
+	// Make the base advance so the PR is genuinely behind, and require
+	// up-to-date heads — an answer only git can give.
+	s.SeedCommit("acme/widgets", "main", map[string]string{"b.txt": "b"}, "move base")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	snap, err := s.Snapshot(t.TempDir())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	restored, err := Restore(snap, t.TempDir(), WithClock(clk))
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	behind, err := restored.FetchCommitsBehind("acme", "widgets", "main", "fabrik/issue-7")
+	if err != nil {
+		t.Fatalf("FetchCommitsBehind on the restored repo: %v", err)
+	}
+	if behind != 1 {
+		t.Errorf("commits behind = %d, want 1 — recomputed from the copied repository", behind)
+	}
+	state, err := restored.FetchPRMergeableState("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRMergeableState: %v", err)
+	}
+	if state != "behind" {
+		t.Errorf("mergeable state = %q, want behind", state)
+	}
+
+	if err := restored.MergePR("acme", "widgets", 8); err == nil {
+		t.Error("MergePR succeeded on a PR that is behind with up-to-date required")
+	}
+
+	// The copied repository must also still be *writable*, not merely
+	// readable: drop the up-to-date requirement and let the merge write a real
+	// commit into the copied bare repo. A copy that lost its object database's
+	// permissions, or carried a stale worktree lock, fails here and nowhere
+	// else.
+	restored.SeedRequireUpToDate("acme/widgets", "main", false)
+	if err := restored.Err(); err != nil {
+		t.Fatalf("SeedRequireUpToDate on the restored Sim: %v", err)
+	}
+	if err := restored.MergePR("acme", "widgets", 8); err != nil {
+		t.Fatalf("MergePR on the restored repository: %v", err)
+	}
+	merged, err := restored.FetchPRMerged("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRMerged: %v", err)
+	}
+	if !merged {
+		t.Error("the merge did not record against the restored repository")
+	}
+}
+
+// TestRestoreResumesScheduledSequencesAtTheSamePosition is the second half of
+// AC7: an undrained step still fires at its original instant, and a drained
+// one stays drained.
+func TestRestoreResumesScheduledSequencesAtTheSamePosition(t *testing.T) {
+	s, clk, sha := seedRichSim(t)
+
+	// Drain the CI step before snapshotting; leave the review step pending.
+	clk.Advance(time.Hour)
+	runs, err := s.FetchCheckRuns("acme", "widgets", sha)
+	if err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	if len(runs) != 1 || checkVerdict(runs[0]) != "failure" {
+		t.Fatalf("pre-snapshot CI step did not land: %+v", runs)
+	}
+
+	snap, err := s.Snapshot(t.TempDir())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	restoredClock := newFakeClock()
+	restoredClock.t = clk.Now()
+	restored, err := Restore(snap, t.TempDir(), WithClock(restoredClock))
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	// The drained step stays drained: its effect persists and it does not
+	// re-apply.
+	runs, err = restored.FetchCheckRuns("acme", "widgets", sha)
+	if err != nil {
+		t.Fatalf("FetchCheckRuns after restore: %v", err)
+	}
+	if len(runs) != 1 || checkVerdict(runs[0]) != "failure" {
+		t.Errorf("drained CI step did not survive the restore: %+v", runs)
+	}
+
+	// The undrained one has not fired yet…
+	reviews, err := restored.FetchPRReviews("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("got %d reviews before the pending step's instant, want 1", len(reviews))
+	}
+
+	// …and fires at its original instant, unchanged by the restart.
+	restoredClock.Advance(time.Hour)
+	reviews, err = restored.FetchPRReviews("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 2 {
+		t.Errorf("got %d reviews after the pending step's instant, want 2 — the step did not survive the restore", len(reviews))
+	}
+}
+
+// The recompute counter is read-count state, so it must resume mid-drain
+// rather than resetting to its seeded value or to zero.
+func TestRestoreResumesTheRecomputeCounter(t *testing.T) {
+	s, clk, _ := seedRichSim(t)
+	s.SeedMergeableRecomputePending("acme/widgets", 8, 3)
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	if _, _, err := s.FetchPRMergeableFields("acme", "widgets", 8); err != nil {
+		t.Fatalf("FetchPRMergeableFields: %v", err)
+	}
+
+	snap, err := s.Snapshot(t.TempDir())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	restored, err := Restore(snap, t.TempDir(), WithClock(clk))
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	// Two reads left in the window, then the real answer.
+	for i := 0; i < 2; i++ {
+		mergeable, state, err := restored.FetchPRMergeableFields("acme", "widgets", 8)
+		if err != nil {
+			t.Fatalf("read %d: %v", i+1, err)
+		}
+		if mergeable != nil || state != "unknown" {
+			t.Fatalf("read %d after restore = (%v, %q), want the window to still be draining", i+1, mergeable, state)
+		}
+	}
+	mergeable, _, err := restored.FetchPRMergeableFields("acme", "widgets", 8)
+	if err != nil {
+		t.Fatalf("read 3: %v", err)
+	}
+	if mergeable == nil {
+		t.Error("the recompute window did not drain after restore — the counter reset instead of resuming")
+	}
+}
+
+// The restored model must be an independent copy: mutating one must not be
+// visible through the other, or a "restart" scenario would still be sharing
+// state with the engine it claims to have discarded.
+func TestRestoredModelIsIndependentOfTheOriginal(t *testing.T) {
+	s, clk, _ := seedRichSim(t)
+	snap, err := s.Snapshot(t.TempDir())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	restored, err := Restore(snap, t.TempDir(), WithClock(clk))
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	if err := restored.AddLabelToIssue("acme", "widgets", 7, "only-in-restored"); err != nil {
+		t.Fatalf("AddLabelToIssue: %v", err)
+	}
+	if err := s.AddLabelToIssue("acme", "widgets", 7, "only-in-original"); err != nil {
+		t.Fatalf("AddLabelToIssue: %v", err)
+	}
+
+	origLabels, err := s.FetchLabels("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	restLabels, err := restored.FetchLabels("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if contains(origLabels, "only-in-restored") {
+		t.Error("a mutation on the restored Sim was visible on the original")
+	}
+	if contains(restLabels, "only-in-original") {
+		t.Error("a mutation on the original Sim was visible on the restored one")
+	}
+}
+
+// One snapshot must seed several restores — a scenario may want to branch off
+// the same recovered state twice.
+func TestASnapshotIsReusable(t *testing.T) {
+	s, clk, _ := seedRichSim(t)
+	snap, err := s.Snapshot(t.TempDir())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	first, err := Restore(snap, t.TempDir(), WithClock(clk))
+	if err != nil {
+		t.Fatalf("first Restore: %v", err)
+	}
+	if err := first.AddLabelToIssue("acme", "widgets", 7, "only-in-first"); err != nil {
+		t.Fatalf("AddLabelToIssue: %v", err)
+	}
+
+	second, err := Restore(snap, t.TempDir(), WithClock(clk))
+	if err != nil {
+		t.Fatalf("second Restore: %v", err)
+	}
+	labels, err := second.FetchLabels("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if contains(labels, "only-in-first") {
+		t.Error("the second restore saw a mutation made on the first")
+	}
+}
+
+// TestInstrumentedSnapshotCarriesFaultsAndLog is the instrumentation half of
+// R5/D5: the engine died and came back, and GitHub is still broken.
+func TestInstrumentedSnapshotCarriesFaultsAndLog(t *testing.T) {
+	s, clk, _ := seedRichSim(t)
+	in := Instrument(s)
+
+	in.Faults().FailAlways("AddLabelToIssue", ErrRateLimit())
+	if err := in.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-done"); err == nil {
+		t.Fatal("AddLabelToIssue succeeded despite FailAlways")
+	}
+	if _, err := in.FetchLabels("acme", "widgets", 7); err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	logBefore := in.Log().Len()
+
+	snap, err := in.Snapshot(t.TempDir())
+	if err != nil {
+		t.Fatalf("Instrumented.Snapshot: %v", err)
+	}
+	restored, err := RestoreInstrumented(snap, t.TempDir(), WithClock(clk))
+	if err != nil {
+		t.Fatalf("RestoreInstrumented: %v", err)
+	}
+
+	// The failure persists across the restart.
+	if err := restored.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-done"); err == nil {
+		t.Error("the fault did not survive the restore — GitHub quietly healed")
+	}
+
+	// The log survives, and an ordering assertion can span the restart.
+	if got := restored.Log().Len(); got != logBefore+1 {
+		t.Errorf("restored log has %d entries, want %d (the %d carried plus the post-restart call)",
+			got, logBefore+1, logBefore)
+	}
+	precedes, err := restored.Log().Precedes(MethodIs("AddLabelToIssue"), MethodIs("FetchLabels"))
+	if err != nil {
+		t.Fatalf("Precedes across the restart: %v", err)
+	}
+	if !precedes {
+		t.Error("ordering across the restart was lost")
+	}
+
+	// Call counters survive too, so FailOnCall's K still counts from the
+	// original table's creation.
+	if got := restored.Faults().CallCount("AddLabelToIssue"); got != 2 {
+		t.Errorf("CallCount after restore = %d, want 2 (one before, one after)", got)
+	}
+}
+
+// A snapshot taken from a bare Sim carries no instruments. Handing back an
+// empty fault table would let a recovery scenario pass by testing a GitHub
+// that had silently stopped failing.
+func TestRestoreInstrumentedRefusesABareSnapshot(t *testing.T) {
+	s, _, _ := seedRichSim(t)
+	snap, err := s.Snapshot(t.TempDir())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if _, err := RestoreInstrumented(snap, t.TempDir()); err == nil {
+		t.Fatal("RestoreInstrumented accepted a snapshot taken by Sim.Snapshot")
+	}
+}
+
+// TestSnapshotFieldRegistryIsComplete is the drift detector for the deep copy.
+//
+// A field added to model.go and not handled by Snapshot/Restore vanishes
+// across a restart, where it looks exactly like an engine defect — the model
+// forgot something GitHub would have kept. Reflection over the real structs is
+// the only way to notice; the registry forces a deliberate decision per field
+// rather than an omission.
+func TestSnapshotFieldRegistryIsComplete(t *testing.T) {
+	for name, typ := range snapshotRegisteredTypes {
+		t.Run(name, func(t *testing.T) {
+			registry, ok := snapshotFieldRegistry[name]
+			if !ok {
+				t.Fatalf("type %s has no entry in snapshotFieldRegistry", name)
+			}
+			seen := make(map[string]bool, typ.NumField())
+			for i := 0; i < typ.NumField(); i++ {
+				field := typ.Field(i).Name
+				seen[field] = true
+				if _, ok := registry[field]; !ok {
+					t.Errorf("%s.%s is not in snapshotFieldRegistry: decide whether Snapshot copies, "+
+						"rebuilds or deliberately drops it, and record that here", name, field)
+				}
+			}
+			for field := range registry {
+				if !seen[field] {
+					t.Errorf("snapshotFieldRegistry lists %s.%s, which no longer exists", name, field)
+				}
+			}
+		})
+	}
+	for name := range snapshotFieldRegistry {
+		if _, ok := snapshotRegisteredTypes[name]; !ok {
+			t.Errorf("snapshotFieldRegistry has an entry for %q with no corresponding type", name)
+		}
+	}
+}
+
+// Every model type reachable from Sim must be registered, or a whole struct
+// could be added and deep-copied wrongly with nothing to notice.
+func TestEveryModelTypeIsRegistered(t *testing.T) {
+	want := []string{"Sim", "repoState", "issueRecord", "prRecord", "commentRecord", "projectState", "itemState"}
+	for _, name := range want {
+		if _, ok := snapshotRegisteredTypes[name]; !ok {
+			t.Errorf("model type %s is not registered for the completeness check", name)
+		}
+	}
+}
+
+// Both directions must be idempotent. Git writes its loose objects read-only
+// (0444), so a naive copy fails the moment either destination already holds a
+// previous copy — and the failure is a bare "permission denied" on an object
+// hash, which reads as a git problem rather than a copy problem.
+func TestSnapshotAndRestoreAreIdempotentOverAnExistingDirectory(t *testing.T) {
+	s, clk, sha := seedRichSim(t)
+
+	staging := t.TempDir()
+	if _, err := s.Snapshot(staging); err != nil {
+		t.Fatalf("first Snapshot: %v", err)
+	}
+	snap, err := s.Snapshot(staging)
+	if err != nil {
+		t.Fatalf("second Snapshot into the same staging dir: %v", err)
+	}
+
+	target := t.TempDir()
+	if _, err := Restore(snap, target, WithClock(clk)); err != nil {
+		t.Fatalf("first Restore: %v", err)
+	}
+	restored, err := Restore(snap, target, WithClock(clk))
+	if err != nil {
+		t.Fatalf("second Restore into the same baseDir: %v", err)
+	}
+
+	// And the twice-copied repository still answers a git-derived question.
+	if _, err := restored.FetchCheckRuns("acme", "widgets", sha); err != nil {
+		t.Fatalf("FetchCheckRuns after the second restore: %v", err)
+	}
+	if _, err := restored.FetchCommitsBehind("acme", "widgets", "main", "fabrik/issue-7"); err != nil {
+		t.Fatalf("FetchCommitsBehind after the second restore: %v", err)
+	}
+}
+
+func TestSnapshotRejectsAnEmptyStagingDir(t *testing.T) {
+	s, _, _ := seedRichSim(t)
+	if _, err := s.Snapshot(""); err == nil {
+		t.Fatal("Snapshot accepted an empty staging directory")
+	}
+}
+
+// copyDir must refuse anything that is not a regular file or a directory
+// rather than skipping it: a silent skip corrupts the restore in a way that
+// surfaces much later as an inexplicable git failure.
+func TestCopyDirRefusesNonRegularFiles(t *testing.T) {
+	src := t.TempDir()
+	if err := os.Symlink(filepath.Join(src, "nothing"), filepath.Join(src, "link")); err != nil {
+		t.Skipf("cannot create a symlink here: %v", err)
+	}
+	err := copyDir(src, filepath.Join(t.TempDir(), "dst"))
+	if err == nil {
+		t.Fatal("copyDir silently accepted a symlink")
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Errorf("error %q does not explain what it refused", err)
+	}
+}


### PR DESCRIPTION
Closes #1457

Turns `tests/sim/simgh` from a faithful GitHub stand-in into a controllable test instrument. Four capabilities, plus the docs and the mutation sweep that keep them honest.

## What this adds

**Clock-driven schedules** (`schedule.go`, `Seed*At`/`Seed*After` in `seed.go`). A step is a *pending mutation applied on read*, not a read filter — when its time arrives it writes into the model permanently. Two consequences, both deliberate: repeated reads at one clock instant are stable, and engine mutations to the same surface stay observable afterwards (a filter would mask `AddReviewRequest`, the bot re-prompt ladder's own mutation).

Sequencing is clock-driven, not read-count-driven, because **one poll is not one read**: `settleAwaitingCIScan`'s `RefreshCheckRunsLive` plus `checkCIGate` read the same SHA twice per poll, and whether the first happens depends on harness wiring. Read-count sequencing survives only for `mergeableRecomputeReads`, which models a real GitHub recompute.

**Fault injection** (`fault.go`, `ghfault/`). Any interface method fails on demand — once, N times, always, on the Kth call, or narrowed by an `Args` predicate. The narrowing is load-bearing: each settle scan retries a *specific* call for a *specific* issue while other workers touch other items. Method names are reflection-validated; an unknown name, `RateLimitStats` (no error return, so a fault could never fire), and a nil error all panic rather than sitting silently inert.

**An ordered mutation log** (`mutationlog.go`). Records every intercepted call *with its outcome* — attempts, not just mutations, which is the only way "N failures then the success" is expressible. Two-phase append (reserve before the call, complete after) makes ordering exact within a goroutine, which is what every real ordering assertion is. `Precedes` errors rather than answering `false` on an unmatched predicate.

**Snapshot/restore** (`snapshot.go`). Deep-copies the model, copies each bare repo as a directory tree under `gitMu` after a defensive `git worktree prune`, and carries the fault schedule and log too — a restart scenario's GitHub must not quietly heal.

## Key design point

`Instrumented` holds its `*Sim` as a **named field, never embedded**. Embedding would satisfy `var _ engine.GitHubClient = (*Instrumented)(nil)` by method promotion, so a forgotten wrapper would compile cleanly and silently bypass both instruments. With a named field it's a compile error — the entire reason to prefer a decorator. There's a doc comment on the field saying so, because the "simplification" is tempting and the failure mode is invisible.

## How to test

```bash
go test -race ./tests/sim/...        # 399 tests
go vet ./...
bash tests/sim/simgh/nonvacuity.sh   # 144 mutations, ~35 min
```

The sweep is the real review aid: it neutralises each behaviour in turn and asserts the suite goes red. 41 mutations are new here, including AC10's named case — **an injector that silently succeeds** — because a fault-injection test that passes because nothing failed asserts something about a call that was never made.

## Worth a reviewer's attention

- **`FetchCombinedStatus` lost its second `drainCI`.** The first section always drains before it can return, so the second could never apply a step and no mutation could prove it does anything. Removed with a comment; the one case it would catch needs a real clock.
- **`TestScheduleVisibleThroughEveryReadPath` builds a fresh `Sim` per path.** With a shared one, the first read's drain masked a missing drain in every later path — the guard would have stayed green with a drain deleted.
- **`copyFile` replaces rather than truncates.** Git writes loose objects `0444`, so a second snapshot into one staging directory failed with a bare "permission denied" on an object hash. Found by the concurrency test.
- **`engine/simgh_fault_classification_test.go`** is the only file under `engine/`, and it is a test file in `package engine`. No production code there is touched. It asserts the `ghfault` constructors against the real, unexported `isTransientAPIError` — including the negative case, and including that rate-limit shapes deliberately do *not* satisfy the narrower `isTransientError`.
- **`FIDELITY.md`** gains entries for what the new capabilities let a scenario construct that GitHub could not, with concrete impossible states spelled out — scripted verdicts are unconstrained by real branch protection, and that freedom is also a way to write a test that passes against an impossible world.

## Known unrelated failure

`cmd.TestExecute_ConfigYAMLApplied` fails in my environment. `cmd/` and all engine production code are byte-identical to the base commit, and the test reaches the real GitHub API — pre-existing and environment-dependent, not reachable from this change set.