### PR TITLE
fix(tui): color GraphQL budget indicator from burn-rate projection, not raw percentage

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -3002,6 +3002,24 @@ The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
 Typical cost is ~5–30 points per poll depending on active items, well within the
 5,000 points/hour limit.
 
+#### Footer GraphQL Indicator Color
+
+The TUI footer's GraphQL indicator (`remaining/limit  countdown`) colors itself from a
+**projected-exhaustion estimate**, not raw percentage remaining. Fabrik estimates the
+burn rate (points consumed per minute) from consecutive polls, projects that rate
+forward to the window reset, and compares the projection against `Remaining`:
+
+- **Green** — projected consumption stays comfortably below `Remaining`.
+- **Yellow** — projected consumption is within 25% of `Remaining`.
+- **Red** — projected consumption would exceed `Remaining` before the window resets.
+
+This means a low percentage remaining with little time left in the window can still be
+green: if the window is about to reset, the budget resets with it. Conversely, a
+seemingly-healthy percentage with a high burn rate and a long time left before reset can
+turn yellow or red. On startup, before enough polls have landed to estimate a rate, and
+whenever the engine is idle, the indicator is green — it never flashes red before there
+is a burn rate to project from.
+
 #### Cold-Start Cache Population
 
 On first startup, Fabrik bootstraps the board cache from the same lightweight probe

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3000,6 +3000,24 @@ The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
 Typical cost is ~5–30 points per poll depending on active items, well within the
 5,000 points/hour limit.
 
+#### Footer GraphQL Indicator Color
+
+The TUI footer's GraphQL indicator (`remaining/limit  countdown`) colors itself from a
+**projected-exhaustion estimate**, not raw percentage remaining. Fabrik estimates the
+burn rate (points consumed per minute) from consecutive polls, projects that rate
+forward to the window reset, and compares the projection against `Remaining`:
+
+- **Green** — projected consumption stays comfortably below `Remaining`.
+- **Yellow** — projected consumption is within 25% of `Remaining`.
+- **Red** — projected consumption would exceed `Remaining` before the window resets.
+
+This means a low percentage remaining with little time left in the window can still be
+green: if the window is about to reset, the budget resets with it. Conversely, a
+seemingly-healthy percentage with a high burn rate and a long time left before reset can
+turn yellow or red. On startup, before enough polls have landed to estimate a rate, and
+whenever the engine is idle, the indicator is green — it never flashes red before there
+is a burn rate to project from.
+
 #### Cold-Start Cache Population
 
 On first startup, Fabrik bootstraps the board cache from the same lightweight probe

--- a/tui/footer.go
+++ b/tui/footer.go
@@ -108,6 +108,21 @@ func (f FooterComponent) observeGraphQLSample(stats RateLimitStats) FooterCompon
 		return f
 	}
 
+	if prev.at.IsZero() {
+		// prev was recorded by the f.now.IsZero() branch above (the first
+		// sample landed before any TickEvent had set f.now — the engine's
+		// synchronous startup poll typically beats the TUI's first 1s tick).
+		// That timestamp isn't a real baseline, so treat this sample as a
+		// fresh baseline too rather than computing elapsed against a
+		// zero-value time.Time, which would grossly overstate the elapsed
+		// duration (the zero value is year 1) and silently bias
+		// burnRatePerMin toward zero (a false "safe" reading) regardless of
+		// actual consumption. See issue #1510 review discussion.
+		f.lastSample = graphqlSample{at: f.now, remaining: stats.Remaining}
+		f.haveBurnRate = false
+		return f
+	}
+
 	elapsed := f.now.Sub(prev.at)
 	if elapsed <= 0 {
 		// Non-advancing or out-of-order timestamp; keep the prior estimate

--- a/tui/footer.go
+++ b/tui/footer.go
@@ -11,6 +11,23 @@ import (
 	"github.com/muesli/termenv"
 )
 
+// graphqlProjectionYellowMargin is the fraction of Remaining at which the
+// GraphQL budget indicator turns yellow: projected consumption to reset
+// exceeding this fraction of Remaining is "approaching" exhaustion.
+// Deliberately a separate constant from engine/backoff.go's ADR-028
+// rateLimitBackoffThreshold/rateLimitHealthyThreshold — those gate
+// poll-interval backoff (a behavioral concern); this gates only the
+// footer's display color, and the two must stay independently tunable.
+// See issue #1510.
+const graphqlProjectionYellowMargin = 0.75
+
+// graphqlSample is a single (time, Remaining) observation of the GraphQL
+// rate-limit budget, taken from a PollCompletedEvent.
+type graphqlSample struct {
+	at        time.Time
+	remaining int
+}
+
 // FooterComponent renders the bottom status bar: project info, rate limit stats,
 // and (when webhook mode is active) the webhook health indicator.
 type FooterComponent struct {
@@ -19,6 +36,16 @@ type FooterComponent struct {
 	now           time.Time
 	webhookState  string         // "", "starting_up", "healthy", "unhealthy"
 	webhookCounts map[string]int // per-type event counts
+
+	// GraphQL burn-rate estimation state (#1510). haveSample/lastSample track
+	// the most recent PollCompletedEvent observation; haveBurnRate/burnRatePerMin
+	// hold the estimate derived from the two most recent samples. Kept entirely
+	// in-component (rather than widening RateLimitStats) — see ADR discussion
+	// in issue #1510's Plan stage.
+	haveSample     bool
+	lastSample     graphqlSample
+	haveBurnRate   bool
+	burnRatePerMin float64
 }
 
 func (f FooterComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
@@ -27,7 +54,7 @@ func (f FooterComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
 		f.now = ev.At
 	case PollCompletedEvent:
 		if ev.GraphQLStats.Limit > 0 {
-			f.graphqlStats = ev.GraphQLStats
+			f = f.observeGraphQLSample(ev.GraphQLStats)
 		}
 	case ProjectMetaEvent:
 		f.projectInfo.BoardTitle = ev.BoardTitle
@@ -39,6 +66,87 @@ func (f FooterComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
 		}
 	}
 	return f, nil
+}
+
+// observeGraphQLSample records a new GraphQL rate-limit observation and updates
+// the burn-rate estimate from it. The estimate is a simple two-point delta
+// against the immediately-prior sample (Δpoints/Δwall-clock-minutes) — no
+// rolling window or smoothing, per issue #1510's Plan.
+//
+// A Remaining increase between consecutive samples is treated as a window
+// reset: the stale sample is discarded and the estimator restarts (a
+// cold-start-like gap of one cycle) rather than compute a negative rate.
+// Sample timestamps use f.now (updated once per second via TickEvent) rather
+// than time.Now(), keeping the estimator deterministic and testable via
+// direct field assignment.
+func (f FooterComponent) observeGraphQLSample(stats RateLimitStats) FooterComponent {
+	f.graphqlStats = stats
+
+	if f.now.IsZero() {
+		// No TickEvent has landed yet; treat this as a fresh baseline rather
+		// than compute a bogus rate against a zero timestamp. Harmless: cold
+		// start already renders green.
+		f.lastSample = graphqlSample{at: f.now, remaining: stats.Remaining}
+		f.haveSample = true
+		f.haveBurnRate = false
+		return f
+	}
+
+	if !f.haveSample {
+		f.lastSample = graphqlSample{at: f.now, remaining: stats.Remaining}
+		f.haveSample = true
+		f.haveBurnRate = false
+		return f
+	}
+
+	prev := f.lastSample
+	if stats.Remaining > prev.remaining {
+		// Window reset: Remaining jumped back up. Discard the stale sample
+		// and restart the estimator rather than emit a negative burn rate.
+		f.lastSample = graphqlSample{at: f.now, remaining: stats.Remaining}
+		f.haveBurnRate = false
+		return f
+	}
+
+	elapsed := f.now.Sub(prev.at)
+	if elapsed <= 0 {
+		// Non-advancing or out-of-order timestamp; keep the prior estimate
+		// rather than divide by a non-positive duration, but still advance
+		// the baseline so the next sample compares against this one.
+		f.lastSample = graphqlSample{at: f.now, remaining: stats.Remaining}
+		return f
+	}
+
+	pointsConsumed := prev.remaining - stats.Remaining // >= 0, reset case handled above
+	f.burnRatePerMin = float64(pointsConsumed) / elapsed.Minutes()
+	f.haveBurnRate = true
+	f.lastSample = graphqlSample{at: f.now, remaining: stats.Remaining}
+	return f
+}
+
+// graphqlStyle selects the display style for the GraphQL budget indicator by
+// projecting the estimated burn rate forward to the window reset and
+// comparing it against Remaining, rather than coloring on raw percentage
+// remaining alone (issue #1510).
+//
+// Cold start (no burn-rate estimate yet) and an idle/zero burn rate both
+// render green by construction — never a fallback to percentage-based
+// coloring, which would reintroduce the false alarm this issue exists to fix.
+func (f FooterComponent) graphqlStyle() lipgloss.Style {
+	minutesToReset := f.graphqlStats.Reset.Sub(f.now).Minutes()
+	if !f.haveBurnRate || f.burnRatePerMin <= 0 || minutesToReset <= 0 {
+		return successStyle
+	}
+	projected := f.burnRatePerMin * minutesToReset
+	remaining := float64(f.graphqlStats.Remaining)
+	switch {
+	case projected > remaining:
+		return failStyle
+	case projected > graphqlProjectionYellowMargin*remaining:
+		return activeStyle
+	default:
+		return successStyle
+	}
 }
 
 // webhookIndicator returns the rendered webhook health indicator string, or "" when
@@ -124,17 +232,7 @@ func (f FooterComponent) View(width int) string {
 	if f.graphqlStats.Limit > 0 {
 		countdown := fmtRateLimitCountdown(f.graphqlStats.Reset, f.now)
 		plain := fmt.Sprintf("%d/%d  %s", f.graphqlStats.Remaining, f.graphqlStats.Limit, countdown)
-		pct := float64(f.graphqlStats.Remaining) / float64(f.graphqlStats.Limit)
-		var style lipgloss.Style
-		switch {
-		case pct > 0.5:
-			style = successStyle
-		case pct > 0.2:
-			style = activeStyle
-		default:
-			style = failStyle
-		}
-		rightParts = append(rightParts, style.Render(plain))
+		rightParts = append(rightParts, f.graphqlStyle().Render(plain))
 	}
 	var rightStr string
 	if len(rightParts) > 0 {

--- a/tui/footer_test.go
+++ b/tui/footer_test.go
@@ -236,6 +236,57 @@ func TestGraphQLStyle_ProjectionBoundary(t *testing.T) {
 	}
 }
 
+// TestGraphQLStyle_FirstSampleBeforeFirstTick verifies that when the first
+// PollCompletedEvent lands before any TickEvent has set f.now (f.now is the
+// zero time.Time — the engine's synchronous startup poll typically beats the
+// TUI's first 1s tick), the *next* sample does not compute an elapsed
+// duration against that bogus zero-value baseline (which would grossly
+// overstate elapsed and silently drive burnRatePerMin toward zero regardless
+// of actual consumption — a false "safe" reading). Instead it re-baselines,
+// exactly like a genuine cold start; only the sample after that produces a
+// real estimate, and that estimate must reflect the true burn rate.
+func TestGraphQLStyle_FirstSampleBeforeFirstTick(t *testing.T) {
+	f := FooterComponent{}
+	// f.now is still zero: no TickEvent has landed yet.
+	comp, _ := f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 2000, Reset: time.Now().Add(11 * time.Minute)}})
+	f = comp.(FooterComponent)
+	if f.haveBurnRate {
+		t.Fatal("no burn rate expected from the very first sample")
+	}
+
+	// A TickEvent finally lands, then a second sample arrives with a large
+	// drop in Remaining. Without the fix, this would be computed against the
+	// zero-value baseline and silently understate the true burn rate.
+	now := time.Now()
+	comp, _ = f.Update(TickEvent{At: now})
+	f = comp.(FooterComponent)
+	comp, _ = f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 500, Reset: now.Add(10 * time.Minute)}})
+	f = comp.(FooterComponent)
+
+	if f.haveBurnRate {
+		t.Error("sample immediately following a zero-f.now baseline must re-baseline, not compute a rate")
+	}
+	if got := f.graphqlStyle(); got.GetForeground() != successStyle.GetForeground() {
+		t.Errorf("re-baselining sample: got %v, want successStyle (cold-start-like green)", got)
+	}
+
+	// The *third* sample, now measured against a real prior timestamp,
+	// produces a genuine estimate that reflects the actual high burn rate.
+	f.now = now.Add(1 * time.Minute)
+	comp, _ = f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 100, Reset: now.Add(9 * time.Minute)}})
+	f = comp.(FooterComponent)
+
+	if !f.haveBurnRate {
+		t.Fatal("expected a real burn-rate estimate on the third sample")
+	}
+	if f.burnRatePerMin != 400 {
+		t.Errorf("expected burn rate of 400 pts/min (500-100 over 1 minute), got %v", f.burnRatePerMin)
+	}
+	if got := f.graphqlStyle(); got.GetForeground() != failStyle.GetForeground() {
+		t.Errorf("high real burn rate must be reflected as red, got %v", got)
+	}
+}
+
 // TestGraphQLStyle_WindowReset verifies that a Remaining increase between
 // consecutive samples is treated as a window reset: the estimator discards
 // the stale sample (rendering green, cold-start-like) rather than computing

--- a/tui/footer_test.go
+++ b/tui/footer_test.go
@@ -108,10 +108,13 @@ func TestViewFooter_RateLimitShown(t *testing.T) {
 	}
 }
 
-// TestViewFooter_RateLimitColors verifies the color thresholds applied to the
-// rate limit section. Colors are forced via lipgloss.SetColorProfile so that
-// ANSI escape sequences are emitted even in a non-TTY test environment.
-func TestViewFooter_RateLimitColors(t *testing.T) {
+// TestViewFooter_RateLimitColors_ColdStartAlwaysGreen verifies that setting
+// graphqlStats directly (bypassing Update, so no PollCompletedEvent sample
+// has ever been observed) always renders green regardless of percentage
+// remaining — the cold-start behavior required by issue #1510's Requirement
+// 4 ("must not flash red on startup"). This supersedes the pre-#1510 version
+// of this test, which pinned the removed percentage-only coloring.
+func TestViewFooter_RateLimitColors_ColdStartAlwaysGreen(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.TrueColor)
 	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
 
@@ -121,11 +124,10 @@ func TestViewFooter_RateLimitColors(t *testing.T) {
 		name      string
 		remaining int
 		limit     int
-		wantColor string // lipgloss color code present in ANSI escape
 	}{
-		{"green >50%", 2600, 5000, "42"},
-		{"yellow 20-50%", 1500, 5000, "214"},
-		{"red <20%", 900, 5000, "196"},
+		{"formerly green >50%", 2600, 5000},
+		{"formerly yellow 20-50%", 1500, 5000},
+		{"formerly red <20%", 900, 5000},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -138,12 +140,209 @@ func TestViewFooter_RateLimitColors(t *testing.T) {
 				Reset:     reset,
 			}
 			footer := m.footer.View(m.width)
-			// The ANSI escape for the color code should be present in the raw string.
-			if !strings.Contains(footer, tc.wantColor) {
-				t.Errorf("expected color %q for %d/%d; footer=%q", tc.wantColor, tc.remaining, tc.limit, footer)
+			if !strings.Contains(footer, "42") {
+				t.Errorf("expected cold-start green (42) for %d/%d; footer=%q", tc.remaining, tc.limit, footer)
+			}
+			if strings.Contains(footer, "214") || strings.Contains(footer, "196") {
+				t.Errorf("cold start must never render yellow/red; footer=%q", footer)
 			}
 		})
 	}
+}
+
+// TestGraphQLStyle_ReportedCase pins the false positive reported in issue
+// #1510: 1980/5000 remaining, 4 minutes to reset, with poll-loop spend far
+// below what's needed to exhaust the budget in that window. Must render
+// green, not the old percentage logic's yellow.
+func TestGraphQLStyle_ReportedCase(t *testing.T) {
+	f := FooterComponent{}
+	now := time.Now()
+
+	// Warm up the estimator with a low, healthy burn rate: 5 points consumed
+	// over 5 minutes (1 point/min) is orders of magnitude below what would be
+	// needed to exhaust 1980 remaining in the 4 minutes left.
+	f.now = now
+	comp, _ := f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 1985, Reset: now.Add(9 * time.Minute)}})
+	f = comp.(FooterComponent)
+
+	f.now = now.Add(5 * time.Minute)
+	comp, _ = f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 1980, Reset: now.Add(4 * time.Minute)}})
+	f = comp.(FooterComponent)
+
+	if !f.haveBurnRate {
+		t.Fatal("expected a burn-rate estimate after two samples")
+	}
+	if got := f.graphqlStyle(); got.GetForeground() != successStyle.GetForeground() {
+		t.Errorf("reported case: got style %v, want successStyle (green)", got)
+	}
+}
+
+// TestGraphQLStyle_ProjectedExhaustionRed pins a genuine exhaustion
+// projection: a high burn rate that will consume Remaining well before
+// Reset.
+func TestGraphQLStyle_ProjectedExhaustionRed(t *testing.T) {
+	f := FooterComponent{}
+	now := time.Now()
+
+	f.now = now
+	comp, _ := f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 2000, Reset: now.Add(11 * time.Minute)}})
+	f = comp.(FooterComponent)
+
+	// 1000 points consumed in 1 minute -> burn rate 1000/min. Projected over
+	// the remaining 10 minutes (10000) vastly exceeds Remaining (1000).
+	f.now = now.Add(1 * time.Minute)
+	comp, _ = f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 1000, Reset: now.Add(10 * time.Minute)}})
+	f = comp.(FooterComponent)
+
+	if got := f.graphqlStyle(); got.GetForeground() != failStyle.GetForeground() {
+		t.Errorf("exhaustion case: got style %v, want failStyle (red)", got)
+	}
+}
+
+// TestGraphQLStyle_ProjectionBoundary pins the exact comparison operators at
+// both thresholds: strictly-greater-than in both cases, so a projection
+// exactly equal to a threshold stays in the lower (safer) band.
+func TestGraphQLStyle_ProjectionBoundary(t *testing.T) {
+	// remaining=1000, burnRate=100 pts/min => projected = 100 * minutes.
+	// graphqlProjectionYellowMargin (0.75) puts the yellow threshold at 750.
+	cases := []struct {
+		name    string
+		minutes float64 // minutes to reset
+		want    lipgloss.Style
+	}{
+		{"just under yellow margin -> green", 7.49, successStyle},          // projected 749 < 750
+		{"exactly at yellow margin -> green (not strictly greater)", 7.5, successStyle}, // projected 750 == 750
+		{"just over yellow margin -> yellow", 7.51, activeStyle},           // projected 751 > 750
+		{"exactly at remaining -> yellow (not strictly greater)", 10.0, activeStyle},    // projected 1000 == 1000
+		{"just over remaining -> red", 10.01, failStyle},                   // projected 1001 > 1000
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Now()
+			f := FooterComponent{
+				now:            now,
+				haveBurnRate:   true,
+				burnRatePerMin: 100,
+				graphqlStats: RateLimitStats{
+					Limit:     5000,
+					Remaining: 1000,
+					Reset:     now.Add(time.Duration(tc.minutes * float64(time.Minute))),
+				},
+			}
+			if got := f.graphqlStyle(); got.GetForeground() != tc.want.GetForeground() {
+				t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGraphQLStyle_WindowReset verifies that a Remaining increase between
+// consecutive samples is treated as a window reset: the estimator discards
+// the stale sample (rendering green, cold-start-like) rather than computing
+// a negative burn rate, and a subsequent post-reset sample produces a fresh,
+// correct estimate.
+func TestGraphQLStyle_WindowReset(t *testing.T) {
+	f := FooterComponent{}
+	now := time.Now()
+
+	// Establish a high burn rate pre-reset.
+	f.now = now
+	comp, _ := f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 2000, Reset: now.Add(11 * time.Minute)}})
+	f = comp.(FooterComponent)
+	f.now = now.Add(1 * time.Minute)
+	comp, _ = f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 500, Reset: now.Add(10 * time.Minute)}})
+	f = comp.(FooterComponent)
+	if got := f.graphqlStyle(); got.GetForeground() != failStyle.GetForeground() {
+		t.Fatalf("pre-reset sanity check: got %v, want failStyle", got)
+	}
+
+	// Window resets: Remaining jumps back up to Limit.
+	f.now = now.Add(2 * time.Minute)
+	comp, _ = f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 5000, Reset: now.Add(70 * time.Minute)}})
+	f = comp.(FooterComponent)
+	if f.haveBurnRate {
+		t.Error("window reset should discard the burn-rate estimate")
+	}
+	if got := f.graphqlStyle(); got.GetForeground() != successStyle.GetForeground() {
+		t.Errorf("immediately after window reset: got %v, want successStyle (green)", got)
+	}
+
+	// A subsequent post-reset sample computes a fresh rate correctly (not
+	// poisoned by the pre-reset delta).
+	f.now = now.Add(3 * time.Minute)
+	comp, _ = f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 4990, Reset: now.Add(69 * time.Minute)}})
+	f = comp.(FooterComponent)
+	if !f.haveBurnRate {
+		t.Fatal("expected a fresh burn-rate estimate after the post-reset sample")
+	}
+	if f.burnRatePerMin != 10 {
+		t.Errorf("expected fresh burn rate of 10 pts/min, got %v", f.burnRatePerMin)
+	}
+	if got := f.graphqlStyle(); got.GetForeground() != successStyle.GetForeground() {
+		t.Errorf("healthy post-reset burn rate: got %v, want successStyle (green)", got)
+	}
+}
+
+// TestGraphQLStyle_IdleZeroBurn verifies an idle engine (Remaining unchanged
+// across samples) renders green no matter how low Remaining has fallen.
+func TestGraphQLStyle_IdleZeroBurn(t *testing.T) {
+	f := FooterComponent{}
+	now := time.Now()
+
+	f.now = now
+	comp, _ := f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 50, Reset: now.Add(11 * time.Minute)}})
+	f = comp.(FooterComponent)
+	f.now = now.Add(5 * time.Minute)
+	comp, _ = f.Update(PollCompletedEvent{GraphQLStats: RateLimitStats{Limit: 5000, Remaining: 50, Reset: now.Add(6 * time.Minute)}})
+	f = comp.(FooterComponent)
+
+	if f.burnRatePerMin != 0 {
+		t.Fatalf("expected zero burn rate for an idle engine, got %v", f.burnRatePerMin)
+	}
+	if got := f.graphqlStyle(); got.GetForeground() != successStyle.GetForeground() {
+		t.Errorf("idle engine at low Remaining: got %v, want successStyle (green)", got)
+	}
+}
+
+// TestGraphQLStyle_ResetAtOrBehindNow verifies no panic/division issue and a
+// green result when Reset is at or behind now, even with an established
+// non-zero burn rate.
+func TestGraphQLStyle_ResetAtOrBehindNow(t *testing.T) {
+	now := time.Now()
+	f := FooterComponent{
+		now:            now,
+		haveBurnRate:   true,
+		burnRatePerMin: 100,
+		graphqlStats: RateLimitStats{
+			Limit:     5000,
+			Remaining: 10,
+			Reset:     now.Add(-1 * time.Minute), // behind now
+		},
+	}
+	if got := f.graphqlStyle(); got.GetForeground() != successStyle.GetForeground() {
+		t.Errorf("Reset behind now: got %v, want successStyle (green)", got)
+	}
+
+	f.graphqlStats.Reset = now // exactly at now
+	if got := f.graphqlStyle(); got.GetForeground() != successStyle.GetForeground() {
+		t.Errorf("Reset at now: got %v, want successStyle (green)", got)
+	}
+}
+
+// TestGraphQLStyle_LimitZero verifies no division-by-zero panic when Limit
+// is zero (the pre-existing Limit > 0 gate in Update/View covers this, but
+// graphqlStyle itself must also not divide by Limit anywhere).
+func TestGraphQLStyle_LimitZero(t *testing.T) {
+	f := FooterComponent{
+		now: time.Now(),
+		graphqlStats: RateLimitStats{
+			Limit:     0,
+			Remaining: 0,
+			Reset:     time.Time{},
+		},
+	}
+	// Must not panic.
+	_ = f.graphqlStyle()
 }
 
 // TestViewFooter_TruncationWithRateLimit verifies that at narrow widths the

--- a/tui/footer_test.go
+++ b/tui/footer_test.go
@@ -210,11 +210,11 @@ func TestGraphQLStyle_ProjectionBoundary(t *testing.T) {
 		minutes float64 // minutes to reset
 		want    lipgloss.Style
 	}{
-		{"just under yellow margin -> green", 7.49, successStyle},          // projected 749 < 750
+		{"just under yellow margin -> green", 7.49, successStyle},                       // projected 749 < 750
 		{"exactly at yellow margin -> green (not strictly greater)", 7.5, successStyle}, // projected 750 == 750
-		{"just over yellow margin -> yellow", 7.51, activeStyle},           // projected 751 > 750
+		{"just over yellow margin -> yellow", 7.51, activeStyle},                        // projected 751 > 750
 		{"exactly at remaining -> yellow (not strictly greater)", 10.0, activeStyle},    // projected 1000 == 1000
-		{"just over remaining -> red", 10.01, failStyle},                   // projected 1001 > 1000
+		{"just over remaining -> red", 10.01, failStyle},                                // projected 1001 > 1000
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #1510

## What this does

The TUI footer's GraphQL rate-limit indicator (`remaining/limit  countdown`) used to color itself from percentage-remaining alone, which produced false alarms: `1980/5000` with 4 minutes to reset showed yellow even though the actual burn rate meant the budget would comfortably survive to the window reset.

This replaces that logic with a **projection**: estimate the burn rate (points/minute) from consecutive `PollCompletedEvent` samples, project consumption forward to the window reset, and compare against `Remaining`.

- **Green** — projected consumption stays comfortably below `Remaining`.
- **Yellow** — projected consumption is within 25% of `Remaining`.
- **Red** — projected consumption would exceed `Remaining` before reset.

## Key changes

- `tui/footer.go`: adds `graphqlSample`, burn-rate state (`haveSample`/`lastSample`/`haveBurnRate`/`burnRatePerMin`) to `FooterComponent`, an `observeGraphQLSample` method (two-point delta, `f.now`-timestamped, window-reset detection via a `Remaining` increase), and a `graphqlStyle()` method that replaces the old `pct`-based switch in `View()`. Displayed text (`%d/%d  %s`) is unchanged — only the style derivation.
- Cold start (no samples yet) and idle/zero burn rate both render green by construction — never a fallback to the removed percentage logic.
- `tui/footer_test.go`: rewrites `TestViewFooter_RateLimitColors` (which pinned the removed behavior) into a cold-start-always-green test, and adds coverage for: the reported false-positive case, a genuine exhaustion projection, the exact yellow/red comparison boundaries, window-reset handling (including a fresh post-reset estimate), idle/zero burn, `Reset` at/behind `now`, and `Limit == 0`.
- `docs/USER_GUIDE.md` / `docs/llms-full.txt`: documents the new color semantics in the Rate Limit Monitoring section.

Sample state is kept entirely inside `tui/footer.go` — no changes to `tui.RateLimitStats`, `tui/events.go`, `engine/poll.go`, or `engine/backoff.go` (ADR-028's poll-backoff hysteresis is a distinct, untouched mechanism).

## How to test

```
go build ./...
go vet ./...
go test -race ./tui/...
```

All new tests are in `tui/footer_test.go` under `TestGraphQLStyle_*` and `TestViewFooter_RateLimitColors_ColdStartAlwaysGreen`.