### PR TITLE
docs: correct CLAUDE.md review_authority filter to match #1045 behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,9 +164,15 @@ review_authority: authoritative # Optional: advisory (default) | authoritative. 
                                 # computation otherwise. Governs MERGING, never WORKING: an unresolved
                                 # CHANGES_REQUESTED does not make Fabrik sit idle — it reinvokes the stage
                                 # to address the reviewer's feedback (both inline thread comments and the
-                                # body of any CHANGES_REQUESTED review, which GitHub requires non-empty;
-                                # COMMENTED review bodies are deliberately excluded, since automated
-                                # reviewers routinely submit a generic summary as one), bounded by
+                                # body of any review whose state is not DISMISSED or PENDING — as of #1045,
+                                # CHANGES_REQUESTED, COMMENTED, and APPROVED bodies are all treated as
+                                # potentially actionable, since a bot reviewer that submits its entire
+                                # finding set as COMMENTED (e.g. Pruefer) would otherwise be silently
+                                # dropped; the accepted trade-off is that a generic bot summary (e.g.
+                                # Copilot/Gemini's COMMENTED overview) can also trigger a reinvoke, whose
+                                # cost is capped by the no-op cycle exemption — a reinvoke landing no
+                                # commit reverses the cycle-counter increment (ReviewCycleDecremented)),
+                                # bounded by
                                 # MaxReviewCycles, with pauseForReviewCycleLimit as the terminal fallback
                                 # only if the loop never converges — never as the first response to a
                                 # change request. yolo/cruise

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,8 +171,7 @@ review_authority: authoritative # Optional: advisory (default) | authoritative. 
                                 # dropped; the accepted trade-off is that a generic bot summary (e.g.
                                 # Copilot/Gemini's COMMENTED overview) can also trigger a reinvoke, whose
                                 # cost is capped by the no-op cycle exemption — a reinvoke landing no
-                                # commit reverses the cycle-counter increment (ReviewCycleDecremented)),
-                                # bounded by
+                                # commit reverses the cycle-counter increment (ReviewCycleDecremented)), bounded by
                                 # MaxReviewCycles, with pauseForReviewCycleLimit as the terminal fallback
                                 # only if the loop never converges — never as the first response to a
                                 # change request. yolo/cruise

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,8 +174,8 @@ review_authority: authoritative # Optional: advisory (default) | authoritative. 
                                 # commit reverses the cycle-counter increment (ReviewCycleDecremented)), bounded by
                                 # MaxReviewCycles, with pauseForReviewCycleLimit as the terminal fallback
                                 # only if the loop never converges — never as the first response to a
-                                # change request. yolo/cruise
-                                # never bypass an authoritative gate's MERGE decision — they still control
+                                # change request. yolo/cruise never bypass an authoritative gate's MERGE
+                                # decision — they still control
                                 # auto-advance/auto-merge timing, only once the gate itself is satisfied.
                                 # See ADR-1250, ADR-1375.
 expected_reviewers:             # Optional: declares unrequested reviewers (self-submitting review bots


### PR DESCRIPTION
Closes #1520

## What this does

Corrects a stale statement in `CLAUDE.md`'s `review_authority: authoritative` documentation block that described the *pre-#1045* review-body actionability filter. #1045 inverted that behavior, but `CLAUDE.md` was never updated to match — creating a "trap for the next reader" (per the issue, a genuine `COMMENTED`-triggered reinvoke was misdiagnosed as an engine bug during 0.0.78 e2e triage precisely because of this stale sentence).

## Key changes

- `CLAUDE.md` (~line 166-169): replaced the claim that "COMMENTED review bodies are deliberately excluded" with a description of the current filter (`buildReviewBodyCommentsFromReviews`, `engine/reviews.go`): any review body from a non-`DISMISSED`, non-`PENDING` state is potentially actionable — `CHANGES_REQUESTED`, `COMMENTED`, and `APPROVED` bodies are all treated the same way. Also names the deliberate trade-off #1045 accepted (a generic bot summary can trigger a reinvoke) and the mitigation (the `ReviewCycleDecremented` no-op cycle exemption bounds that cost).

## What was verified, not changed

- `docs/state-machine.md` and `docs/USER_GUIDE.md` were re-checked and already describe the current #1045 behavior correctly — no edits needed.
- ADR-1375 (which documents the design #1045 superseded) is left untouched, as historical ADRs should be.
- `docs/llms-full.txt` was regenerated as a sanity check; no diff resulted, confirming `CLAUDE.md` isn't part of the canonical doc bundle.
- `grep -rn COMMENTED docs/ CLAUDE.md` confirms every remaining mention across the repo is now consistent with #1045's actual behavior.

## How to test

This is a documentation-only change — no code paths are affected. To verify:
```
grep -rn COMMENTED docs/ CLAUDE.md
```
Every match should describe `COMMENTED` bodies as actionable (per #1045), not excluded.