### PR TITLE
test(e2e): key AC7 off the original review's ID, not reinvoke count

### DIFF
--- a/engine/reinvoke.go
+++ b/engine/reinvoke.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
@@ -37,6 +38,22 @@ type reinvokeOpts struct {
 	// worktree dir and the processComments error. Used for CI's no-op-SHA
 	// recording and rebase's auto-merge re-enablement.
 	after func(workDir string, err error)
+}
+
+// commentIDsForLog joins the IDs of a dispatched comment batch for inclusion
+// in dispatchReinvoke's log line, so a log scraper (e.g. the e2e suite) can
+// distinguish which review/comment a given reinvoke was dispatched for,
+// rather than relying on a count- or timing-based proxy. "|" is used as the
+// separator: GraphQL node IDs are base64url (comma-safe already, but "|"
+// avoids any ambiguity), and review-body synthetic IDs (reviewBodyCommentID,
+// "review-body:<DatabaseID>") never contain it either. Returns "" for an
+// empty batch.
+func commentIDsForLog(comments []gh.Comment) string {
+	ids := make([]string, len(comments))
+	for i, c := range comments {
+		ids[i] = c.ID
+	}
+	return strings.Join(ids, "|")
 }
 
 // dispatchReinvoke is the shared goroutine scaffold for all three reinvoke
@@ -112,7 +129,7 @@ func (e *Engine) dispatchReinvoke(ctx context.Context, board *gh.ProjectBoard, i
 			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})
 		}
 
-		e.logf(item.Number, opts.tag, "re-invoking stage %q via comment processing\n", stage.Name)
+		e.logf(item.Number, opts.tag, "re-invoking stage %q via comment processing (comments: %s)\n", stage.Name, commentIDsForLog(comments))
 		err := e.processComments(ctx, board, item, reinvokeStage, comments, onPIDReady)
 
 		if opts.after != nil {

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -990,6 +990,38 @@ func tryLogLineContaining(env *Env, substring string, startOffset int64) (string
 	}
 }
 
+// allLogLinesContaining does a single, non-fatal scan of the test bed's
+// fabrik.log starting at startOffset for every line containing substring —
+// unlike tryLogLineContaining, which returns only the first match, this
+// returns all of them. Used where a caller must distinguish which of several
+// matching lines actually matters (e.g. AC7's per-review-ID check), rather
+// than merely detecting presence or absence.
+func allLogLinesContaining(env *Env, substring string, startOffset int64) ([]string, error) {
+	f, err := os.Open(env.LogPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(startOffset, 0); err != nil {
+		return nil, err
+	}
+	var matches []string
+	r := bufio.NewReader(f)
+	for {
+		line, err := r.ReadString('\n')
+		if strings.Contains(line, substring) {
+			matches = append(matches, line)
+		}
+		if err != nil {
+			return matches, nil
+		}
+	}
+}
+
 // ── small internals ────────────────────────────────────────────────────────
 
 func getenvOr(key, fallback string) string {

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"testing"
 	"time"
@@ -82,6 +83,14 @@ import (
 // pre-#1375 behavior; see adrs/1375-review-authority-reinvoke-not-pause.md
 // for why that behavior was wrong and what replaces it.
 
+// reviewBodyIDPattern extracts a review-body synthetic comment ID
+// ("review-body:<database ID>", produced by engine/reviews.go's
+// reviewBodyCommentID) from a dispatchReinvoke log line enriched by
+// commentIDsForLog (engine/reinvoke.go, #1519). Used by AC7 below to key its
+// "same review not reprocessed" check off the review's own identity, not off
+// reinvoke count or timing.
+var reviewBodyIDPattern = regexp.MustCompile(`review-body:\d+`)
+
 // TestReviewAuthorityReinvokesOnChangesRequested covers AC1 and AC6 (R1/R3,
 // #1375, ADR-1375). This supersedes the retired
 // TestReviewAuthorityBlocksAndPausesOnChangesRequested and its expectation
@@ -100,8 +109,26 @@ import (
 // REQUEST_CHANGES, no inline thread comments) — and confirms it alone
 // triggers the reinvoke. AC7 requires the same review is not re-processed on
 // a later poll: after the reinvoke completes, this test waits through a
-// further poll window and asserts no second review-reinvoke dispatch occurs
-// for the same review.
+// further poll window and asserts no reinvoke dispatch carries the same
+// review's ID among its comments.
+//
+// AC7's premise (#1519, correcting the original design under #1375): a
+// *second* review-reinvoke dispatch in the settle window is not by itself a
+// violation. #1045 widened buildReviewBodyCommentsFromReviews's
+// actionable-feedback filter so any non-DISMISSED, non-PENDING review body is
+// actionable, not just CHANGES_REQUESTED — so a distinct, previously
+// unprocessed review body (e.g. the bed's self-submitting bot reviewer
+// posting a generic COMMENTED summary, which every real bed observes within
+// seconds of the test's own review) correctly triggers its own reinvoke, and
+// AC7 must tolerate it. What AC7 actually guards is narrower: the dedup on
+// the *original* review (keyed on reviewBodyCommentID, "review-body:<review
+// database ID>") must hold — that review's ID must never reappear in a later
+// reinvoke's comment batch. dispatchReinvoke's log line is enriched (#1519,
+// engine/reinvoke.go's commentIDsForLog) to carry the dispatched comment IDs
+// specifically so this test can key the check off the original review's ID,
+// not off dispatch count or timing — a widened match that merely tolerated
+// *any* second reinvoke would satisfy R3 while reintroducing a vacuous test
+// (R2), since it could no longer detect a genuine dedup regression.
 //
 // Requires #1261 (engine support for the review-authority:authoritative
 // label) and #1375 (this issue) to be merged.
@@ -157,8 +184,23 @@ func TestReviewAuthorityReinvokesOnChangesRequested(t *testing.T) {
 	// verdict has not cleared) — before Finding 1's fix this reinvoke was
 	// unreachable, and the gate would instead sit on fabrik:awaiting-review
 	// until FABRIK_REVIEW_WAIT_TIMEOUT elapsed.
-	WaitForLogLine(t, env, fmt.Sprintf("[#%d review-reinvoke] re-invoking stage", num), logOffset, 10*time.Minute)
+	firstReinvokeLine := WaitForLogLine(t, env, fmt.Sprintf("[#%d review-reinvoke] re-invoking stage", num), logOffset, 10*time.Minute)
 	t.Logf("review-reinvoke dispatched for %s#%d — authoritative CHANGES_REQUESTED body alone triggered a reinvoke", env.RepoAlpha, num)
+
+	// Extract the original review's synthetic comment ID so AC7 below can key
+	// its check off the review's own identity. AC6's premise guarantees this
+	// scenario is a body-only REQUEST_CHANGES review (no inline comments), which
+	// always produces exactly one review-body: ID — if extraction ever comes up
+	// empty, something upstream broke (the log enrichment, or AC6's shape
+	// assumption), and failing loudly here is preferable to AC7 silently
+	// no-op'ing.
+	originalReviewIDs := reviewBodyIDPattern.FindAllString(firstReinvokeLine, -1)
+	if len(originalReviewIDs) == 0 {
+		t.Fatalf("could not extract a review-body: ID from the first review-reinvoke log line %q — "+
+			"expected commentIDsForLog (engine/reinvoke.go) to have enriched it with the dispatched review's synthetic ID", firstReinvokeLine)
+	}
+	originalReviewID := originalReviewIDs[0]
+	t.Logf("original review's synthetic comment ID: %s", originalReviewID)
 
 	// The reinvoke, not a pause, is the primary response — fabrik:paused must
 	// not have fired from this alone.
@@ -173,20 +215,36 @@ func TestReviewAuthorityReinvokesOnChangesRequested(t *testing.T) {
 	WaitForLogLine(t, env, fmt.Sprintf("[#%d done] comment processing complete", num), logOffset, 20*time.Minute)
 	t.Logf("review-reinvoke completed for %s#%d", env.RepoAlpha, num)
 
-	// AC7: the same review must not be re-processed on a later poll. No new
-	// review has been submitted and no new thread comments exist, so
-	// buildReviewFeedbackComments must now return empty — confirm no second
-	// review-reinvoke dispatch occurs within a bounded settle window.
+	// AC7: the same review must not be re-processed on a later poll. The
+	// dedup in buildReviewBodyCommentsFromReviews (engine/reviews.go) is keyed
+	// per review-body ID (snap.CommentProcessed(reviewBodyCommentID(r))), so
+	// once the original review is processed, its own ID must never reappear
+	// in a later reinvoke's dispatched comment batch. A *different* review's
+	// ID reappearing is not a violation — since #1045, any distinct,
+	// previously unprocessed non-DISMISSED review body is actionable, and the
+	// bed's self-submitting bot reviewer routinely posts a generic COMMENTED
+	// summary within seconds of the test's own review, correctly triggering
+	// its own reinvoke. This scans every review-reinvoke line in the settle
+	// window (not just the first) and fails only if the original review's ID
+	// is among them.
 	settleOffset := LogOffset(t, env)
 	settleDeadline := time.Now().Add(90 * time.Second)
 	for time.Now().Before(settleDeadline) {
 		pollSleep(pollBase())
 	}
-	if line, err := tryLogLineContaining(env, fmt.Sprintf("[#%d review-reinvoke] re-invoking stage", num), settleOffset); err == nil && line != "" {
-		t.Fatalf("AC7 violated: a second review-reinvoke dispatched for %s#%d after the same review was already processed: %q",
-			env.RepoAlpha, num, line)
+	lines, err := allLogLinesContaining(env, fmt.Sprintf("[#%d review-reinvoke] re-invoking stage", num), settleOffset)
+	if err != nil {
+		t.Fatalf("scanning settle window for review-reinvoke lines: %v", err)
 	}
-	t.Logf("AC7 verified: %s#%d did not re-dispatch a reinvoke for the same, already-processed review", env.RepoAlpha, num)
+	for _, line := range lines {
+		if slices.Contains(reviewBodyIDPattern.FindAllString(line, -1), originalReviewID) {
+			t.Fatalf("AC7 violated: a review-reinvoke dispatched for %s#%d reprocessed the already-processed review %s: %q",
+				env.RepoAlpha, num, originalReviewID, line)
+		}
+		t.Logf("tolerated: a review-reinvoke dispatched for %s#%d for a different review (not %s), the bed's real steady-state behavior since #1045: %q",
+			env.RepoAlpha, num, originalReviewID, line)
+	}
+	t.Logf("AC7 verified: %s#%d did not re-dispatch a reinvoke for the same, already-processed review %s", env.RepoAlpha, num, originalReviewID)
 }
 
 // TestReviewAuthorityCycleLimitPauses covers AC4: a reviewer requesting

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -191,13 +191,13 @@ func TestReviewAuthorityReinvokesOnChangesRequested(t *testing.T) {
 	// its check off the review's own identity. AC6's premise guarantees this
 	// scenario is a body-only REQUEST_CHANGES review (no inline comments), which
 	// always produces exactly one review-body: ID — if extraction ever comes up
-	// empty, something upstream broke (the log enrichment, or AC6's shape
-	// assumption), and failing loudly here is preferable to AC7 silently
-	// no-op'ing.
+	// empty or with more than one ID, something upstream broke (the log
+	// enrichment, or AC6's shape assumption), and failing loudly here is
+	// preferable to AC7 silently no-op'ing or picking an arbitrary ID.
 	originalReviewIDs := reviewBodyIDPattern.FindAllString(firstReinvokeLine, -1)
-	if len(originalReviewIDs) == 0 {
-		t.Fatalf("could not extract a review-body: ID from the first review-reinvoke log line %q — "+
-			"expected commentIDsForLog (engine/reinvoke.go) to have enriched it with the dispatched review's synthetic ID", firstReinvokeLine)
+	if len(originalReviewIDs) != 1 {
+		t.Fatalf("expected exactly one review-body: ID in the first review-reinvoke log line %q, got %d (%v) — "+
+			"expected commentIDsForLog (engine/reinvoke.go) to have enriched it with exactly the dispatched review's synthetic ID", firstReinvokeLine, len(originalReviewIDs), originalReviewIDs)
 	}
 	originalReviewID := originalReviewIDs[0]
 	t.Logf("original review's synthetic comment ID: %s", originalReviewID)


### PR DESCRIPTION
Closes #1519

## What this does

Fixes `TestReviewAuthorityReinvokesOnChangesRequested`'s AC7, which asserted *no* second `review-reinvoke` dispatch at all within a 90s settle window. That premise went stale under #1045, which widened the actionable-feedback filter (`buildReviewBodyCommentsFromReviews`) so any non-DISMISSED, non-PENDING review body is actionable — not just `CHANGES_REQUESTED`. The bed's self-submitting bot reviewer routinely posts a generic `COMMENTED` summary within seconds of the test's own review, correctly triggering its own reinvoke and failing AC7 on every run.

## Key changes

1. **`engine/reinvoke.go`** — added `commentIDsForLog`, appending the dispatched comment/review-body IDs to the shared `dispatchReinvoke` log line (`... re-invoking stage %q via comment processing (comments: %s)`). Additive only — the existing prefix substring matched by other tests (`TestReviewAuthorityCycleLimitPauses`, `expected_reviewers_test.go`) is unchanged. Also touches CI-fix/rebase reinvoke output, but both use fixed sentinel IDs so the appended content is inert there.
2. **`tests/e2e/harness.go`** — added `allLogLinesContaining`, mirroring `tryLogLineContaining` but returning every match in the window instead of just the first.
3. **`tests/e2e/review_authority_test.go`** — AC7 now extracts the original review's synthetic ID (`review-body:<DatabaseID>`) from the AC1/AC6 reinvoke log line, scans all settle-window reinvoke lines, and fails only if that specific ID reappears. A distinct review's ID triggering its own dispatch is now logged as tolerated, not a failure. Rewrote the stale "no new review can arrive" premise comment to document the corrected invariant and the #1045/#1519 history, so a future reader doesn't draw the same wrong conclusion.

## Why this is still a meaningful regression test

The fix keys off `reviewBodyCommentID`'s stable synthetic ID rather than a widened substring/count/timing proxy, so it still fails loudly if the engine genuinely reprocesses the already-dedup'd review — it just no longer treats an unrelated bot's distinct review as a false positive.

## How to test

- `go build ./...`, `go vet ./...`, `go vet -tags e2e ./tests/e2e/...`, `go build -tags e2e ./tests/e2e/...`, `gofmt -l` — all clean.
- Full non-e2e suite passes (`go test ./...`); the one failure seen (`cmd.TestExecute_ConfigYAMLApplied`, a SIGINT-timing test) is pre-existing and reproduces identically on pristine `origin/main`, unrelated to this change's files.
- The e2e test itself (`go:build e2e`) requires a live bed and can't run in this environment; correctness rests on the log-line enrichment and the extraction/comparison logic being straightforward and manually verified.

No documentation impact — this log line's text isn't referenced by any canonical doc.