### PR TITLE
docs: bring README and docs/index up to date with v0.0.78

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ GitHub Project Board (source of truth)
 > **Cold-start optimization (v0.0.58):** On startup, closed Done items are seeded from probe data as terminal without a deep-fetch, reducing cold-start GraphQL cost by ~80–90%. Combined with probe-driven polling, this makes running two Fabrik instances on a single token budget practical.
 >
 > **Anthropic auth namespace scrub (v0.0.77):** Every worker invocation's environment is scrubbed of the Anthropic/Claude-Code auth namespace by default (`ANTHROPIC_*` wildcard, plus an enumerated `CLAUDE_CODE_*` auth-selector list) — an ambient `ANTHROPIC_API_KEY` in the engine's environment can no longer silently redirect a stage from subscription billing to metered API billing. `FABRIK_ANTHROPIC_API_KEY` is the only supported opt-in for API billing; `apiKeyHelper` is refused outright, both at startup and per-invocation. See [Anthropic Auth Namespace Scrub & `apiKeyHelper` Refusal](docs/USER_GUIDE.md#anthropic-auth-namespace-scrub--apikeyhelper-refusal) in the User Guide.
+>
+> **GitHub Enterprise Server support (v0.0.78):** Fabrik can run against a GHES instance instead of github.com — pure endpoint/host configuration, no adapter layer. Set `--ghes-host` / `FABRIK_GHES_HOST` (or `ghes_host` in `.fabrik/config.yaml`) and Fabrik independently derives the REST (`/api/v3/...`) and GraphQL (`/api/graphql`) endpoints, points bare-clone URLs and commit noreply emails at your host, and propagates `GH_HOST` to every stage worker's `gh` CLI calls so they target the same instance. Absent any GHES configuration, behavior is unchanged. See [GitHub Enterprise Server Support](docs/USER_GUIDE.md#github-enterprise-server-support) in the User Guide.
 
 ### Webhook Mode (Optional)
 
@@ -161,14 +163,18 @@ requires auto-advance to be active):
    Gemini that self-trigger via webhook without appearing in the formal
    reviewer list). If the condition isn't met and the per-cycle timeout
    expires, the issue pauses with `fabrik:awaiting-input`.
-3. **Re-invocation:** When the gate clears and there are unresolved PR
-   review thread comments, Fabrik re-invokes the stage agent to address that
-   inline feedback and push a new commit, then waits for the next review
-   round. Reviews with no inline thread comments—including reviews with only
-   top-level review text (for example, bot approvals or summary-only
-   comments)—do not trigger re-invocation, and the issue advances normally.
-   After each re-invocation cycle, Fabrik posts a PR summary comment with a
-   per-thread footer listing how each inline review thread was addressed.
+3. **Re-invocation:** When the gate clears, Fabrik re-invokes the stage
+   agent to address unresolved inline PR review thread comments **and** the
+   top-level body of any review whose state is not `DISMISSED`/`PENDING`
+   (`CHANGES_REQUESTED`, `COMMENTED`, and `APPROVED` bodies are all treated
+   as potentially actionable — this is what lets a bot reviewer like Pruefer,
+   which submits its entire finding set as a `COMMENTED` review, get picked
+   up and addressed instead of silently dropped), then waits for the next
+   review round. Only a truly empty-bodied `APPROVED` review with no inline
+   comments has nothing to route, so re-invocation is skipped and the issue
+   advances normally. After each re-invocation cycle, Fabrik posts a PR
+   summary comment with a per-thread footer listing how each inline review
+   thread was addressed.
 
 > **Configuration:** `--max-review-cycles` / `FABRIK_MAX_REVIEW_CYCLES` (default `5`)
 > caps the number of re-invocation cycles per session. `--review-wait-timeout` /
@@ -217,6 +223,22 @@ appears on next TUI startup instead, so operator customizations are never silent
 overwritten. See
 [USER_GUIDE.md §Recovering from Wedged State](docs/USER_GUIDE.md#recovering-from-wedged-state)
 for the full escape-hatch procedure.
+
+### Clean-Stop Shutdown
+
+Sending `SIGINT` or `SIGTERM` (Ctrl-C on the bare CLI, or quitting the TUI)
+triggers a clean stop, not a kill: Fabrik stops admitting new work, pauses
+every in-flight issue durably (`fabrik:paused` + `fabrik:awaiting-input`,
+plus an audit comment naming the interrupted stage), and commits and pushes
+any uncommitted worktree progress before winding down. The entire drain —
+Claude worker kill-grace escalation plus the pause-write phase — is bounded
+by `--drain-deadline` (default 30 seconds), so Fabrik exits rather than
+hanging if something gets stuck. Force-quit remains available as an escape
+hatch: press Ctrl-C (or send SIGINT/SIGTERM) a second time while the clean
+stop is in progress to exit immediately with no further label writes or
+worktree commits. See
+[USER_GUIDE.md §Graceful Shutdown](docs/USER_GUIDE.md#graceful-shutdown)
+for the full sequence.
 
 ## Default Pipeline
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -534,6 +534,20 @@ fabrik --auto-upgrade</pre>
           Every worker invocation's environment is scrubbed of the Anthropic/Claude-Code auth namespace by default, so an ambient API key can never silently flip a stage from subscription to metered billing — with an explicit opt-in and an outright refusal of <code>apiKeyHelper</code>.
         </div>
       </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#github-enterprise-server-support" aria-label="GitHub Enterprise Server Support — open documentation">
+        <span class="feature-icon">🏢</span>
+        <div class="feature-title">GitHub Enterprise Server Support</div>
+        <div class="feature-desc">
+          Runs against a GHES instance instead of github.com via pure endpoint/host configuration — dual REST/GraphQL endpoints, host-aware git layer, and <code>GH_HOST</code> propagated to every stage worker's <code>gh</code> CLI calls.
+        </div>
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#graceful-shutdown" aria-label="Graceful Shutdown — open documentation">
+        <span class="feature-icon">🛑</span>
+        <div class="feature-title">Graceful Shutdown</div>
+        <div class="feature-desc">
+          SIGINT/SIGTERM triggers a clean stop, not a kill — in-flight issues are paused durably and worktree progress is committed and pushed, all within a bounded drain deadline. Force-quit stays available if it gets stuck.
+        </div>
+      </a>
     </div>
 
     <div class="factory-callout">


### PR DESCRIPTION
Closes #1535

Brings `README.md` and `docs/index.md` in line with `docs/USER_GUIDE.md` (confirmed already current) for v0.0.78's two headline features and one behavior correction.

**Changes:**

- **GitHub Enterprise Server support** — added a versioned callout to README's "How It Works" section (matching the existing v0.0.57/v0.0.58/v0.0.77 callout pattern) and a new feature card to `docs/index.md`'s `#features` grid. Both summarize dual REST/GraphQL endpoint derivation, host-aware git layer, `GH_HOST` propagation to stage workers, and `--ghes-host`/`FABRIK_GHES_HOST` config, linking to `docs/USER_GUIDE.md#github-enterprise-server-support`.
- **Clean-stop graceful shutdown** — added a new `### Clean-Stop Shutdown` section to README as a sibling of the existing "In-Place Restart" section (SIGHUP restart-in-place is a related but distinct mechanism from SIGINT/SIGTERM clean stop, per the issue spec), and a new, separate feature card in `docs/index.md` (rather than folding into the existing In-Place Restart card, to avoid conflating two different USER_GUIDE anchors under one title). Both link to `docs/USER_GUIDE.md#graceful-shutdown`.
- **Corrected stale Review-and-Fix description** — README previously stated that reviews with no inline thread comments never trigger re-invocation. As of #1045 (shipped in v0.0.78), the top-level body of any review whose state isn't `DISMISSED`/`PENDING` is also actionable (`CHANGES_REQUESTED`, `COMMENTED`, `APPROVED` alike) — this is what lets a bot reviewer like Pruefer, which submits its entire finding set as a single `COMMENTED` review, get picked up instead of silently dropped. The replacement wording mirrors `docs/USER_GUIDE.md`'s Phase 3 description and preserves the one case that genuinely still skips re-invocation: a truly empty-bodied `APPROVED` review with zero inline comments.

**Verification:**
- Both new anchors (`#github-enterprise-server-support`, `#graceful-shutdown`) confirmed to exist in `docs/USER_GUIDE.md` via grep.
- `bash scripts/generate-llms-full.sh` produces no diff (neither edited file is a bundle input, and no canonical doc changed) — confirms R6 was correctly a no-op.
- `go build` and `go vet ./...` both clean (docs-only change, but verified nothing else was disturbed).

**How to test:** Read through the new README sections and `docs/index.md` feature cards for accuracy against `docs/USER_GUIDE.md#github-enterprise-server-support` and `docs/USER_GUIDE.md#graceful-shutdown`; click through the new links to confirm they resolve.