### PR TITLE
fix(github): page REST collection fetchers instead of truncating at page one

### DIFF
--- a/github/comments.go
+++ b/github/comments.go
@@ -113,8 +113,7 @@ func (c *Client) UpdateIssueBody(owner, repo string, issueNumber int, body strin
 // "/pruefer review" comment commands and apply 👀/🚀 reaction idempotency.
 // Returns nil, nil on 404.
 func (c *Client) FetchIssueComments(owner, repo string, issueNumber int) ([]Comment, error) {
-	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments?per_page=100", c.baseURL, owner, repo, issueNumber)
-	var raw []struct {
+	type rawComment struct {
 		ID        int       `json:"id"`
 		Body      string    `json:"body"`
 		CreatedAt time.Time `json:"created_at"`
@@ -132,7 +131,15 @@ func (c *Client) FetchIssueComments(owner, repo string, issueNumber int) ([]Comm
 			Eyes     int `json:"eyes"`
 		} `json:"reactions"`
 	}
-	if err := c.restGetJSON(apiURL, &raw); err != nil {
+	// Paginated (#1539): GitHub returns issue comments oldest-first, so reading
+	// only page one drops the NEWEST comments on any thread past restPageSize —
+	// exactly the ones comment processing exists to react to. A busy issue would
+	// silently stop responding to new instructions.
+	raw, err := paginateREST[rawComment](c, fmt.Sprintf("comments for %s/%s#%d", owner, repo, issueNumber), func(page int) string {
+		return fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments?per_page=%d&page=%d",
+			c.baseURL, owner, repo, issueNumber, restPageSize, page)
+	})
+	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil, nil
 		}

--- a/github/labels.go
+++ b/github/labels.go
@@ -147,12 +147,18 @@ func (c *Client) RemoveLabelFromIssue(owner, repo string, issueNumber int, label
 // FetchLabelAppliedAt returns the time when labelName was last applied to the
 // given issue, using the GitHub issue events API. Returns time.Time{} (zero)
 // without error if the event is not found (fail-open: timeout will not fire).
-// Pages through all events to find the most recent application.
+// Pages through all events to find the most recent application, bounded by
+// restMaxPages (#1539 review finding 1) — this loop was previously
+// `for page := 1; ; page++` with no cap, so a server that never returns an
+// empty page would spin forever. The bound is fail-open, consistent with the
+// rest of this function: exhausting it returns the newest application seen so
+// far rather than an error, since a missed timestamp only means the timeout
+// this feeds does not fire — never a wrong action.
 func (c *Client) FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
 	var applied time.Time
-	for page := 1; ; page++ {
-		apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/events?per_page=100&page=%d",
-			c.baseURL, owner, repo, issueNumber, page)
+	for page := 1; page <= restMaxPages; page++ {
+		apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/events?per_page=%d&page=%d",
+			c.baseURL, owner, repo, issueNumber, restPageSize, page)
 		var events []struct {
 			Event     string `json:"event"`
 			CreatedAt string `json:"created_at"`

--- a/github/pagination_test.go
+++ b/github/pagination_test.go
@@ -1,0 +1,246 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Tests for #1539: REST collection fetchers must page until exhausted rather
+// than treating page one as the whole collection.
+//
+// Each multi-page test builds a fixture strictly larger than restPageSize and
+// asserts the LAST record is present — the first page alone can never satisfy
+// that, which is what makes these non-vacuous against the pre-fix code.
+
+// pagedArrayServer serves a bare JSON array endpoint that honours page/per_page.
+// items is the full collection; each element is marshalled as-is. It records how
+// many requests it served so single-page tests can assert no speculative probe.
+func pagedArrayServer(t *testing.T, path string, items []map[string]any, requests *int) (*httptest.Server, *Client) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		*requests++
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page < 1 {
+			page = 1
+		}
+		per, _ := strconv.Atoi(r.URL.Query().Get("per_page"))
+		if per < 1 {
+			per = 30
+		}
+		start := (page - 1) * per
+		if start > len(items) {
+			start = len(items)
+		}
+		end := start + per
+		if end > len(items) {
+			end = len(items)
+		}
+		if err := json.NewEncoder(w).Encode(items[start:end]); err != nil {
+			t.Errorf("encoding page %d: %v", page, err)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, NewClientWithBaseURL("test-token", srv.URL)
+}
+
+// TestFetchPRReviews_PagesBeyondFirstPage is the direct regression test for the
+// production failure: on handarbeit/fabrik#1256 the newest reviews sat past the
+// first page, so FetchPRReviews collapsed each author to a stale verdict and
+// Pruefer re-reviewed an unchanged head 315 times.
+func TestFetchPRReviews_PagesBeyondFirstPage(t *testing.T) {
+	const total = restPageSize*2 + 7 // 207: forces a third, short page
+	items := make([]map[string]any, 0, total)
+	for i := 0; i < total; i++ {
+		items = append(items, map[string]any{
+			"id":           i + 1,
+			"user":         map[string]any{"login": "bot"},
+			"state":        "COMMENTED",
+			"body":         "review",
+			"commit_id":    fmt.Sprintf("sha%03d", i),
+			"submitted_at": "2026-08-11T00:00:00Z",
+		})
+	}
+	reqs := 0
+	_, c := pagedArrayServer(t, "/repos/o/r/pulls/1/reviews", items, &reqs)
+
+	got, err := c.FetchPRReviews("o", "r", 1)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	// All reviews share one author, so the collapse keeps exactly one entry —
+	// and it must be the LAST review, not the last one on page 1.
+	if len(got) != 1 {
+		t.Fatalf("expected 1 collapsed review, got %d", len(got))
+	}
+	wantSHA := fmt.Sprintf("sha%03d", total-1)
+	if got[0].CommitID != wantSHA {
+		t.Errorf("collapsed to commit %q, want %q — the newest review was not seen, "+
+			"which is exactly the truncation that drove the #1256 re-review loop", got[0].CommitID, wantSHA)
+	}
+	if reqs != 3 {
+		t.Errorf("served %d requests, want 3 (two full pages + one short)", reqs)
+	}
+}
+
+// TestFetchPRReviews_SinglePageIssuesOneRequest pins R5/A4: a collection that
+// fits on one page must not cost a speculative second round trip.
+func TestFetchPRReviews_SinglePageIssuesOneRequest(t *testing.T) {
+	items := []map[string]any{{
+		"id": 1, "user": map[string]any{"login": "alice"},
+		"state": "APPROVED", "commit_id": "abc", "submitted_at": "2026-08-11T00:00:00Z",
+	}}
+	reqs := 0
+	_, c := pagedArrayServer(t, "/repos/o/r/pulls/1/reviews", items, &reqs)
+
+	if _, err := c.FetchPRReviews("o", "r", 1); err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if reqs != 1 {
+		t.Errorf("served %d requests for a single-page collection, want exactly 1", reqs)
+	}
+}
+
+// TestFetchIssueComments_PagesBeyondFirstPage covers the comment-processing
+// consequence: GitHub returns issue comments oldest-first, so truncation drops
+// the newest — the ones Fabrik reacts to.
+func TestFetchIssueComments_PagesBeyondFirstPage(t *testing.T) {
+	const total = restPageSize + 5
+	items := make([]map[string]any, 0, total)
+	for i := 0; i < total; i++ {
+		items = append(items, map[string]any{
+			"id":         i + 1,
+			"body":       fmt.Sprintf("comment-%d", i),
+			"created_at": "2026-08-11T00:00:00Z",
+			"user":       map[string]any{"login": "human"},
+		})
+	}
+	reqs := 0
+	_, c := pagedArrayServer(t, "/repos/o/r/issues/7/comments", items, &reqs)
+
+	got, err := c.FetchIssueComments("o", "r", 7)
+	if err != nil {
+		t.Fatalf("FetchIssueComments: %v", err)
+	}
+	if len(got) != total {
+		t.Fatalf("got %d comments, want %d", len(got), total)
+	}
+	want := fmt.Sprintf("comment-%d", total-1)
+	if got[len(got)-1].Body != want {
+		t.Errorf("last comment body = %q, want %q — newest comments were truncated away", got[len(got)-1].Body, want)
+	}
+}
+
+// TestListOpenPRs_PagesBeyondFirstPage replaces the previous "warn at exactly
+// 100" behavior with genuine completeness.
+func TestListOpenPRs_PagesBeyondFirstPage(t *testing.T) {
+	const total = restPageSize + 3
+	items := make([]map[string]any, 0, total)
+	for i := 0; i < total; i++ {
+		items = append(items, map[string]any{
+			"number": i + 1,
+			"title":  fmt.Sprintf("pr-%d", i),
+			"state":  "open",
+			"user":   map[string]any{"login": "someone"},
+			"head":   map[string]any{"sha": "s", "ref": "b"},
+			"base":   map[string]any{"ref": "main"},
+		})
+	}
+	reqs := 0
+	_, c := pagedArrayServer(t, "/repos/o/r/pulls", items, &reqs)
+
+	got, err := c.ListOpenPRs("o", "r")
+	if err != nil {
+		t.Fatalf("ListOpenPRs: %v", err)
+	}
+	if len(got) != total {
+		t.Fatalf("got %d open PRs, want %d", len(got), total)
+	}
+	if got[len(got)-1].Number != total {
+		t.Errorf("last PR number = %d, want %d", got[len(got)-1].Number, total)
+	}
+}
+
+// checkRunsServer serves the object-shaped check-runs endpoint. reportedTotal is
+// what total_count claims, independent of how many runs are actually served, so
+// a mismatch can be simulated.
+func checkRunsServer(t *testing.T, runs []map[string]any, reportedTotal int) *Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/o/r/commits/sha1/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page < 1 {
+			page = 1
+		}
+		per, _ := strconv.Atoi(r.URL.Query().Get("per_page"))
+		if per < 1 {
+			per = 30
+		}
+		start := (page - 1) * per
+		if start > len(runs) {
+			start = len(runs)
+		}
+		end := start + per
+		if end > len(runs) {
+			end = len(runs)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"total_count": reportedTotal,
+			"check_runs":  runs[start:end],
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return NewClientWithBaseURL("test-token", srv.URL)
+}
+
+// TestFetchCheckRuns_PagesBeyondDefaultPageSize is the CI-gate consequence: the
+// pre-fix code sent no per_page at all, so GitHub's default of 30 applied and a
+// commit with more checks read as a complete set.
+func TestFetchCheckRuns_PagesBeyondDefaultPageSize(t *testing.T) {
+	const total = restPageSize + 11
+	runs := make([]map[string]any, 0, total)
+	for i := 0; i < total; i++ {
+		runs = append(runs, map[string]any{
+			"id": i + 1, "name": fmt.Sprintf("check-%d", i),
+			"status": "completed", "conclusion": "success",
+		})
+	}
+	c := checkRunsServer(t, runs, total)
+
+	got, err := c.FetchCheckRuns("o", "r", "sha1")
+	if err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	if len(got) != total {
+		t.Fatalf("got %d check runs, want %d — a CI verdict computed from this set would be based on an incomplete view", len(got), total)
+	}
+	if got[len(got)-1].Name != fmt.Sprintf("check-%d", total-1) {
+		t.Errorf("last check run = %q, want check-%d", got[len(got)-1].Name, total-1)
+	}
+}
+
+// TestFetchCheckRuns_TotalCountMismatchIsAnError pins R3/A2: an incomplete set
+// must fail loudly rather than produce a verdict the caller cannot distinguish
+// from a complete one.
+func TestFetchCheckRuns_TotalCountMismatchIsAnError(t *testing.T) {
+	runs := []map[string]any{
+		{"id": 1, "name": "only-one", "status": "completed", "conclusion": "success"},
+	}
+	c := checkRunsServer(t, runs, 5) // server claims 5, serves 1
+
+	_, err := c.FetchCheckRuns("o", "r", "sha1")
+	if err == nil {
+		t.Fatal("expected an error when total_count exceeds the collected set, got nil — " +
+			"an incomplete check-run list must never be returned as if complete")
+	}
+	if !strings.Contains(err.Error(), "collected 1 of 5") {
+		t.Errorf("error %q should name the collected and reported counts", err)
+	}
+}

--- a/github/pagination_test.go
+++ b/github/pagination_test.go
@@ -107,6 +107,38 @@ func TestFetchPRReviews_SinglePageIssuesOneRequest(t *testing.T) {
 	}
 }
 
+// TestFetchPRReviews_ExactlyOnePageFullStillTerminates pins the boundary the
+// other tests step over: a collection of exactly restPageSize records is
+// indistinguishable from a full page with more behind it, so the loop must
+// fetch one more page, see it empty, and stop — returning the complete set
+// rather than looping or dropping records.
+func TestFetchPRReviews_ExactlyOnePageFullStillTerminates(t *testing.T) {
+	items := make([]map[string]any, 0, restPageSize)
+	for i := 0; i < restPageSize; i++ {
+		items = append(items, map[string]any{
+			"id":           i + 1,
+			"user":         map[string]any{"login": fmt.Sprintf("author-%d", i)},
+			"state":        "COMMENTED",
+			"commit_id":    fmt.Sprintf("sha%03d", i),
+			"submitted_at": "2026-08-11T00:00:00Z",
+		})
+	}
+	reqs := 0
+	_, c := pagedArrayServer(t, "/repos/o/r/pulls/1/reviews", items, &reqs)
+
+	got, err := c.FetchPRReviews("o", "r", 1)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	// Distinct authors, so the collapse keeps one entry each.
+	if len(got) != restPageSize {
+		t.Fatalf("got %d reviews, want %d", len(got), restPageSize)
+	}
+	if reqs != 2 {
+		t.Errorf("served %d requests, want 2 (one full page + one empty page proving the end)", reqs)
+	}
+}
+
 // TestFetchIssueComments_PagesBeyondFirstPage covers the comment-processing
 // consequence: GitHub returns issue comments oldest-first, so truncation drops
 // the newest — the ones Fabrik reacts to.
@@ -164,6 +196,37 @@ func TestListOpenPRs_PagesBeyondFirstPage(t *testing.T) {
 	}
 	if got[len(got)-1].Number != total {
 		t.Errorf("last PR number = %d, want %d", got[len(got)-1].Number, total)
+	}
+}
+
+// TestFetchPRFiles_BoundedAgainstEndlessPages covers the hang vector closed in
+// the #1539 review: FetchPRFiles predates paginateREST and looped
+// `for page := 1; ; page++` with no cap, so a server that never returns a short
+// page spun forever while the result slice grew without bound. Verified to be
+// non-vacuous by removing the bound — without it this test does not fail, it
+// hangs, which is precisely the defect.
+func TestFetchPRFiles_BoundedAgainstEndlessPages(t *testing.T) {
+	full := make([]map[string]any, restPageSize)
+	for i := range full {
+		full[i] = map[string]any{"filename": fmt.Sprintf("file%d.go", i)}
+	}
+	var pages int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages++
+		json.NewEncoder(w).Encode(full) // always a full page: never terminates on its own
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("test-token", srv.URL)
+	files, err := c.FetchPRFiles("o", "r", 1)
+	if err == nil {
+		t.Fatalf("expected an error when the endpoint never returns a short page, got %d files and nil error", len(files))
+	}
+	if files != nil {
+		t.Errorf("expected nil results alongside the error, got %d files", len(files))
+	}
+	if pages != restMaxPages {
+		t.Errorf("served %d pages, want the restMaxPages bound of %d", pages, restMaxPages)
 	}
 }
 

--- a/github/prs.go
+++ b/github/prs.go
@@ -72,8 +72,7 @@ func (c *Client) FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, 
 // first-seen or not — rather than being treated as a verdict by omission.
 // Returns nil, nil on 404.
 func (c *Client) FetchPRReviews(owner, repo string, prNumber int) ([]PRReview, error) {
-	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews?per_page=100", c.baseURL, owner, repo, prNumber)
-	var raw []struct {
+	type rawReview struct {
 		ID   int `json:"id"`
 		User *struct {
 			Login string `json:"login"`
@@ -83,7 +82,16 @@ func (c *Client) FetchPRReviews(owner, repo string, prNumber int) ([]PRReview, e
 		CommitID    string `json:"commit_id"`
 		SubmittedAt string `json:"submitted_at"`
 	}
-	if err := c.restGetJSON(apiURL, &raw); err != nil {
+	// Paginated (#1539): the collapse below keeps the LAST eligible review per
+	// author, so reading only page one silently pins every author's verdict to
+	// whatever they last said within the first restPageSize reviews. On a
+	// long-lived PR that is an arbitrarily stale verdict — it drove a 315-review
+	// re-review loop in Pruefer and reaches the authoritative landing gate.
+	raw, err := paginateREST[rawReview](c, fmt.Sprintf("PR #%d reviews", prNumber), func(page int) string {
+		return fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews?per_page=%d&page=%d",
+			c.baseURL, owner, repo, prNumber, restPageSize, page)
+	})
+	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil, nil
 		}
@@ -575,27 +583,59 @@ type CheckRun struct {
 }
 
 // FetchCheckRuns retrieves check runs for a given commit SHA via the REST API.
+//
+// Paginated and total_count-verified (#1539). This was the worst of the
+// truncating fetchers: it sent no per_page at all, so GitHub's default of 30
+// applied, and it discarded the total_count the endpoint reports — a commit with
+// more than 30 check runs therefore read as a complete, potentially all-green
+// set. Every CI gate decision (checkCIGate, the merge-train trial classifier)
+// rests on this list, so a truncated read can advance an item whose remaining
+// checks are still pending or failing.
+//
+// The count check is deliberately an error rather than a warning: a CI verdict
+// computed from a known-incomplete set is worse than no verdict, since the
+// caller cannot tell the two apart.
 func (c *Client) FetchCheckRuns(owner, repo, sha string) ([]CheckRun, error) {
-	apiURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/check-runs", c.baseURL, owner, repo, sha)
-	var raw struct {
-		CheckRuns []struct {
-			ID         int64  `json:"id"`
-			Name       string `json:"name"`
-			Status     string `json:"status"`
-			Conclusion string `json:"conclusion"`
-			Output     struct {
-				Summary string `json:"summary"`
-				Text    string `json:"text"`
-			} `json:"output"`
-			DetailsURL string `json:"details_url"`
-			HTMLURL    string `json:"html_url"`
-		} `json:"check_runs"`
+	type rawCheckRun struct {
+		ID         int64  `json:"id"`
+		Name       string `json:"name"`
+		Status     string `json:"status"`
+		Conclusion string `json:"conclusion"`
+		Output     struct {
+			Summary string `json:"summary"`
+			Text    string `json:"text"`
+		} `json:"output"`
+		DetailsURL string `json:"details_url"`
+		HTMLURL    string `json:"html_url"`
 	}
-	if err := c.restGetJSON(apiURL, &raw); err != nil {
-		return nil, fmt.Errorf("fetching check runs for %s: %w", sha, err)
+	var all []rawCheckRun
+	totalCount := -1
+	for page := 1; page <= restMaxPages; page++ {
+		apiURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/check-runs?per_page=%d&page=%d",
+			c.baseURL, owner, repo, sha, restPageSize, page)
+		var raw struct {
+			TotalCount int           `json:"total_count"`
+			CheckRuns  []rawCheckRun `json:"check_runs"`
+		}
+		if err := c.restGetJSON(apiURL, &raw); err != nil {
+			return nil, fmt.Errorf("fetching check runs for %s: %w", sha, err)
+		}
+		totalCount = raw.TotalCount
+		all = append(all, raw.CheckRuns...)
+		if len(raw.CheckRuns) < restPageSize {
+			break
+		}
+		if page == restMaxPages {
+			return nil, fmt.Errorf("fetching check runs for %s: exceeded %d pages without reaching the end — refusing to return a truncated result",
+				sha, restMaxPages)
+		}
 	}
-	out := make([]CheckRun, len(raw.CheckRuns))
-	for i, cr := range raw.CheckRuns {
+	if totalCount >= 0 && len(all) != totalCount {
+		return nil, fmt.Errorf("fetching check runs for %s: collected %d of %d reported check runs — refusing to return an incomplete set",
+			sha, len(all), totalCount)
+	}
+	out := make([]CheckRun, len(all))
+	for i, cr := range all {
 		out[i] = CheckRun{
 			ID:            cr.ID,
 			Name:          cr.Name,
@@ -791,12 +831,11 @@ func labelNames(labels []rawLabel) []string {
 
 // ListOpenPRs returns all open pull requests for a repository (draft and
 // non-draft), including author and label metadata needed for Pruefer's PR
-// selection logic. Capped at 100 results (GitHub's max per_page); a warning
-// is logged (not silently truncated) when exactly 100 are returned, since
-// more open PRs may exist.
+// selection logic. Pages until exhausted (#1539) — it previously returned only
+// the first 100 and logged a warning, so a repo with more open PRs than that
+// had the remainder invisible to PR selection and merge-train discovery.
 func (c *Client) ListOpenPRs(owner, repo string) ([]PRDetails, error) {
-	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls?state=open&per_page=100", c.baseURL, owner, repo)
-	var raw []struct {
+	type rawPR struct {
 		Number int    `json:"number"`
 		Title  string `json:"title"`
 		State  string `json:"state"`
@@ -814,11 +853,12 @@ func (c *Client) ListOpenPRs(owner, repo string) ([]PRDetails, error) {
 			Ref string `json:"ref"`
 		} `json:"base"`
 	}
-	if err := c.restGetJSON(apiURL, &raw); err != nil {
+	raw, err := paginateREST[rawPR](c, fmt.Sprintf("open PRs for %s/%s", owner, repo), func(page int) string {
+		return fmt.Sprintf("%s/repos/%s/%s/pulls?state=open&per_page=%d&page=%d",
+			c.baseURL, owner, repo, restPageSize, page)
+	})
+	if err != nil {
 		return nil, fmt.Errorf("listing open PRs for %s/%s: %w", owner, repo, err)
-	}
-	if len(raw) == 100 {
-		logf(0, "prs", "ListOpenPRs %s/%s: received exactly 100 results — more open PRs may exist (pagination not implemented)\n", owner, repo)
 	}
 	out := make([]PRDetails, len(raw))
 	for i, pr := range raw {

--- a/github/prs.go
+++ b/github/prs.go
@@ -609,7 +609,7 @@ func (c *Client) FetchCheckRuns(owner, repo, sha string) ([]CheckRun, error) {
 		HTMLURL    string `json:"html_url"`
 	}
 	var all []rawCheckRun
-	totalCount := -1
+	totalCount := 0
 	for page := 1; page <= restMaxPages; page++ {
 		apiURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/check-runs?per_page=%d&page=%d",
 			c.baseURL, owner, repo, sha, restPageSize, page)
@@ -630,7 +630,16 @@ func (c *Client) FetchCheckRuns(owner, repo, sha string) ([]CheckRun, error) {
 				sha, restMaxPages)
 		}
 	}
-	if totalCount >= 0 && len(all) != totalCount {
+	// Only cross-check when the server actually reported a positive total.
+	// Guarding on >= 0 (as this first did) makes an ABSENT total_count — which
+	// decodes to 0 — indistinguishable from a genuine zero, so any deployment
+	// that omits the field would hard-fail every CI gate on every commit. Real
+	// github.com always sends it (see testdata/recordings/fetch_check_runs.json,
+	// a captured response), but v0.0.78 added GHES support and no equivalent
+	// recording exists for it, so this fails open on absence and closed only on
+	// a real, positive disagreement. A server reporting 0 while returning runs
+	// is incoherent and not worth defending against.
+	if totalCount > 0 && len(all) != totalCount {
 		return nil, fmt.Errorf("fetching check runs for %s: collected %d of %d reported check runs — refusing to return an incomplete set",
 			sha, len(all), totalCount)
 	}
@@ -898,9 +907,15 @@ func (c *Client) FetchPRDiff(owner, repo string, prNumber int) (string, error) {
 // page, stop on an empty page. Returns nil, nil on 404.
 func (c *Client) FetchPRFiles(owner, repo string, prNumber int) ([]string, error) {
 	var out []string
-	for page := 1; ; page++ {
-		apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files?per_page=100&page=%d",
-			c.baseURL, owner, repo, prNumber, page)
+	// Bounded by restMaxPages (#1539 review finding 1). This loop predates
+	// paginateREST and was written as `for page := 1; ; page++` with no cap, so a
+	// server that never returns an empty page — a misconfigured proxy, a GHES
+	// bug, a hostile endpoint — spins forever while `out` grows without bound.
+	// Not converted to paginateREST because the accumulation projects to a field
+	// rather than collecting whole records; the bound is what actually matters.
+	for page := 1; page <= restMaxPages; page++ {
+		apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files?per_page=%d&page=%d",
+			c.baseURL, owner, repo, prNumber, restPageSize, page)
 		var raw []struct {
 			Filename string `json:"filename"`
 		}
@@ -910,14 +925,15 @@ func (c *Client) FetchPRFiles(owner, repo string, prNumber int) ([]string, error
 			}
 			return nil, fmt.Errorf("fetching files for PR #%d: %w", prNumber, err)
 		}
-		if len(raw) == 0 {
-			break
-		}
 		for _, f := range raw {
 			out = append(out, f.Filename)
 		}
+		if len(raw) < restPageSize {
+			return out, nil
+		}
 	}
-	return out, nil
+	return nil, fmt.Errorf("fetching files for PR #%d: exceeded %d pages without reaching the end — refusing to return a truncated result",
+		prNumber, restMaxPages)
 }
 
 // ReviewEvent selects the wire "event" value SubmitPRReview submits. Its

--- a/github/pruefer_extensions_test.go
+++ b/github/pruefer_extensions_test.go
@@ -161,8 +161,13 @@ func TestFetchPRFiles_MultiPage(t *testing.T) {
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	if len(seenPages) != 3 {
-		t.Errorf("expected 3 page requests (100, then 1, then empty stop), got %d: %v", len(seenPages), seenPages)
+	// Was 3 before #1539: the loop used to stop only on an *empty* page, so a
+	// short second page still cost a third request to confirm the end. It now
+	// stops on any page shorter than restPageSize — same data, one fewer round
+	// trip, and consistent with paginateREST. The count is asserted rather than
+	// ignored because it is the only way to tell the two termination rules apart.
+	if len(seenPages) != 2 {
+		t.Errorf("expected 2 page requests (100, then a short page ending it), got %d: %v", len(seenPages), seenPages)
 	}
 }
 

--- a/github/pruefer_extensions_test.go
+++ b/github/pruefer_extensions_test.go
@@ -420,16 +420,19 @@ func TestListOpenPRs(t *testing.T) {
 	}
 }
 
-func TestListOpenPRs_WarnsAtCap(t *testing.T) {
-	var warned bool
-	Logf = func(issueNumber int, tag, format string, args ...any) {
-		if tag == "prs" {
-			warned = true
-		}
-	}
-	defer func() { Logf = nil }()
-
-	entries := make([]map[string]interface{}, 100)
+// TestListOpenPRs_NeverSilentlyTruncates supersedes the former
+// TestListOpenPRs_WarnsAtCap (#1539). That test pinned the old contract — stop
+// at 100 results and log a warning — which pagination replaces outright, so its
+// assertion could not survive the fix. Its underlying intent, "a capped read is
+// never presented as a complete one", is preserved here and strengthened: the
+// call must now fail rather than return a short list.
+//
+// The fixture is a server that ignores `page` and returns a full page forever —
+// the exact pathology restMaxPages exists to bound. Completeness on a
+// well-behaved multi-page server is covered by
+// TestListOpenPRs_PagesBeyondFirstPage in pagination_test.go.
+func TestListOpenPRs_NeverSilentlyTruncates(t *testing.T) {
+	entries := make([]map[string]interface{}, restPageSize)
 	for i := range entries {
 		entries[i] = map[string]interface{}{
 			"number": i + 1, "state": "open",
@@ -437,21 +440,24 @@ func TestListOpenPRs_WarnsAtCap(t *testing.T) {
 			"head": map[string]string{"sha": "sha", "ref": "ref"},
 		}
 	}
+	var pages int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages++
 		json.NewEncoder(w).Encode(entries)
 	}))
 	defer srv.Close()
 
 	c := NewClientWithBaseURL("token", srv.URL)
 	prs, err := c.ListOpenPRs("owner", "repo")
-	if err != nil {
-		t.Fatalf("ListOpenPRs: %v", err)
+	if err == nil {
+		t.Fatalf("expected an error when the endpoint never returns a short page, got %d PRs and nil error — "+
+			"a bounded read must fail loudly rather than hand back a truncated set", len(prs))
 	}
-	if len(prs) != 100 {
-		t.Fatalf("expected 100 PRs, got %d", len(prs))
+	if prs != nil {
+		t.Errorf("expected nil results alongside the error, got %d PRs", len(prs))
 	}
-	if !warned {
-		t.Error("expected a warning to be logged when exactly 100 PRs are returned")
+	if pages != restMaxPages {
+		t.Errorf("served %d pages, want the restMaxPages bound of %d", pages, restMaxPages)
 	}
 }
 

--- a/github/rest.go
+++ b/github/rest.go
@@ -250,10 +250,18 @@ const restMaxPages = 100
 // landing gate, where a stale verdict changes a merge decision.
 //
 // Termination: a page shorter than restPageSize is the last one, so a collection
-// that fits on a single page costs exactly one request (no speculative probe).
+// of fewer than restPageSize records costs exactly one request. A collection of
+// exactly restPageSize (or any exact multiple) is indistinguishable from a full
+// page with more behind it, and costs one additional request that comes back
+// empty — the price of not probing speculatively in the common case.
+//
 // Hitting restMaxPages returns an error rather than the accumulated prefix —
 // silently degrading into a short list is precisely the defect being fixed, so
-// the bound fails loud.
+// the bound fails loud. Known limitation: a genuine collection of exactly
+// restMaxPages*restPageSize records is indistinguishable from a server that
+// never returns a short page, and is reported as the latter. At 10,000 records
+// that is far outside any real review list, comment thread, or open-PR set, and
+// erring toward "refuse" beats erring toward a silent truncation.
 func paginateREST[T any](c *Client, what string, urlFor func(page int) string) ([]T, error) {
 	var all []T
 	for page := 1; page <= restMaxPages; page++ {

--- a/github/rest.go
+++ b/github/rest.go
@@ -225,3 +225,47 @@ func (c *Client) restDelete(url string) error {
 	_, _, err := c.do("DELETE", url, nil)
 	return err
 }
+
+// restPageSize is the page size every paginated REST fetcher requests. GitHub
+// caps per_page at 100 for the endpoints used here; asking for more is silently
+// clamped, so this is the largest page we can actually get.
+const restPageSize = 100
+
+// restMaxPages bounds paginateREST so a server that never returns a short page
+// cannot spin forever. 100 pages × 100 items = 10,000 records, far beyond any
+// realistic PR review list, issue thread, or open-PR set. Reaching it is
+// treated as an error rather than a truncated result — see paginateREST.
+const restMaxPages = 100
+
+// paginateREST accumulates every page of a GitHub REST collection endpoint that
+// returns a bare JSON array. urlFor builds the request URL for a 1-based page
+// number and must include per_page=restPageSize.
+//
+// Why this exists (#1539): every caller here previously issued a single request
+// and treated page one as the whole collection. Past the boundary that returns a
+// partial slice with no error and no signal — indistinguishable from a complete
+// answer. On handarbeit/fabrik#1256 that let Pruefer re-review an unchanged head
+// 315 times, because FetchPRReviews could not see the reviews it had just
+// submitted; the same truncation reaches engine/reviews.go's authoritative
+// landing gate, where a stale verdict changes a merge decision.
+//
+// Termination: a page shorter than restPageSize is the last one, so a collection
+// that fits on a single page costs exactly one request (no speculative probe).
+// Hitting restMaxPages returns an error rather than the accumulated prefix —
+// silently degrading into a short list is precisely the defect being fixed, so
+// the bound fails loud.
+func paginateREST[T any](c *Client, what string, urlFor func(page int) string) ([]T, error) {
+	var all []T
+	for page := 1; page <= restMaxPages; page++ {
+		var chunk []T
+		if err := c.restGetJSON(urlFor(page), &chunk); err != nil {
+			return nil, err
+		}
+		all = append(all, chunk...)
+		if len(chunk) < restPageSize {
+			return all, nil
+		}
+	}
+	return nil, fmt.Errorf("fetching %s: exceeded %d pages (%d records) without reaching the end — refusing to return a truncated result",
+		what, restMaxPages, restMaxPages*restPageSize)
+}


### PR DESCRIPTION
Closes #1539

## What this fixes

Four REST collection fetchers in `github/` issued a single request and treated page one as the whole collection — returning a partial set with no error and no truncation signal, indistinguishable from a complete answer.

**This is a live production failure, not a hypothetical.** Pruefer re-reviewed `handarbeit/fabrik#1256` **315 times** against an unchanged head, roughly every 3.5 minutes for days, until the daemon was killed manually. Its own diagnostic logging shows the frozen comparison:

```
[pr#1256 select] head-SHA check for handarbeit-pruefer[bot]:
    compared=a05573dc…   ← the PR's actual head
    found=2885fb75…      ← newest review it can see
    outcome=proceeding
```

The review histogram explains `found`: 34 distinct SHAs (one review each) followed by a 71-long run of `2885fb75` puts review #100 — the last entry on a `per_page=100` response — inside that stale block. **It is a ratchet, not a plateau:** every spurious review grows the collection and pushes the true latest further beyond the boundary, so past ~100 reviews the condition is permanent and self-reinforcing.

`FetchPRReviews` is not Pruefer-only — `engine/reviews.go` calls it at lines 137, 771, 1263 and 1394, including `reviewGateBlocksLanding`. On a PR past 100 reviews, Fabrik's **authoritative landing gate** made its merge decision against a stale verdict. That is merge correctness, not just wasted spend.

## Changes

**`paginateREST`** (`github/rest.go`) — one shared generic helper rather than a fourth hand-rolled page loop (`FetchLabelAppliedAt` and `FetchPRFiles` already have their own). A page shorter than `restPageSize` terminates, so a single-page collection still costs exactly one request — no speculative probe. Reaching `restMaxPages` (100 pages / 10,000 records) returns an **error**, not the accumulated prefix: silently degrading into a short list is precisely the defect being fixed.

| function | before | after |
|---|---|---|
| `FetchPRReviews` | `per_page=100`, one page | paged; the collapse now sees each author's genuine latest review |
| `FetchIssueComments` | `per_page=100`, one page | paged; comments are oldest-first, so truncation dropped the **newest** — the ones comment processing exists to react to |
| `ListOpenPRs` | `per_page=100` + warn at exactly 100 | paged; the warning is now unnecessary |
| `FetchCheckRuns` | **no `per_page`** (GitHub default 30), `total_count` discarded | paged **and** verified against `total_count`, erroring on mismatch |

`FetchCheckRuns` was the worst of the four. Every CI gate decision (`checkCIGate`, the merge-train trial classifier) rests on that list, so a commit with >30 check runs could read as a complete, all-green set. The count check is an error rather than a warning because a verdict computed from a known-incomplete set is worse than no verdict — the caller cannot tell them apart.

**Deliberately unchanged:** `ListPRs` (documented intentional "50 most-recently-updated" cap for idempotency detection) and `FetchPRReviewRequests` (object response whose `users` array realistically stays under one page). Both should change only with evidence.

## A replaced test

`TestListOpenPRs_WarnsAtCap` pinned the old contract — stop at 100 and log a warning — which this change removes, so its assertion could not survive. Rather than delete it, it is superseded by **`TestListOpenPRs_NeverSilentlyTruncates`**, preserving the underlying intent ("a capped read is never presented as a complete one") and strengthening it to require an error. Its fixture — a server that ignores `page` and returns a full page forever — is exactly the pathology `restMaxPages` bounds, which nothing else covered.

## Non-vacuity (A5)

Every new test was verified red against neutralized code, with the fix reverted one at a time:

| neutralization | observed failure |
|---|---|
| `FetchPRReviews` back to single-page | `collapsed to commit "sha099", want "sha206"` + `served 1 requests, want 3` |
| `total_count` check wrapped in `if false &&` | `expected an error when total_count exceeds the collected set, got nil` |
| `FetchCheckRuns` `per_page` dropped (default 30) | `collected 30 of 111 reported check runs` — caught by the independent `total_count` guard |
| `FetchIssueComments` back to single-page | `got 100 comments, want 105` |
| `ListOpenPRs` back to single-page | `got 100 open PRs, want 103` |

The third is worth noting: with pagination broken, the `total_count` verification caught it independently. The two protections are not redundant.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` clean on all touched files.
- `go test -race ./...` fully green.
- Pre-existing `TestFetchCheckRuns_Success` / `TestFetchCheckRuns_Empty` pass unmodified.

One unrelated pre-existing `gofmt` drift exists in `github/types.go` on `main` (alignment in `MergeQueueEntry`). Deliberately left alone rather than mixed into this change.

## Note on #1496

#1496 is **not** a fix for this. It corrected the supersession rule for `COMMENTED` reviews — the right rule, applied to a truncated list. Pruefer was running a binary containing #1496 throughout the 315-review loop described above.
