### PR TITLE
fix(engine): ensureRepoReady singleflight elects a second clone owner on failure, duplicating the clone and its comment

### DIFF
--- a/adrs/1543-clone-inflight-retry-boundary.md
+++ b/adrs/1543-clone-inflight-retry-boundary.md
@@ -353,3 +353,45 @@ attempted... has NOT been paused"). Covered by
 case) alongside the existing `TestRecordMergeTrainCloneSkip_MessageNamesPinnedOwner`
 (anchor-is-bystander case, now also asserting the bystander framing is
 present).
+
+### Correction: escalate exactly once per episode, not once per `MaxRetries` skips
+
+A third review pass (human, this time) traced through the consequence of
+removing `pauseIssue` (the first correction above): in this codebase's
+established escalate-after-`MaxRetries` convention (ADR-060, ADR-061,
+ADR-1097, ADR-1422), `fabrik:paused` *is* the idempotency guard — it's
+applied once, the comment rides along, and the label's presence stops the
+path repeating on a later poll. Once the anchor is deliberately never
+paused, that guard no longer exists, but the original implementation still
+reset `mergeTrainCloneSkipCounts[repoKey]` to `0` immediately after
+escalating — intended (per its own comment) to give "a future streak... a
+fresh budget." On a **persistent** wedge — the only kind this mechanism
+exists for; it stays wedged until an operator clears the pinned owner's
+`fabrik:paused` or the engine restarts — the counter simply climbs back up
+to `MaxRetries` and escalates again, indefinitely, once every `MaxRetries`
+skips, sprayed across whichever item happens to be anchor at that moment
+(review feedback on this PR; the interaction was flagged as something that
+should have been caught when escalation was first requested).
+`TestRecordMergeTrainCloneSkip_ResetAfterEscalationGivesFreshBudget` had
+certified exactly this behavior as a feature — it only proved the *next*
+call didn't re-escalate, not that the call after that didn't either.
+
+The fix drops the reset entirely and changes the escalation condition from
+`count >= MaxRetries` to `count == MaxRetries`: the counter still climbs on
+every subsequent skip of a persistent wedge, but since it only ever equals
+`MaxRetries` once per monotonically-increasing streak, the comment fires
+exactly once, and every later skip falls through silently to the existing
+per-skip log line. `resetMergeTrainCloneSkip` — already called whenever
+`ensureRepoReady` succeeds for the repo — is what now delivers the
+originally-intended "fresh budget for a future streak": deleting the map
+entry on recovery is what makes a genuinely new episode start its own count
+from `1` and earn its own single escalation when it reaches `MaxRetries` in
+turn, without needing an in-band reset inside the escalation branch itself.
+Renamed the test to `TestRecordMergeTrainCloneSkip_NoRepeatEscalationOnPersistentWedge`
+(asserts exactly one comment across ten consecutive skips past `MaxRetries`,
+with no intervening success) and added
+`TestRecordMergeTrainCloneSkip_NewEpisodeAfterRecoveryEscalatesAgain`
+(asserts a second, independent escalation after an intervening
+`resetMergeTrainCloneSkip`). Verified non-vacuous by reintroducing the old
+reset-after-escalate behavior and confirming the persistent-wedge test fails
+5/5, then reverting.

--- a/adrs/1543-clone-inflight-retry-boundary.md
+++ b/adrs/1543-clone-inflight-retry-boundary.md
@@ -1,0 +1,234 @@
+# ADR 1543: Identity-Gated Retry Boundary for `cloneInFlight` Failures
+
+**Status:** Accepted
+
+**Supersedes (in part):** ADR 022 (Per-Repo Singleflight Coordination for Bare Clones) — specifically its "Failure-path cleanup" and "Ordering invariant on failure" sections, which describe the buggy protocol this ADR replaces. ADR 022's election protocol, waiter-blocking design, and success-path handling are unchanged and remain in force.
+
+## Context
+
+ADR 022 introduced `cloneInFlight`, a `sync.Map`-based singleflight mechanism so
+concurrent callers for the same repo elect one clone owner instead of racing
+`git clone --bare` into the same destination directory. On failure, ADR 022's
+protocol was:
+
+```go
+close(call.done)                       // release waiters
+e.cloneInFlight.Delete(nameWithOwner)  // <-- entry gone here
+msg := ...
+e.pauseIssue(item, msg, ...)           // AddComment happens here
+...
+return ErrSkipItem
+```
+
+ADR 022 justified the `Delete` as enabling "future poll cycles (after the user
+removes `fabrik:paused`)" to retry, and asserted the ordering invariant was safe
+because "a re-entrant goroutine from the *next* poll cycle" is the only thing
+that could see the cleared entry.
+
+That assertion was wrong. `Delete` ran *before* the failure was fully handled
+(`pauseIssue`'s comment + label writes, plus a TUI history append). Any
+goroutine — including one from the *same* burst that simply hadn't reached
+`LoadOrStore` yet — could observe the gap and become a second owner: re-running
+`ensureBareClone` (wasteful, and for `ensureSpawnTargetReady` a second
+concurrent `git clone --bare` into the same directory — the exact corruption
+race ADR 022 exists to prevent) and posting a second "cannot clone repo"
+comment.
+
+This surfaced as an intermittent CI failure
+(`TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt`) that reached
+production: it failed a merge-train trial for an unrelated, clean PR (#1450) on
+2026-08-11, pausing it with actionless advice ("fix the failing check(s) on
+this PR"). The test had passed 5/5 on `main` and 40/40 under `-race` — it
+caught the defect by luck of goroutine scheduling, not by design. See #1543.
+
+### Why "just defer the `Delete`" is not enough
+
+The obvious fix — move `Delete` to after `pauseIssue` completes — narrows the
+race window but does not close it. `poll.go`'s dispatch loop is itself
+throttled by a semaphore (`MaxConcurrent`, default 5): with more than
+`MaxConcurrent` concurrent callers for one repo, the excess callers don't even
+reach `ensureRepoReady` until an earlier worker (possibly the clone owner
+itself) releases its semaphore slot — which can happen only *after* the
+owner's entire failure-handling sequence has finished. A same-burst sibling
+can therefore legitimately arrive after a deferred `Delete` too. Any complete
+fix has to define the retry boundary in terms of something more precise than
+"before" or "after" a fixed point in the owner's own control flow.
+
+## Decision
+
+Replace the unconditional `Delete` with an **identity-gated retry boundary**:
+a failed `cloneInFlight` entry is only ever cleared by a caller whose own
+identity matches the item that owned the failed attempt, *and* whose own
+(already-fetched) `Labels` confirm `fabrik:paused` is no longer present.
+
+### Protocol changes
+
+`cloneCall` gains an `ownerKey` field (issueKey format, `"owner/repo#N"`),
+set only on failure, before `close(call.done)`:
+
+```go
+call.ownerKey = callerKey   // the failing owner's own issueKey
+close(call.done)
+// no Delete here
+e.pauseIssue(item, msg, ...)
+...
+return ErrSkipItem
+```
+
+The `Delete` is not moved — it is removed from the owner's failure path
+entirely. The entry now persists until a *waiter* clears it:
+
+```go
+if existing.err != nil {
+    if existing.ownerKey == callerKey && !hasLabel(callerLabels, "fabrik:paused") {
+        e.cloneInFlight.CompareAndDelete(nameWithOwner, actual)
+        continue // retry as a fresh owner
+    }
+    return ErrSkipItem // (or, for ensureSpawnTargetReady, post own comment + return error)
+}
+```
+
+`ensureRepoReady` and `ensureSpawnTargetReady` are both restructured as a
+`for` loop around the existing election/wait logic so a successful identity
+match can retry in-place without recursion.
+
+### What "a later poll may retry" now means, precisely
+
+Only the *exact item* that owned the failed attempt can ever satisfy
+`existing.ownerKey == callerKey`. That item carries `fabrik:paused` the moment
+`pauseIssue` returns, and a paused item is never redispatched — dispatch
+admission excludes paused items everywhere in this codebase. So the earliest
+any caller can pass the identity+label check is a **strictly later poll
+cycle**, specifically: the poll cycle after an operator removes
+`fabrik:paused` from that item and the engine redispatches it. No sibling from
+the original burst can ever match, regardless of how the semaphore staggers
+its arrival, because it is provably a *different* item — this closes the gap
+that a deferred-`Delete`-only fix leaves open for `N > MaxConcurrent` bursts.
+
+For `ensureSpawnTargetReady`, the identity is the spawning `parentItem`
+(`postSpawnCloneError`'s existing target), not the cloned repo's own item —
+there is no "the repo's own item" for a spawn target, only the parent(s) that
+discovered it.
+
+### Test seam: `cloneAttemptHook`
+
+A new `cloneAttemptHook func(nameWithOwner string)` field on `Engine`
+(nil in production, mirroring the existing `trainRedBatchHook` precedent) is
+invoked once per genuine owner attempt, immediately before `ensureBareClone`.
+This gives tests a direct clone-attempt count independent of `AddComment`
+counting — necessary for `ensureSpawnTargetReady`, where every distinct
+parent legitimately posts its own comment by design, so comment-counting
+cannot distinguish "one clone, N comments" from "two clones, N comments."
+
+### Deterministic regression tests (R5)
+
+The flaky goroutine-barrier test
+(`TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt`) is kept — it is
+still real concurrency/`-race` coverage — but fixed to give each goroutine a
+distinct item number (matching real production bursts, where different board
+items race on a never-before-cloned repo; a shared item number would trivially
+satisfy the new identity gate for every goroutine, defeating the test).
+
+New sequential (non-racing) tests prove each edge of the gate directly:
+
+- **Different item after failure** → no second clone attempt, no second
+  comment (proves the identity half of the gate).
+- **Same item, still paused** → no retry (proves the label half of the gate;
+  guards against the R2 wedge risk in the other direction — retrying too
+  eagerly).
+- **Same item, unpaused after fix** → retries and succeeds, demonstrating
+  AC3's "fails, then succeeds on a later attempt." The bare-clone destination
+  is pre-created as a real (empty) bare repo (`git init --bare`) so
+  `ensureBareClone`'s existing "already exists → repair" path returns success
+  deterministically, with no network dependency (per
+  `.claude/rules/golang.md`).
+
+The same three-shape coverage is added for `ensureSpawnTargetReady`, keyed on
+`parentItem`.
+
+**Non-vacuousness verified**: with the identity check in both functions
+temporarily replaced with an unconditional `true` (reintroducing the pre-fix
+"any waiter can retry" behavior), the new deterministic tests fail on 20/20
+runs — not intermittently. This was verified locally and reverted before
+committing the fix; see the PR description.
+
+## Alternatives Considered
+
+### Defer `Delete` until after `pauseIssue` completes
+
+Simplest, smallest diff. Rejected as incomplete: as explained above, it
+narrows but does not close the race for repos with more concurrent callers
+than `MaxConcurrent` — a semaphore-delayed sibling can still legitimately
+arrive after the owner's entire failure-handling sequence and become a second
+owner. R1 requires "regardless of scheduling," which this does not achieve.
+
+### Settle scan tied to the paused label
+
+Clear the failed entry via a per-poll settle scan (following the established
+pattern in `engine/ci_settle.go`, `engine/claude_limit_settle.go`, etc.) that
+observes the owner item's `fabrik:paused` removal. This is the literal reading
+of R2's wording and would close the same-burst gap identically to the chosen
+design. Rejected in favor of the identity gate because it requires a new file,
+new `poll.go` wiring, and an extra GraphQL round-trip per poll for something
+answerable entirely from data already in hand (the map entry's recorded owner
++ the caller's own already-fetched `item.Labels`) — no live GitHub call is
+needed, since `ensureRepoReady`/`ensureSpawnTargetReady` are themselves called
+with a freshly-fetched `item` on every dispatch.
+
+### Time/generation-based cooldown
+
+Retain the failed entry with a timestamp or generation counter, clearing it
+after a fixed cooldown independent of label state. Rejected: it would
+silently retry (and re-fail, re-comment) on a schedule even if the operator
+never fixed anything, contradicting the pause message's own instruction ("fix
+the clone issue and remove `fabrik:paused` to retry"). It also has no
+existing precedent in this codebase for this kind of state — `generation`
+appears only in `merge_train.go` and `generated_files.go`, for unrelated
+concepts — so it would introduce a novel pattern rather than reuse an
+established one.
+
+### Live per-waiter fetch of the owner item's current labels
+
+Instead of trusting the caller's own already-fetched `item.Labels`, have a
+waiter live-fetch the owner item's current state via `FetchItemDetails`
+before deciding whether to retry. Rejected as unnecessary: the identity check
+already restricts "who can retry" to the specific owning item, and that item
+only ever calls `ensureRepoReady`/`ensureSpawnTargetReady` again via a fresh
+dispatch (which always re-fetches its own labels first) — a live fetch inside
+the singleflight path would be redundant GraphQL cost for no additional
+correctness.
+
+## Consequences
+
+- **R1 (one attempt, one comment per failure, per burst)**: satisfied for
+  arbitrary N, not just `N <= MaxConcurrent` — see "What 'a later poll may
+  retry' now means, precisely" above.
+- **R2 (retry across poll cycles)**: preserved, redefined precisely as "the
+  owning item, redispatched after `fabrik:paused` is confirmed removed."
+- **R4 (`ensureSpawnTargetReady`)**: fixed with the identical protocol, not
+  exempted — its defect (concurrent-clone directory corruption) was more
+  severe than `ensureRepoReady`'s (a cosmetic duplicate comment).
+- **Documented residual limitation — merge-train's `batch[0]` anchor**:
+  `prepareTrainWorker` (`engine/merge_train.go:496`) calls
+  `ensureRepoReady(ctx, batch[0])` using an arbitrary Queued-column member as
+  the repo anchor. If that specific (now-paused) item is never reselected as
+  `batch[0]` on a later poll — e.g. another Queued item consistently sorts
+  first — the repo's `cloneInFlight` entry stays failed and every merge-train
+  pass for that repo keeps silently skipping (safe: never duplicates the
+  clone or comment) rather than retrying, until either that item does become
+  `batch[0]` again or the process restarts (an existing, uncontested reset
+  boundary for `cloneInFlight` — restarts already clear all entries). This is
+  a pre-existing characteristic of the batch-anchor design's arbitrary member
+  selection, not introduced or worsened by this fix — the old code's
+  unconditional `Delete` traded away race-safety for unconditional
+  retry-liveness in exchange for the very duplication bug this ADR fixes.
+  Redesigning batch-anchor selection to prefer a paused member (so it's
+  reselected and can self-heal) is a reasonable follow-up but is out of this
+  issue's scope.
+- `cloneInFlight` remains per-process, unpersisted; an engine restart still
+  clears all entries unconditionally, as before.
+- No user-facing behavior change: `ErrSkipItem` for all non-owners,
+  `fabrik:paused`/`fabrik:awaiting-input` on the affected item(s), and one
+  comment per genuinely distinct failure are all unchanged in shape — only
+  the internal coordination correctness and the precise retry-boundary
+  semantics improve.

--- a/adrs/1543-clone-inflight-retry-boundary.md
+++ b/adrs/1543-clone-inflight-retry-boundary.md
@@ -250,30 +250,28 @@ repo (`Engine.mergeTrainCloneSkipCounts`, keyed `"owner/repo"` — repo-keyed
 rather than item-keyed, since `batch[0]`'s identity is exactly what varies
 across polls) each time `ensureRepoReady` returns `ErrSkipItem` for the
 anchor. Once the streak reaches `e.cfg.MaxRetries`, `recordMergeTrainCloneSkip`
-pauses the *current* anchor item with an explanatory comment that names the
+posts an explanatory **comment only** on the *current* anchor item, naming the
 repo, the streak length, and — read from the live `cloneInFlight` entry — the
 specific issue whose failed attempt still owns the retry gate, so an operator
-knows exactly which issue's `fabrik:paused` to clear. The current anchor is
-paused (not the original owner) because it is the item a human reading the
-Queued column right now can act on; the comment makes clear its own clone was
-never attempted, so the pause reads as a wedge notification rather than a
-fresh clone failure. The streak resets to zero both on escalation (so a fresh
-budget applies to any future streak) and whenever `ensureRepoReady` succeeds
-for that repo (`resetMergeTrainCloneSkip`) — mirroring `mergeTrainEjectionCounts`/
-`ejectMember`'s existing counter-then-escalate-then-reset shape in the same
-file, and the escalate-after-`MaxRetries` convention used throughout the
-ADR-1270 settle scans elsewhere in the engine package. `MaxRetries <= 0`
-(unlimited) never escalates, matching every other `MaxRetries`-gated
-escalation path.
+knows exactly which issue's `fabrik:paused` to clear. It does **not** add
+`fabrik:paused` (or any other label) to the anchor — see "Correction: the
+anchor must not be paused" below for why. The streak resets to zero both on
+escalation (so a fresh budget applies to any future streak) and whenever
+`ensureRepoReady` succeeds for that repo (`resetMergeTrainCloneSkip`) —
+mirroring `mergeTrainEjectionCounts`/`ejectMember`'s existing
+counter-then-escalate-then-reset shape in the same file, and the
+escalate-after-`MaxRetries` convention used throughout the ADR-1270 settle
+scans elsewhere in the engine package. `MaxRetries <= 0` (unlimited) never
+escalates, matching every other `MaxRetries`-gated escalation path.
 
 **Alternatives considered**:
 
-- *Promote the log line to a warning only* (no pause/comment): makes the
-  condition greppable in `fabrik.log` but leaves the operator-visible symptom
-  (a repo's merge train quietly never landing anything) unexplained anywhere
-  a human would normally look — GitHub, not the daemon's log file. Rejected
-  as insufficient on its own for a condition this codebase otherwise always
-  surfaces via `fabrik:paused` + comment.
+- *Promote the log line to a warning only* (no comment): makes the condition
+  greppable in `fabrik.log` but leaves the operator-visible symptom (a repo's
+  merge train quietly never landing anything) unexplained anywhere a human
+  would normally look — GitHub, not the daemon's log file. Rejected as
+  insufficient on its own for a condition this codebase otherwise always
+  surfaces via a GitHub comment.
 - *Pin the retry gate to the repo instead of the anchor's item identity*
   (removing the wedge at its source, for the merge-train call site only):
   considered, but the identity gate's correctness depends on checking the
@@ -288,9 +286,45 @@ escalation path.
   the shared `cloneInFlight` coordination, which is exactly the
   batch-anchor-selection redesign Plan already judged out of this issue's
   scope. Rejected as more invasive than escalating the existing gap.
+- *Resolve the pinned owner (`ownerKey`) to a real `gh.ProjectItem` and pause
+  that instead of the anchor*: would target the item an operator actually
+  needs to act on, but `ownerKey` is only a `"owner/repo#N"` string — turning
+  it back into a full `gh.ProjectItem` (with the GraphQL node `ID` mutations
+  need) requires an extra board lookup this path doesn't otherwise perform,
+  and it would be redundant besides: that item was already paused with its
+  own "cannot clone repo" comment by `ensureRepoReady` at the moment its
+  clone attempt failed (see "What 'a later poll may retry' now means,
+  precisely" above). Rejected as unnecessary complexity for a state that's
+  already durable.
 
 This closes the residual limitation as a *shippable* one: the repo is never
 duplicated-cloned or duplicated-commented (R1 still holds), and it is now
 never silently wedged past `MaxRetries` polls either — it escalates loudly
 instead, following this codebase's established pattern rather than inventing
 a new one.
+
+### Correction: the anchor must not be paused
+
+The first version of this escalation called `pauseIssue` on the current
+anchor (adding `fabrik:paused` + `fabrik:awaiting-input` alongside the
+comment), reasoning that the anchor was "the item a human reading the Queued
+column right now can act on." PR review (both a bot review pass and a human
+reviewer, independently) identified a real defect in that reasoning:
+`batch[0]` is an **arbitrary, otherwise-healthy** Queued member — it did
+nothing wrong, and pausing it removes it from dispatch eligibility exactly
+like any other `fabrik:paused` item. Because fixing the *pinned owner's*
+clone issue never un-pauses the *anchor* (they are different items, and
+nothing links the two labels), every time the streak fired against a newly
+rotated anchor, a **different**, previously-innocent Queued member would be
+permanently exiled — with no effect on the actual wedge, since the anchor's
+own clone was never even attempted. Left unaddressed, an unresolved clone
+failure would progressively bench the repo's entire Queued population one
+member at a time, purely as a side effect of an escalation mechanism meant
+only to make the wedge *visible*.
+
+The fix is the comment-only design described above: `recordMergeTrainCloneSkip`
+now calls `postItemComment`, not `pauseIssue`. This preserves the goal
+(the wedge is visible on GitHub, and the comment names exactly which issue's
+`fabrik:paused` an operator needs to clear) without the collateral damage —
+the anchor remains fully eligible for the next batch, since it never leaves
+Queued in the first place.

--- a/adrs/1543-clone-inflight-retry-boundary.md
+++ b/adrs/1543-clone-inflight-retry-boundary.md
@@ -208,27 +208,89 @@ correctness.
 - **R4 (`ensureSpawnTargetReady`)**: fixed with the identical protocol, not
   exempted — its defect (concurrent-clone directory corruption) was more
   severe than `ensureRepoReady`'s (a cosmetic duplicate comment).
-- **Documented residual limitation — merge-train's `batch[0]` anchor**:
-  `prepareTrainWorker` (`engine/merge_train.go:496`) calls
+- **Merge-train's `batch[0]` anchor — detected and escalated, not silently
+  wedged**: `prepareTrainWorker` (`engine/merge_train.go`) calls
   `ensureRepoReady(ctx, batch[0])` using an arbitrary Queued-column member as
-  the repo anchor. If that specific (now-paused) item is never reselected as
-  `batch[0]` on a later poll — e.g. another Queued item consistently sorts
-  first — the repo's `cloneInFlight` entry stays failed and every merge-train
-  pass for that repo keeps silently skipping (safe: never duplicates the
-  clone or comment) rather than retrying, until either that item does become
-  `batch[0]` again or the process restarts (an existing, uncontested reset
-  boundary for `cloneInFlight` — restarts already clear all entries). This is
-  a pre-existing characteristic of the batch-anchor design's arbitrary member
-  selection, not introduced or worsened by this fix — the old code's
-  unconditional `Delete` traded away race-safety for unconditional
-  retry-liveness in exchange for the very duplication bug this ADR fixes.
-  Redesigning batch-anchor selection to prefer a paused member (so it's
-  reselected and can self-heal) is a reasonable follow-up but is out of this
-  issue's scope.
+  the repo anchor. Because `batch[0]` can be a different item on every poll
+  whenever Queued membership churns, a later anchor's identity generally
+  cannot match the `ownerKey` pinned by the original failure, so the retry
+  gate above cannot reopen for it — left unaddressed, the repo's
+  `cloneInFlight` entry would stay failed and every merge-train pass for that
+  repo would keep silently skipping (safe: never duplicates the clone or
+  comment) rather than retrying, until either the exact original anchor is
+  reselected or the process restarts. See "Escalating the `batch[0]`
+  wedge" below for how this is now surfaced instead of left as a silent,
+  restart-only-recoverable condition.
 - `cloneInFlight` remains per-process, unpersisted; an engine restart still
   clears all entries unconditionally, as before.
-- No user-facing behavior change: `ErrSkipItem` for all non-owners,
+- No user-facing behavior change to the core `ensureRepoReady`/
+  `ensureSpawnTargetReady` protocol: `ErrSkipItem` for all non-owners,
   `fabrik:paused`/`fabrik:awaiting-input` on the affected item(s), and one
   comment per genuinely distinct failure are all unchanged in shape — only
   the internal coordination correctness and the precise retry-boundary
-  semantics improve.
+  semantics improve. The merge-train anchor now additionally escalates on a
+  bounded streak (see below) — a new, deliberate behavior, not a shape change
+  to the core protocol.
+
+## Escalating the `batch[0]` wedge (#1543 follow-up)
+
+The original version of this ADR recorded the `batch[0]` anchor gap above as
+an accepted, out-of-scope residual limitation — safe (no duplication) but
+capable of leaving a repo's merge train silently skipping forever, recoverable
+only by the exact original anchor being reselected or a process restart. Once
+this PR was in front of a human reviewer, that framing was reconsidered: the
+gap is *introduced by this PR* (the pre-fix code's unconditional `Delete`
+never had this failure mode — it traded that liveness for the duplication bug
+this ADR exists to fix), and it lands in merge-train machinery this release
+actively depends on. A silent, restart-only-recoverable wedge in new
+production code was judged not shippable as a footnote.
+
+**Decision**: `prepareTrainWorker` now tracks a consecutive-skip streak per
+repo (`Engine.mergeTrainCloneSkipCounts`, keyed `"owner/repo"` — repo-keyed
+rather than item-keyed, since `batch[0]`'s identity is exactly what varies
+across polls) each time `ensureRepoReady` returns `ErrSkipItem` for the
+anchor. Once the streak reaches `e.cfg.MaxRetries`, `recordMergeTrainCloneSkip`
+pauses the *current* anchor item with an explanatory comment that names the
+repo, the streak length, and — read from the live `cloneInFlight` entry — the
+specific issue whose failed attempt still owns the retry gate, so an operator
+knows exactly which issue's `fabrik:paused` to clear. The current anchor is
+paused (not the original owner) because it is the item a human reading the
+Queued column right now can act on; the comment makes clear its own clone was
+never attempted, so the pause reads as a wedge notification rather than a
+fresh clone failure. The streak resets to zero both on escalation (so a fresh
+budget applies to any future streak) and whenever `ensureRepoReady` succeeds
+for that repo (`resetMergeTrainCloneSkip`) — mirroring `mergeTrainEjectionCounts`/
+`ejectMember`'s existing counter-then-escalate-then-reset shape in the same
+file, and the escalate-after-`MaxRetries` convention used throughout the
+ADR-1270 settle scans elsewhere in the engine package. `MaxRetries <= 0`
+(unlimited) never escalates, matching every other `MaxRetries`-gated
+escalation path.
+
+**Alternatives considered**:
+
+- *Promote the log line to a warning only* (no pause/comment): makes the
+  condition greppable in `fabrik.log` but leaves the operator-visible symptom
+  (a repo's merge train quietly never landing anything) unexplained anywhere
+  a human would normally look — GitHub, not the daemon's log file. Rejected
+  as insufficient on its own for a condition this codebase otherwise always
+  surfaces via `fabrik:paused` + comment.
+- *Pin the retry gate to the repo instead of the anchor's item identity*
+  (removing the wedge at its source, for the merge-train call site only):
+  considered, but the identity gate's correctness depends on checking the
+  *caller's own already-fetched* `Labels` for `fabrik:paused` — a repo-level
+  pin would make that check trivially pass for whichever new, never-paused
+  item next becomes `batch[0]`, reopening a repeated-clone-attempt-and-comment
+  pattern across polls for exactly this call site (a narrower echo of the bug
+  this ADR fixes). Making it correct without that reopening would require a
+  live label fetch inside the singleflight path — the same cost this ADR's
+  main design explicitly avoids (see "Why not a live GitHub fetch" above) —
+  or a structurally separate, merge-train-only clone-failure path bypassing
+  the shared `cloneInFlight` coordination, which is exactly the
+  batch-anchor-selection redesign Plan already judged out of this issue's
+  scope. Rejected as more invasive than escalating the existing gap.
+
+This closes the residual limitation as a *shippable* one: the repo is never
+duplicated-cloned or duplicated-commented (R1 still holds), and it is now
+never silently wedged past `MaxRetries` polls either — it escalates loudly
+instead, following this codebase's established pattern rather than inventing
+a new one.

--- a/adrs/1543-clone-inflight-retry-boundary.md
+++ b/adrs/1543-clone-inflight-retry-boundary.md
@@ -255,14 +255,14 @@ repo, the streak length, and — read from the live `cloneInFlight` entry — th
 specific issue whose failed attempt still owns the retry gate, so an operator
 knows exactly which issue's `fabrik:paused` to clear. It does **not** add
 `fabrik:paused` (or any other label) to the anchor — see "Correction: the
-anchor must not be paused" below for why. The streak resets to zero both on
-escalation (so a fresh budget applies to any future streak) and whenever
-`ensureRepoReady` succeeds for that repo (`resetMergeTrainCloneSkip`) —
-mirroring `mergeTrainEjectionCounts`/`ejectMember`'s existing
-counter-then-escalate-then-reset shape in the same file, and the
-escalate-after-`MaxRetries` convention used throughout the ADR-1270 settle
-scans elsewhere in the engine package. `MaxRetries <= 0` (unlimited) never
-escalates, matching every other `MaxRetries`-gated escalation path.
+anchor must not be paused" below for why. The comment fires exactly once per
+wedge episode: escalation happens the moment the streak first reaches
+`e.cfg.MaxRetries`, with no reset on escalation itself. The streak resets to
+zero only when `ensureRepoReady` succeeds for that repo
+(`resetMergeTrainCloneSkip`) — see "Correction: escalate exactly once per
+episode" below for why an in-band reset on escalation was tried and removed.
+`MaxRetries <= 0` (unlimited) never escalates, matching every other
+`MaxRetries`-gated escalation path.
 
 **Alternatives considered**:
 

--- a/adrs/1543-clone-inflight-retry-boundary.md
+++ b/adrs/1543-clone-inflight-retry-boundary.md
@@ -328,3 +328,28 @@ now calls `postItemComment`, not `pauseIssue`. This preserves the goal
 `fabrik:paused` an operator needs to clear) without the collateral damage —
 the anchor remains fully eligible for the next batch, since it never leaves
 Queued in the first place.
+
+### Correction: the anchor can *be* the pinned owner
+
+A second review pass (again both a bot pass and independently) caught a
+remaining defect in the escalation message itself: it unconditionally
+asserted the anchor's "own clone was never attempted" and that it "has NOT
+been paused." Both claims are false whenever the anchor *is* the pinned
+owner — reachable on the very first `ErrSkipItem` for a repo (trivially with
+`MaxRetries: 1`; also reachable at the default `MaxRetries: 3` if the same
+anchor recurs across polls before its own `fabrik:paused` takes visible
+effect). In that case the anchor's clone attempt is exactly what failed, and
+`ensureRepoReady` already paused it with its own "cannot clone repo" comment
+— telling that same issue to go look at a separately "pinned" issue that
+doesn't exist would misdirect the one operator most able to act.
+
+`recordMergeTrainCloneSkip` now compares `issueKey(anchor, e.defaultRepo())`
+against the pinned `ownerKey` and branches the message: when they match, the
+comment states plainly that this item's own clone attempt is the one pinning
+the retry gate, and that it already carries `fabrik:paused`; only when they
+differ does it use the original bystander framing ("its own clone was never
+attempted... has NOT been paused"). Covered by
+`TestRecordMergeTrainCloneSkip_MessageWhenAnchorIsOwner` (anchor-is-owner
+case) alongside the existing `TestRecordMergeTrainCloneSkip_MessageNamesPinnedOwner`
+(anchor-is-bystander case, now also asserting the bystander framing is
+present).

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -90,6 +90,16 @@ type cloneCall struct {
 	done chan struct{} // closed when clone completes (success or failure)
 	dir  string        // bareDir on success; empty on failure
 	err  error         // clone error on failure; nil on success
+	// ownerKey identifies the item (issueKey format, "owner/repo#N") that owned
+	// a *failed* clone attempt. Set only on failure, before done is closed, so
+	// it's safely visible to waiters via the channel-close happens-before edge.
+	// It is the identity half of the retry-boundary gate (ADR-1543): a failed
+	// entry is only ever cleared by a caller whose own issueKey matches
+	// ownerKey and whose own (already-fetched) Labels no longer carry
+	// fabrik:paused — i.e. the specific item that owned the failure, redispatched
+	// after an operator has cleared the pause. See ensureRepoReady and
+	// ensureSpawnTargetReady.
+	ownerKey string
 }
 
 type Engine struct {
@@ -167,6 +177,15 @@ type Engine struct {
 	// test proving the guard exists would pass unmodified against pre-#1440 code too.
 	// Nil in production (zero cost).
 	trainRedBatchHook func()
+	// cloneAttemptHook, when non-nil, is called once per genuine clone owner
+	// attempt — right before ensureBareClone is invoked in both ensureRepoReady
+	// and ensureSpawnTargetReady — a test-only call-observation seam (ADR-1543,
+	// #1543 R5) mirroring trainRedBatchHook's pattern above. It gives tests a
+	// direct count of real clone attempts independent of AddComment counting,
+	// which isn't a valid duplicate-clone proxy for ensureSpawnTargetReady
+	// (every distinct parent legitimately posts its own comment by design).
+	// Nil in production (zero cost).
+	cloneAttemptHook func(nameWithOwner string)
 	// generatedFilesOverride overrides the package-level generatedFiles mapping when
 	// non-nil. Tests inject a synthetic path + fake regen command, since the throwaway
 	// repos built by setupTrainRepo have none of docs/llms-full.txt's real source files
@@ -528,77 +547,103 @@ var ErrSkipItem = errors.New("skip item")
 //
 // Concurrent callers for the same repo are serialized via cloneInFlight: the first
 // caller performs the clone while others wait. On failure, only the first caller
-// posts the comment/labels; waiters silently return ErrSkipItem.
+// posts the comment/labels; waiters silently return ErrSkipItem — unless a waiter
+// is the specific item that owned the failed attempt and its own (already-fetched)
+// Labels show fabrik:paused has since been removed, in which case it clears the
+// failed entry and becomes the new owner (see ADR-1543's identity-gated retry
+// boundary, and the cloneCall.ownerKey doc comment).
 func (e *Engine) ensureRepoReady(ctx context.Context, item gh.ProjectItem) error {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	if owner == "" || repo == "" {
 		return nil // cannot determine repo — let processItem handle it
 	}
 	nameWithOwner := owner + "/" + repo
+	worktreeRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
+	callerKey := issueKey(item, e.defaultRepo())
 
-	// Fast path: already registered (common case after first clone).
-	e.mu.Lock()
-	_, registered := e.worktreeManagers[nameWithOwner]
-	e.mu.Unlock()
-	if registered {
-		return nil
-	}
+	for {
+		// Fast path: already registered (common case after first clone).
+		e.mu.Lock()
+		_, registered := e.worktreeManagers[nameWithOwner]
+		e.mu.Unlock()
+		if registered {
+			return nil
+		}
 
-	// Singleflight-style coordination: elect one goroutine to perform the clone.
-	call := &cloneCall{done: make(chan struct{})}
-	actual, loaded := e.cloneInFlight.LoadOrStore(nameWithOwner, call)
-	if loaded {
-		// Another goroutine is already cloning (or has just cloned) this repo.
-		existing := actual.(*cloneCall)
-		<-existing.done
-		if existing.err != nil {
-			e.logf(item.Number, "warn", "bare clone of %s already failed for another worker — skipping\n", nameWithOwner)
+		// Singleflight-style coordination: elect one goroutine to perform the clone.
+		call := &cloneCall{done: make(chan struct{})}
+		actual, loaded := e.cloneInFlight.LoadOrStore(nameWithOwner, call)
+		if loaded {
+			// Another goroutine is already cloning (or has just cloned) this repo.
+			existing := actual.(*cloneCall)
+			<-existing.done
+			if existing.err != nil {
+				// Retry-boundary check: only the item that owned the failed attempt,
+				// once its own pause label is confirmed gone, may retry. Any other
+				// caller — including same-burst siblings of the original owner —
+				// silently skips, exactly as before.
+				if existing.ownerKey == callerKey && !hasLabel(item.Labels, "fabrik:paused") {
+					// Clear the failed entry so this retry becomes a fresh owner.
+					// CompareAndDelete may fail if another goroutine already
+					// cleared/replaced it (e.g. a concurrent call for the same
+					// item) — either way, re-loop and re-evaluate.
+					e.cloneInFlight.CompareAndDelete(nameWithOwner, actual)
+					continue
+				}
+				e.logf(item.Number, "warn", "bare clone of %s already failed for another worker — skipping\n", nameWithOwner)
+				return ErrSkipItem
+			}
+			// Clone succeeded; register the WM using the winner's bareDir.
+			e.registerWorktrees(nameWithOwner, existing.dir, worktreeRoot)
+			return nil
+		}
+
+		// This goroutine is the owner: perform the clone.
+		if e.cloneAttemptHook != nil {
+			e.cloneAttemptHook(nameWithOwner)
+		}
+		bareDir, err := ensureBareClone(e.fabrikDir, owner, repo, e.cfg.User, e.cfg.GitSSH, e.cfg.GHESHost)
+		call.dir = bareDir
+		call.err = err
+
+		if err != nil {
+			// Record who owned this failure before releasing waiters, so the
+			// retry-boundary check above can identify a legitimate retry later.
+			call.ownerKey = callerKey
+			// Signal waiters before cleanup so they can read call.err/ownerKey.
+			close(call.done)
+			// Deliberately NOT deleted here (ADR-1543): deleting before the failure
+			// is fully handled let a same-burst sibling become a second owner and
+			// duplicate the clone + comment (#1543). The entry now persists until a
+			// caller matching ownerKey retries with fabrik:paused confirmed absent.
+
+			msg := fmt.Sprintf("🏭 **Fabrik — cannot clone repo**\n\nFailed to clone `%s/%s`:\n```\n%v\n```\nHuman intervention required. Fix the clone issue and remove `fabrik:paused` to retry.", owner, repo, err)
+			e.pauseIssue(item, msg, pauseOpts{
+				awaitingInput: true,
+				reactRocket:   true,
+			})
+			// Append a history entry so the TUI records the failure.
+			hist := tui.LoadHistory()
+			hist = append(hist, tui.HistoryEntry{
+				IssueNumber: item.Number,
+				Repo:        nameWithOwner,
+				Title:       item.Title,
+				StageName:   "clone",
+				Success:     false,
+				CompletedAt: time.Now(),
+			})
+			tui.SaveHistory(hist)
+			e.logf(item.Number, "error", "cannot clone repo %s: %v — pausing issue\n", nameWithOwner, err)
 			return ErrSkipItem
 		}
-		// Clone succeeded; register the WM using the winner's bareDir.
-		worktreeRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
-		e.registerWorktrees(nameWithOwner, existing.dir, worktreeRoot)
+
+		// Success: register the WM, then signal waiters.
+		// Leave the cloneInFlight entry in place (closed channel, nil err); future callers
+		// will exit at the fast-path registered check before reaching cloneInFlight.
+		e.registerWorktrees(nameWithOwner, bareDir, worktreeRoot)
+		close(call.done)
 		return nil
 	}
-
-	// This goroutine is the owner: perform the clone.
-	worktreeRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
-	bareDir, err := ensureBareClone(e.fabrikDir, owner, repo, e.cfg.User, e.cfg.GitSSH, e.cfg.GHESHost)
-	call.dir = bareDir
-	call.err = err
-
-	if err != nil {
-		// Signal waiters before cleanup so they can read call.err.
-		close(call.done)
-		// Delete the entry so future poll cycles (after user removes fabrik:paused) can retry.
-		e.cloneInFlight.Delete(nameWithOwner)
-
-		msg := fmt.Sprintf("🏭 **Fabrik — cannot clone repo**\n\nFailed to clone `%s/%s`:\n```\n%v\n```\nHuman intervention required. Fix the clone issue and remove `fabrik:paused` to retry.", owner, repo, err)
-		e.pauseIssue(item, msg, pauseOpts{
-			awaitingInput: true,
-			reactRocket:   true,
-		})
-		// Append a history entry so the TUI records the failure.
-		hist := tui.LoadHistory()
-		hist = append(hist, tui.HistoryEntry{
-			IssueNumber: item.Number,
-			Repo:        nameWithOwner,
-			Title:       item.Title,
-			StageName:   "clone",
-			Success:     false,
-			CompletedAt: time.Now(),
-		})
-		tui.SaveHistory(hist)
-		e.logf(item.Number, "error", "cannot clone repo %s: %v — pausing issue\n", nameWithOwner, err)
-		return ErrSkipItem
-	}
-
-	// Success: register the WM, then signal waiters.
-	// Leave the cloneInFlight entry in place (closed channel, nil err); future callers
-	// will exit at the fast-path registered check before reaching cloneInFlight.
-	e.registerWorktrees(nameWithOwner, bareDir, worktreeRoot)
-	close(call.done)
-	return nil
 }
 
 // ensureSpawnTargetReady guarantees that a WorktreeManager exists for
@@ -615,6 +660,13 @@ func (e *Engine) ensureRepoReady(ctx context.Context, item gh.ProjectItem) error
 // post their own error comment and labels on parentItem so no parent issue
 // silently loses its failure notification when concurrent workers race on the
 // same new target repo.
+//
+// As with ensureRepoReady, a failed cloneInFlight entry is only ever cleared
+// by a caller whose own parentItem matches the entry's owner and whose own
+// (already-fetched) Labels no longer carry fabrik:paused — the same
+// identity-gated retry boundary (ADR-1543), closing the same-burst
+// second-owner window that would otherwise run a second concurrent
+// `git clone --bare` into the same destination directory.
 func (e *Engine) ensureSpawnTargetReady(ctx context.Context, targetOwner, targetRepo string, parentItem gh.ProjectItem) error {
 	parentOwner, parentRepo := itemOwnerRepo(parentItem, e.defaultRepo())
 	if parentOwner == "" || parentRepo == "" {
@@ -622,55 +674,75 @@ func (e *Engine) ensureSpawnTargetReady(ctx context.Context, targetOwner, target
 	}
 	nameWithOwner := targetOwner + "/" + targetRepo
 	worktreeRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
+	callerKey := issueKey(parentItem, e.defaultRepo())
 
-	// Fast path: already registered.
-	e.mu.Lock()
-	_, registered := e.worktreeManagers[nameWithOwner]
-	e.mu.Unlock()
-	if registered {
-		return nil
-	}
-
-	// Singleflight coordination: elect one goroutine to perform the clone.
-	call := &cloneCall{done: make(chan struct{})}
-	actual, loaded := e.cloneInFlight.LoadOrStore(nameWithOwner, call)
-	if loaded {
-		// Another goroutine is already cloning (or has just cloned) this repo.
-		// Each parent item is independent here, so every waiter that observes a
-		// clone failure must post its own error comment — unlike ensureRepoReady
-		// waiters, which silently skip because the same item owns all call sites.
-		existing := actual.(*cloneCall)
-		select {
-		case <-existing.done:
-		case <-ctx.Done():
-			return ctx.Err()
+	for {
+		// Fast path: already registered.
+		e.mu.Lock()
+		_, registered := e.worktreeManagers[nameWithOwner]
+		e.mu.Unlock()
+		if registered {
+			return nil
 		}
-		if existing.err != nil {
-			e.postSpawnCloneError(parentOwner, parentRepo, parentItem, targetOwner, targetRepo, existing.err)
-			return fmt.Errorf("ensureSpawnTargetReady: clone of %s/%s failed: %w", targetOwner, targetRepo, existing.err)
+
+		// Singleflight coordination: elect one goroutine to perform the clone.
+		call := &cloneCall{done: make(chan struct{})}
+		actual, loaded := e.cloneInFlight.LoadOrStore(nameWithOwner, call)
+		if loaded {
+			// Another goroutine is already cloning (or has just cloned) this repo.
+			// Each parent item is independent here, so every waiter that observes a
+			// clone failure must post its own error comment — unlike ensureRepoReady
+			// waiters, which silently skip because the same item owns all call sites.
+			existing := actual.(*cloneCall)
+			select {
+			case <-existing.done:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			if existing.err != nil {
+				// Retry-boundary check: only the parent that owned the failed
+				// attempt, once its own pause label is confirmed gone, may retry.
+				if existing.ownerKey == callerKey && !hasLabel(parentItem.Labels, "fabrik:paused") {
+					// Clear the failed entry so this retry becomes a fresh owner.
+					// CompareAndDelete may fail if another goroutine already
+					// cleared/replaced it — either way, re-loop and re-evaluate.
+					e.cloneInFlight.CompareAndDelete(nameWithOwner, actual)
+					continue
+				}
+				e.postSpawnCloneError(parentOwner, parentRepo, parentItem, targetOwner, targetRepo, existing.err)
+				return fmt.Errorf("ensureSpawnTargetReady: clone of %s/%s failed: %w", targetOwner, targetRepo, existing.err)
+			}
+			e.registerWorktrees(nameWithOwner, existing.dir, worktreeRoot)
+			return nil
 		}
-		e.registerWorktrees(nameWithOwner, existing.dir, worktreeRoot)
-		return nil
-	}
 
-	// This goroutine is the owner: perform the clone.
-	bareDir, err := ensureBareClone(e.fabrikDir, targetOwner, targetRepo, e.cfg.User, e.cfg.GitSSH, e.cfg.GHESHost)
-	call.dir = bareDir
-	call.err = err
+		// This goroutine is the owner: perform the clone.
+		if e.cloneAttemptHook != nil {
+			e.cloneAttemptHook(nameWithOwner)
+		}
+		bareDir, err := ensureBareClone(e.fabrikDir, targetOwner, targetRepo, e.cfg.User, e.cfg.GitSSH, e.cfg.GHESHost)
+		call.dir = bareDir
+		call.err = err
 
-	if err != nil {
-		// Signal waiters before cleanup so they can read call.err.
+		if err != nil {
+			// Record who owned this failure before releasing waiters, so the
+			// retry-boundary check above can identify a legitimate retry later.
+			call.ownerKey = callerKey
+			// Signal waiters before cleanup so they can read call.err/ownerKey.
+			close(call.done)
+			// Deliberately NOT deleted here (ADR-1543): see ensureRepoReady's
+			// identical comment. A second owner here would run a second concurrent
+			// `git clone --bare` into the same directory — the exact corruption
+			// race ADR-022 exists to prevent, so this matters more here, not less.
+			e.postSpawnCloneError(parentOwner, parentRepo, parentItem, targetOwner, targetRepo, err)
+			return fmt.Errorf("ensureSpawnTargetReady: clone of %s/%s: %w", targetOwner, targetRepo, err)
+		}
+
+		// Success: register WM, then signal waiters.
+		e.registerWorktrees(nameWithOwner, bareDir, worktreeRoot)
 		close(call.done)
-		// Delete so future retries (after user removes fabrik:paused) can re-attempt.
-		e.cloneInFlight.Delete(nameWithOwner)
-		e.postSpawnCloneError(parentOwner, parentRepo, parentItem, targetOwner, targetRepo, err)
-		return fmt.Errorf("ensureSpawnTargetReady: clone of %s/%s: %w", targetOwner, targetRepo, err)
+		return nil
 	}
-
-	// Success: register WM, then signal waiters.
-	e.registerWorktrees(nameWithOwner, bareDir, worktreeRoot)
-	close(call.done)
-	return nil
 }
 
 // postSpawnCloneError posts an error comment and adds fabrik:paused +

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -137,6 +137,8 @@ type Engine struct {
 	mergeTrainInFlight          sync.Map                      // key: "owner/repo", value: *mergeTrainWorkerState; per-repo train dispatch guard
 	mergeTrainEjectionsMu       sync.Mutex                    // guards mergeTrainEjectionCounts
 	mergeTrainEjectionCounts    map[string]int                // key: "owner/repo#N", ejection count per member
+	mergeTrainCloneSkipMu       sync.Mutex                    // guards mergeTrainCloneSkipCounts
+	mergeTrainCloneSkipCounts   map[string]int                // key: "owner/repo"; consecutive ensureRepoReady ErrSkipItem streak for prepareTrainWorker's batch[0] anchor call — batch[0] can differ across polls, so this is repo-keyed rather than item-keyed like mergeTrainEjectionCounts (#1543 follow-up: identity-gated retry boundary can wedge behind a since-rotated anchor)
 	mergeTrainTrialsMu          sync.Mutex                    // guards mergeTrainTrials
 	mergeTrainTrials            map[string][]time.Time        // key: "owner/repo", trial timestamps for runaway guard (ADR-059 D8)
 	mergeTrainRunawayMu         sync.Mutex                    // guards mergeTrainRunawayAlerted AND serializes fireRunawayGuard's pause+alert critical section across all three call sites (Hook 1 x2, Hook 2) — see fireRunawayGuard (#1533)
@@ -285,24 +287,25 @@ func New(cfg Config) (*Engine, error) {
 	// (see releaseUpgradeToken's doc comment).
 	releaseClient := gh.NewClient(releaseUpgradeToken(cfg))
 	eng := &Engine{
-		cfg:                      cfg,
-		client:                   ghClient,
-		releaseClient:            releaseClient,
-		hostClient:               ghClient,
-		claude:                   &RealClaudeInvoker{DebugOutput: cfg.DebugOutput},
-		worktreeManagers:         make(map[string]*WorktreeManager),
-		fabrikDir:                fabrikDir,
-		store:                    sharedStore,
-		mayNeedWork:              make(map[string]bool),
-		seededRepos:              make(map[string]bool),
-		checkedAutoMergeRepos:    make(map[string]bool),
-		repoAccess:               make(map[string]gh.RepoAccess),
-		sem:                      make(chan struct{}, cfg.MaxConcurrent),
-		mergeTrainEjectionCounts: make(map[string]int),
-		mergeTrainTrials:         make(map[string][]time.Time),
-		mergeTrainRunawayAlerted: make(map[string]int),
-		queuedReviewEjects:       make(map[string]map[int]int),
-		pauseIssueMu:             make(map[string]*pauseIssueMuEntry),
+		cfg:                       cfg,
+		client:                    ghClient,
+		releaseClient:             releaseClient,
+		hostClient:                ghClient,
+		claude:                    &RealClaudeInvoker{DebugOutput: cfg.DebugOutput},
+		worktreeManagers:          make(map[string]*WorktreeManager),
+		fabrikDir:                 fabrikDir,
+		store:                     sharedStore,
+		mayNeedWork:               make(map[string]bool),
+		seededRepos:               make(map[string]bool),
+		checkedAutoMergeRepos:     make(map[string]bool),
+		repoAccess:                make(map[string]gh.RepoAccess),
+		sem:                       make(chan struct{}, cfg.MaxConcurrent),
+		mergeTrainEjectionCounts:  make(map[string]int),
+		mergeTrainCloneSkipCounts: make(map[string]int),
+		mergeTrainTrials:          make(map[string][]time.Time),
+		mergeTrainRunawayAlerted:  make(map[string]int),
+		queuedReviewEjects:        make(map[string]map[int]int),
+		pauseIssueMu:              make(map[string]*pauseIssueMuEntry),
 	}
 
 	// Migrate any old-style worktrees (issue-N/) to the new per-repo layout.
@@ -347,22 +350,23 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 	}
 	wms := make(map[string]*WorktreeManager)
 	eng := &Engine{
-		cfg:                      cfg,
-		client:                   client,
-		releaseClient:            client,
-		claude:                   claude,
-		worktreeManagers:         wms,
-		store:                    itemstate.NewStore(nil),
-		mayNeedWork:              make(map[string]bool),
-		seededRepos:              make(map[string]bool),
-		checkedAutoMergeRepos:    make(map[string]bool),
-		repoAccess:               make(map[string]gh.RepoAccess),
-		sem:                      make(chan struct{}, maxConcurrent),
-		mergeTrainEjectionCounts: make(map[string]int),
-		mergeTrainTrials:         make(map[string][]time.Time),
-		mergeTrainRunawayAlerted: make(map[string]int),
-		queuedReviewEjects:       make(map[string]map[int]int),
-		pauseIssueMu:             make(map[string]*pauseIssueMuEntry),
+		cfg:                       cfg,
+		client:                    client,
+		releaseClient:             client,
+		claude:                    claude,
+		worktreeManagers:          wms,
+		store:                     itemstate.NewStore(nil),
+		mayNeedWork:               make(map[string]bool),
+		seededRepos:               make(map[string]bool),
+		checkedAutoMergeRepos:     make(map[string]bool),
+		repoAccess:                make(map[string]gh.RepoAccess),
+		sem:                       make(chan struct{}, maxConcurrent),
+		mergeTrainEjectionCounts:  make(map[string]int),
+		mergeTrainCloneSkipCounts: make(map[string]int),
+		mergeTrainTrials:          make(map[string][]time.Time),
+		mergeTrainRunawayAlerted:  make(map[string]int),
+		queuedReviewEjects:        make(map[string]map[int]int),
+		pauseIssueMu:              make(map[string]*pauseIssueMuEntry),
 	}
 	if worktrees != nil {
 		worktrees.logfFn = eng.logf

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -576,7 +576,11 @@ func (e *Engine) ensureRepoReady(ctx context.Context, item gh.ProjectItem) error
 		if loaded {
 			// Another goroutine is already cloning (or has just cloned) this repo.
 			existing := actual.(*cloneCall)
-			<-existing.done
+			select {
+			case <-existing.done:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 			if existing.err != nil {
 				// Retry-boundary check: only the item that owned the failed attempt,
 				// once its own pause label is confirmed gone, may retry. Any other

--- a/engine/engine_extra_test.go
+++ b/engine/engine_extra_test.go
@@ -386,6 +386,124 @@ func TestEnsureRepoReady_SameItemUnpausedAfterFix_Retries(t *testing.T) {
 	}
 }
 
+// TestEnsureSpawnTargetReady_CloneFailure_PostsCommentAndPausesParent is the
+// single-caller parity test for ensureSpawnTargetReady, mirroring
+// TestEnsureRepoReady_CloneFailure_PostsCommentAndPauses.
+func TestEnsureSpawnTargetReady_CloneFailure_PostsCommentAndPausesParent(t *testing.T) {
+	skipIfNoGit(t)
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	// ENAMETOOLONG: fails os.MkdirAll before any network call — deterministic, no git subprocess.
+	eng.fabrikDir = strings.Repeat("a", 10000)
+
+	parentItem := gh.ProjectItem{Number: 5, Repo: "owner/repo"}
+	err := eng.ensureSpawnTargetReady(context.Background(), "spawn-target-owner", "spawn-target-repo", parentItem)
+	if err == nil {
+		t.Fatal("expected error on clone failure")
+	}
+	if len(client.addCommentCalls) != 1 {
+		t.Errorf("expected 1 AddComment call, got %d", len(client.addCommentCalls))
+	}
+	var pausedAdded bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pausedAdded = true
+		}
+	}
+	if !pausedAdded {
+		t.Error("expected fabrik:paused label added on parent on clone failure")
+	}
+}
+
+// TestEnsureSpawnTargetReady_DifferentParentAfterFailure_NoSecondCloneAttempt is the
+// deterministic (sequential, non-racing) regression test for #1543 R4:
+// ensureSpawnTargetReady shares cloneInFlight's identity-gated retry boundary with
+// ensureRepoReady. Two different parents racing on the same new spawn-target repo
+// must produce exactly one clone attempt — each parent still legitimately gets its
+// own error comment by design (unlike ensureRepoReady's silent waiters), so the
+// non-duplication signal here is the clone-attempt count, not the comment count.
+func TestEnsureSpawnTargetReady_DifferentParentAfterFailure_NoSecondCloneAttempt(t *testing.T) {
+	skipIfNoGit(t)
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	eng.fabrikDir = strings.Repeat("a", 10000)
+
+	var cloneAttempts int
+	eng.cloneAttemptHook = func(string) { cloneAttempts++ }
+
+	parentA := gh.ProjectItem{Number: 10, Repo: "owner/repo"}
+	if err := eng.ensureSpawnTargetReady(context.Background(), "spawn-target-owner", "spawn-target-repo2", parentA); err == nil {
+		t.Fatal("parent A: expected error on clone failure")
+	}
+	if cloneAttempts != 1 {
+		t.Fatalf("parent A: expected 1 clone attempt, got %d", cloneAttempts)
+	}
+	if len(client.addCommentCalls) != 1 {
+		t.Fatalf("parent A: expected 1 AddComment call, got %d", len(client.addCommentCalls))
+	}
+
+	parentB := gh.ProjectItem{Number: 11, Repo: "owner/repo"}
+	if err := eng.ensureSpawnTargetReady(context.Background(), "spawn-target-owner", "spawn-target-repo2", parentB); err == nil {
+		t.Fatal("parent B: expected error (own comment) on clone failure")
+	}
+	if cloneAttempts != 1 {
+		t.Errorf("parent B: expected no additional clone attempt, got %d total", cloneAttempts)
+	}
+	// Each distinct parent legitimately posts its own comment — this is by design,
+	// not the bug (see ensureSpawnTargetReady's doc comment).
+	if len(client.addCommentCalls) != 2 {
+		t.Errorf("parent B: expected its own additional comment, got %d total", len(client.addCommentCalls))
+	}
+}
+
+// TestEnsureSpawnTargetReady_SameParentUnpausedAfterFix_Retries mirrors
+// TestEnsureRepoReady_SameItemUnpausedAfterFix_Retries, keyed on the owning parent
+// item: after a clone failure, a later call from the *same* parent — once its
+// Labels no longer carry fabrik:paused — retries and succeeds.
+func TestEnsureSpawnTargetReady_SameParentUnpausedAfterFix_Retries(t *testing.T) {
+	skipIfNoGit(t)
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	eng.fabrikDir = strings.Repeat("a", 10000)
+
+	var cloneAttempts int
+	eng.cloneAttemptHook = func(string) { cloneAttempts++ }
+
+	parentItem := gh.ProjectItem{Number: 20, Repo: "owner/repo"}
+	if err := eng.ensureSpawnTargetReady(context.Background(), "spawn-target-owner", "spawn-target-repo3", parentItem); err == nil {
+		t.Fatal("expected error on first attempt")
+	}
+	if cloneAttempts != 1 {
+		t.Fatalf("expected 1 clone attempt after first failure, got %d", cloneAttempts)
+	}
+
+	// Operator fixes the underlying cause and pre-creates the bare-clone
+	// destination as a real bare repo, then removes fabrik:paused from the parent.
+	validDir := t.TempDir()
+	eng.fabrikDir = validDir
+	bareDir := filepath.Join(validDir, ".fabrik", "repos", "spawn-target-owner-spawn-target-repo3.git")
+	if err := os.MkdirAll(bareDir, 0755); err != nil {
+		t.Fatalf("creating bare dir: %v", err)
+	}
+	if out, err := exec.Command("git", "init", "--bare", bareDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v: %s", err, out)
+	}
+
+	unpausedParent := parentItem // fresh copy, no fabrik:paused label
+	if err := eng.ensureSpawnTargetReady(context.Background(), "spawn-target-owner", "spawn-target-repo3", unpausedParent); err != nil {
+		t.Fatalf("expected retry to succeed after fix, got %v", err)
+	}
+	if cloneAttempts != 2 {
+		t.Errorf("expected exactly 2 clone attempts total (initial failure + retry), got %d", cloneAttempts)
+	}
+	eng.mu.Lock()
+	_, registered := eng.worktreeManagers["spawn-target-owner/spawn-target-repo3"]
+	eng.mu.Unlock()
+	if !registered {
+		t.Error("expected WorktreeManager registered after successful retry")
+	}
+}
+
 func TestEnsureDraftPR_NoPR_FailedPush_ReturnsError(t *testing.T) {
 	// No existing PR; push will fail because base dir is not a real repo.
 	// fetchLinkedPRFn not set → mock returns nil, nil (no PR found).

--- a/engine/engine_extra_test.go
+++ b/engine/engine_extra_test.go
@@ -2,6 +2,9 @@ package engine
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -200,6 +203,17 @@ func TestEnsureRepoReady_CloneFailure_PostsCommentAndPauses(t *testing.T) {
 // multiple goroutines call ensureRepoReady for the same (new) repo simultaneously,
 // exactly one AddComment call is made (the clone-failure comment) and all callers
 // return ErrSkipItem. This exercises the singleflight coordination in cloneInFlight.
+//
+// Each goroutine uses a distinct item Number (same repo) — matching what actually
+// happens in production bursts (different board items racing on a never-before-cloned
+// repo), and required by the identity-gated retry boundary (ADR-1543, #1543): with a
+// single shared item and empty Labels, every goroutine would trivially match the
+// owner's identity as unpaused and treat itself as retry-eligible, which is the
+// opposite of what this test is meant to prove. See
+// TestEnsureRepoReady_DifferentItemAfterFailure_NoSecondCloneOrComment and
+// TestEnsureRepoReady_SameItemStillPaused_NoRetry /
+// TestEnsureRepoReady_SameItemUnpausedAfterFix_Retries below for the deterministic,
+// non-racing regression coverage of the actual defect (#1543 R5).
 func TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt(t *testing.T) {
 	skipIfNoGit(t)
 	// Maximize concurrency so goroutines interleave.
@@ -211,8 +225,6 @@ func TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt(t *testing.T) {
 	// ENAMETOOLONG: fails os.MkdirAll before any network call — deterministic, no git subprocess.
 	eng.fabrikDir = strings.Repeat("a", 10000)
 
-	item := gh.ProjectItem{Number: 42, Repo: "fail-test/concurrent"}
-
 	// Use a barrier so all goroutines start at the same moment.
 	var barrier sync.WaitGroup
 	barrier.Add(numWorkers)
@@ -222,6 +234,7 @@ func TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt(t *testing.T) {
 	wg.Add(numWorkers)
 	for i := 0; i < numWorkers; i++ {
 		i := i
+		item := gh.ProjectItem{Number: 100 + i, Repo: "fail-test/concurrent"}
 		go func() {
 			defer wg.Done()
 			barrier.Done()
@@ -245,6 +258,131 @@ func TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt(t *testing.T) {
 	client.mu.Unlock()
 	if numComments != 1 {
 		t.Errorf("expected exactly 1 AddComment call, got %d", numComments)
+	}
+}
+
+// TestEnsureRepoReady_DifferentItemAfterFailure_NoSecondCloneOrComment is the
+// deterministic (sequential, non-racing) regression test for #1543: item A fails
+// to clone; item B (same repo, no scheduling luck involved) must silently skip
+// without a second clone attempt or a second comment. This directly proves the
+// identity-gated retry boundary rather than relying on goroutine scheduling.
+func TestEnsureRepoReady_DifferentItemAfterFailure_NoSecondCloneOrComment(t *testing.T) {
+	skipIfNoGit(t)
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	// ENAMETOOLONG: fails os.MkdirAll before any network call — deterministic, no git subprocess.
+	eng.fabrikDir = strings.Repeat("a", 10000)
+
+	var cloneAttempts int
+	eng.cloneAttemptHook = func(string) { cloneAttempts++ }
+
+	itemA := gh.ProjectItem{Number: 1, Repo: "fail-test/different-item"}
+	if err := eng.ensureRepoReady(context.Background(), itemA); err != ErrSkipItem {
+		t.Fatalf("item A: expected ErrSkipItem, got %v", err)
+	}
+	if cloneAttempts != 1 {
+		t.Fatalf("item A: expected 1 clone attempt, got %d", cloneAttempts)
+	}
+	if len(client.addCommentCalls) != 1 {
+		t.Fatalf("item A: expected 1 AddComment call, got %d", len(client.addCommentCalls))
+	}
+
+	itemB := gh.ProjectItem{Number: 2, Repo: "fail-test/different-item"}
+	if err := eng.ensureRepoReady(context.Background(), itemB); err != ErrSkipItem {
+		t.Fatalf("item B: expected ErrSkipItem, got %v", err)
+	}
+	if cloneAttempts != 1 {
+		t.Errorf("item B: expected no additional clone attempt, got %d total", cloneAttempts)
+	}
+	if len(client.addCommentCalls) != 1 {
+		t.Errorf("item B: expected no additional AddComment call, got %d total", len(client.addCommentCalls))
+	}
+}
+
+// TestEnsureRepoReady_SameItemStillPaused_NoRetry proves the other edge of the
+// identity gate: even the item that owned the failed attempt must not retry while
+// its own (already-fetched) Labels still carry fabrik:paused — otherwise the fix
+// would trade an intermittent duplicate for retrying too eagerly.
+func TestEnsureRepoReady_SameItemStillPaused_NoRetry(t *testing.T) {
+	skipIfNoGit(t)
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	eng.fabrikDir = strings.Repeat("a", 10000)
+
+	var cloneAttempts int
+	eng.cloneAttemptHook = func(string) { cloneAttempts++ }
+
+	item := gh.ProjectItem{Number: 1, Repo: "fail-test/still-paused"}
+	if err := eng.ensureRepoReady(context.Background(), item); err != ErrSkipItem {
+		t.Fatalf("expected ErrSkipItem on first attempt, got %v", err)
+	}
+	if cloneAttempts != 1 {
+		t.Fatalf("expected 1 clone attempt after first failure, got %d", cloneAttempts)
+	}
+
+	// Same item, but now carrying fabrik:paused — as pauseIssue would have just
+	// applied. Must not be treated as retry-eligible.
+	pausedItem := item
+	pausedItem.Labels = []string{"fabrik:paused", "fabrik:awaiting-input"}
+	if err := eng.ensureRepoReady(context.Background(), pausedItem); err != ErrSkipItem {
+		t.Fatalf("expected ErrSkipItem while still paused, got %v", err)
+	}
+	if cloneAttempts != 1 {
+		t.Errorf("expected no additional clone attempt while paused, got %d total", cloneAttempts)
+	}
+	if len(client.addCommentCalls) != 1 {
+		t.Errorf("expected no additional comment while paused, got %d total", len(client.addCommentCalls))
+	}
+}
+
+// TestEnsureRepoReady_SameItemUnpausedAfterFix_Retries demonstrates AC3: after a
+// clone failure, a subsequent call for the *same* item — once its Labels no longer
+// carry fabrik:paused, modeling an operator having fixed the cause and cleared the
+// label — retries and succeeds. The bare-clone directory is pre-created as a real
+// (empty) bare repo so ensureBareClone's "already exists" repair path returns
+// success deterministically, without a network dependency (see
+// .claude/rules/golang.md).
+func TestEnsureRepoReady_SameItemUnpausedAfterFix_Retries(t *testing.T) {
+	skipIfNoGit(t)
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	eng.fabrikDir = strings.Repeat("a", 10000)
+
+	var cloneAttempts int
+	eng.cloneAttemptHook = func(string) { cloneAttempts++ }
+
+	item := gh.ProjectItem{Number: 1, Repo: "retry-test/repo"}
+	if err := eng.ensureRepoReady(context.Background(), item); err != ErrSkipItem {
+		t.Fatalf("expected ErrSkipItem on first attempt, got %v", err)
+	}
+	if cloneAttempts != 1 {
+		t.Fatalf("expected 1 clone attempt after first failure, got %d", cloneAttempts)
+	}
+
+	// Operator fixes the underlying cause (a valid fabrikDir) and pre-creates the
+	// bare-clone destination as a real bare repo, then removes fabrik:paused.
+	validDir := t.TempDir()
+	eng.fabrikDir = validDir
+	bareDir := filepath.Join(validDir, ".fabrik", "repos", "retry-test-repo.git")
+	if err := os.MkdirAll(bareDir, 0755); err != nil {
+		t.Fatalf("creating bare dir: %v", err)
+	}
+	if out, err := exec.Command("git", "init", "--bare", bareDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v: %s", err, out)
+	}
+
+	unpausedItem := item // fresh copy, no fabrik:paused label
+	if err := eng.ensureRepoReady(context.Background(), unpausedItem); err != nil {
+		t.Fatalf("expected retry to succeed after fix, got %v", err)
+	}
+	if cloneAttempts != 2 {
+		t.Errorf("expected exactly 2 clone attempts total (initial failure + retry), got %d", cloneAttempts)
+	}
+	eng.mu.Lock()
+	_, registered := eng.worktreeManagers["retry-test/repo"]
+	eng.mu.Unlock()
+	if !registered {
+		t.Error("expected WorktreeManager registered after successful retry")
 	}
 }
 

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -594,13 +594,26 @@ func (e *Engine) prepareTrainWorker(ctx context.Context, state *mergeTrainWorker
 // never match and the gate stays shut — the repo would otherwise skip silently forever,
 // recoverable only by the original anchor being reselected or an engine restart.
 //
-// This escalates instead, once the streak reaches e.cfg.MaxRetries, mirroring both this
-// file's own mergeTrainEjectionCounts/ejectMember shape (in-memory counter, escalate,
-// reset) and the escalate-after-MaxRetries convention used throughout the ADR-1270 settle
-// scans elsewhere in the engine package. Unlike mergeTrainEjectionCounts (keyed per
-// member, "owner/repo#N", because an ejection is inherently about one member), this is
-// keyed per repo ("owner/repo") — the wedge is a property of the repo's cloneInFlight
-// entry, not of whichever item happens to be batch[0] this poll.
+// This escalates instead, once the streak reaches e.cfg.MaxRetries, by posting a
+// comment on the current anchor naming the pinned owner and the remedy. It deliberately
+// does NOT pause the anchor: an earlier revision called pauseIssue here, but batch[0] is
+// an arbitrary, otherwise-healthy Queued member — pausing it removes it from dispatch
+// eligibility, and since fixing the pinned owner's clone issue never un-pauses this
+// anchor, every MaxRetries-poll streak would permanently exile a *different* innocent
+// member as Queued membership rotates, without doing anything to actually resolve the
+// wedge (review feedback on this PR). A comment-only notice keeps the escalation
+// observable — which is the actual goal — without that collateral damage; the real
+// remedy (clearing fabrik:paused on the pinned owner) is unaffected either way, since
+// that item was already paused with its own explanatory comment at the moment its clone
+// attempt failed (see ensureRepoReady).
+//
+// Mirrors this file's own mergeTrainEjectionCounts/ejectMember shape (in-memory
+// counter, escalate, reset) and the escalate-after-MaxRetries convention used
+// throughout the ADR-1270 settle scans elsewhere in the engine package. Unlike
+// mergeTrainEjectionCounts (keyed per member, "owner/repo#N", because an ejection is
+// inherently about one member), this is keyed per repo ("owner/repo") — the wedge is a
+// property of the repo's cloneInFlight entry, not of whichever item happens to be
+// batch[0] this poll.
 func (e *Engine) recordMergeTrainCloneSkip(repoKey string, anchor gh.ProjectItem) {
 	e.mergeTrainCloneSkipMu.Lock()
 	e.mergeTrainCloneSkipCounts[repoKey]++
@@ -633,11 +646,11 @@ func (e *Engine) recordMergeTrainCloneSkip(repoKey string, anchor gh.ProjectItem
 		ownerClause = fmt.Sprintf("issue %s's failed clone attempt", ownerKey)
 	}
 	msg := fmt.Sprintf(
-		"🏭 **Fabrik merge-train — repo clone wedged**\n\nThe merge train for `%s` has been unable to proceed for %d consecutive attempts. This item (#%d) is the current train anchor, but its own clone was never attempted — the retry is pinned to %s, which must have its `fabrik:paused` label removed (after the underlying clone issue is fixed) before any anchor, including this one, can retry.\n\nThis item has been paused so the wedge is visible. Remove `fabrik:paused` here once the pinned issue above is resolved and the clone succeeds again.",
+		"🏭 **Fabrik merge-train — repo clone wedged**\n\nThe merge train for `%s` has been unable to proceed for %d consecutive attempts. This item (#%d) is the current train anchor, but its own clone was never attempted — the retry is pinned to %s, which must have its `fabrik:paused` label removed (after the underlying clone issue is fixed) before any anchor, including this one, can retry.\n\nThis item itself is otherwise healthy and has NOT been paused — it remains eligible for the next merge-train batch. No action is needed here; resolve the wedge by clearing `fabrik:paused` on the pinned issue above.",
 		repoKey, count, anchor.Number, ownerClause,
 	)
-	e.logf(anchor.Number, "escalate", "merge-train repo %s clone wedged after %d skips — pausing anchor\n", repoKey, count)
-	e.pauseIssue(anchor, msg, pauseOpts{awaitingInput: true, reactRocket: true})
+	e.logf(anchor.Number, "escalate", "merge-train repo %s clone wedged after %d skips — notifying anchor (not pausing)\n", repoKey, count)
+	e.postItemComment(anchor, msg, true)
 }
 
 // resetMergeTrainCloneSkip clears the consecutive-skip counter for repoKey once

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -495,12 +495,13 @@ func (e *Engine) prepareTrainWorker(ctx context.Context, state *mergeTrainWorker
 	// Use batch[0] as the repo anchor for ensureRepoReady.
 	if err := e.ensureRepoReady(ctx, batch[0]); err != nil {
 		if errors.Is(err, ErrSkipItem) {
-			e.logf(0, "merge-train", "repo %s not ready, aborting train\n", repoKey)
+			e.recordMergeTrainCloneSkip(repoKey, batch[0])
 		} else {
 			e.logf(0, "merge-train", "ensureRepoReady failed for %s: %v\n", repoKey, err)
 		}
 		return trialParams{}, nil, false
 	}
+	e.resetMergeTrainCloneSkip(repoKey)
 
 	wm := e.worktreesFor(repoKey)
 	baseBranch, err := wm.DefaultBaseBranch()
@@ -582,6 +583,70 @@ func (e *Engine) prepareTrainWorker(ctx context.Context, state *mergeTrainWorker
 	e.logf(0, "merge-train", "assembled %d train member(s) for %s\n", len(current), repoKey)
 
 	return p, current, true
+}
+
+// recordMergeTrainCloneSkip tracks consecutive ensureRepoReady ErrSkipItem outcomes for
+// prepareTrainWorker's batch[0] repo anchor (#1543 follow-up). batch[0] is an arbitrary
+// Queued-column representative that can differ across polls whenever Queued membership
+// churns — plausible and normal. ADR-1543's identity-gated retry boundary only reopens
+// for the exact item pinned as cloneInFlight's ownerKey at the moment of the original
+// failure, so once a later poll selects a different batch[0], that item's identity can
+// never match and the gate stays shut — the repo would otherwise skip silently forever,
+// recoverable only by the original anchor being reselected or an engine restart.
+//
+// This escalates instead, once the streak reaches e.cfg.MaxRetries, mirroring both this
+// file's own mergeTrainEjectionCounts/ejectMember shape (in-memory counter, escalate,
+// reset) and the escalate-after-MaxRetries convention used throughout the ADR-1270 settle
+// scans elsewhere in the engine package. Unlike mergeTrainEjectionCounts (keyed per
+// member, "owner/repo#N", because an ejection is inherently about one member), this is
+// keyed per repo ("owner/repo") — the wedge is a property of the repo's cloneInFlight
+// entry, not of whichever item happens to be batch[0] this poll.
+func (e *Engine) recordMergeTrainCloneSkip(repoKey string, anchor gh.ProjectItem) {
+	e.mergeTrainCloneSkipMu.Lock()
+	e.mergeTrainCloneSkipCounts[repoKey]++
+	count := e.mergeTrainCloneSkipCounts[repoKey]
+	e.mergeTrainCloneSkipMu.Unlock()
+
+	// Best-effort: name the pinned owner in the log/comment when known. Absent only if
+	// the entry was cleared between ensureRepoReady's read and this one (e.g. a
+	// concurrent successful retry elsewhere) — never treated as an error.
+	ownerKey := ""
+	if v, ok := e.cloneInFlight.Load(repoKey); ok {
+		if call, ok := v.(*cloneCall); ok {
+			ownerKey = call.ownerKey
+		}
+	}
+	e.logf(0, "merge-train", "repo %s not ready (skip %d, pinned owner %q) — aborting train\n", repoKey, count, ownerKey)
+
+	if e.cfg.MaxRetries <= 0 || count < e.cfg.MaxRetries {
+		return
+	}
+
+	// Reset so that once an operator resolves the wedge, a future streak gets a fresh
+	// budget before escalating again — mirrors ejectMember's counter reset.
+	e.mergeTrainCloneSkipMu.Lock()
+	e.mergeTrainCloneSkipCounts[repoKey] = 0
+	e.mergeTrainCloneSkipMu.Unlock()
+
+	ownerClause := "an earlier failed clone attempt"
+	if ownerKey != "" {
+		ownerClause = fmt.Sprintf("issue %s's failed clone attempt", ownerKey)
+	}
+	msg := fmt.Sprintf(
+		"🏭 **Fabrik merge-train — repo clone wedged**\n\nThe merge train for `%s` has been unable to proceed for %d consecutive attempts. This item (#%d) is the current train anchor, but its own clone was never attempted — the retry is pinned to %s, which must have its `fabrik:paused` label removed (after the underlying clone issue is fixed) before any anchor, including this one, can retry.\n\nThis item has been paused so the wedge is visible. Remove `fabrik:paused` here once the pinned issue above is resolved and the clone succeeds again.",
+		repoKey, count, anchor.Number, ownerClause,
+	)
+	e.logf(anchor.Number, "escalate", "merge-train repo %s clone wedged after %d skips — pausing anchor\n", repoKey, count)
+	e.pauseIssue(anchor, msg, pauseOpts{awaitingInput: true, reactRocket: true})
+}
+
+// resetMergeTrainCloneSkip clears the consecutive-skip counter for repoKey once
+// ensureRepoReady succeeds for the merge-train anchor, so a stale streak from a
+// previously-wedged repo doesn't count toward a future skip's escalation threshold.
+func (e *Engine) resetMergeTrainCloneSkip(repoKey string) {
+	e.mergeTrainCloneSkipMu.Lock()
+	delete(e.mergeTrainCloneSkipCounts, repoKey)
+	e.mergeTrainCloneSkipMu.Unlock()
 }
 
 // runMergeTrainWorker is the main body of the merge-train goroutine (ADR-059 D3/D4).

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -594,24 +594,30 @@ func (e *Engine) prepareTrainWorker(ctx context.Context, state *mergeTrainWorker
 // never match and the gate stays shut — the repo would otherwise skip silently forever,
 // recoverable only by the original anchor being reselected or an engine restart.
 //
-// This escalates instead, once the streak reaches e.cfg.MaxRetries, by posting a
-// comment on the current anchor naming the pinned owner and the remedy. It deliberately
-// does NOT pause the anchor: an earlier revision called pauseIssue here, but batch[0] is
-// an arbitrary, otherwise-healthy Queued member — pausing it removes it from dispatch
-// eligibility, and since fixing the pinned owner's clone issue never un-pauses this
-// anchor, every MaxRetries-poll streak would permanently exile a *different* innocent
-// member as Queued membership rotates, without doing anything to actually resolve the
-// wedge (review feedback on this PR). A comment-only notice keeps the escalation
-// observable — which is the actual goal — without that collateral damage; the real
-// remedy (clearing fabrik:paused on the pinned owner) is unaffected either way, since
-// that item was already paused with its own explanatory comment at the moment its clone
-// attempt failed (see ensureRepoReady).
+// This escalates instead, exactly once when the streak first reaches e.cfg.MaxRetries,
+// by posting a comment on the current anchor naming the pinned owner and the remedy. It
+// deliberately does NOT pause the anchor: an earlier revision called pauseIssue here,
+// but batch[0] is an arbitrary, otherwise-healthy Queued member — pausing it removes it
+// from dispatch eligibility, and since fixing the pinned owner's clone issue never
+// un-pauses this anchor, every MaxRetries-poll streak would permanently exile a
+// *different* innocent member as Queued membership rotates, without doing anything to
+// actually resolve the wedge (review feedback on this PR). A comment-only notice keeps
+// the escalation observable — which is the actual goal — without that collateral
+// damage; the real remedy (clearing fabrik:paused on the pinned owner) is unaffected
+// either way, since that item was already paused with its own explanatory comment at
+// the moment its clone attempt failed (see ensureRepoReady).
 //
-// Mirrors this file's own mergeTrainEjectionCounts/ejectMember shape (in-memory
-// counter, escalate, reset) and the escalate-after-MaxRetries convention used
-// throughout the ADR-1270 settle scans elsewhere in the engine package. Unlike
-// mergeTrainEjectionCounts (keyed per member, "owner/repo#N", because an ejection is
-// inherently about one member), this is keyed per repo ("owner/repo") — the wedge is a
+// Unlike this file's own mergeTrainEjectionCounts/ejectMember (which resets its counter
+// after pausing, because fabrik:paused itself is the idempotency guard that stops the
+// pause path repeating), this counter is NOT reset after escalating: since the anchor
+// is deliberately never paused, there is no label to gate a repeat, so a reset here
+// would turn one escalation into a comment fired every MaxRetries skips for as long as
+// the wedge persists (review feedback on this PR — see the "escalate exactly once"
+// comment below). Escalating on count == MaxRetries (not >=, no reset) and leaving the
+// count to climb past it unremarked is what actually delivers "escalate once per
+// episode": a genuinely new episode only starts once resetMergeTrainCloneSkip deletes
+// the counter on the next ensureRepoReady success. This is otherwise keyed per repo
+// ("owner/repo"), not per member like mergeTrainEjectionCounts — the wedge is a
 // property of the repo's cloneInFlight entry, not of whichever item happens to be
 // batch[0] this poll.
 //
@@ -639,15 +645,20 @@ func (e *Engine) recordMergeTrainCloneSkip(repoKey string, anchor gh.ProjectItem
 	}
 	e.logf(0, "merge-train", "repo %s not ready (skip %d, pinned owner %q) — aborting train\n", repoKey, count, ownerKey)
 
-	if e.cfg.MaxRetries <= 0 || count < e.cfg.MaxRetries {
+	// Escalate exactly once per streak, at the moment count first reaches MaxRetries —
+	// not "count >= MaxRetries" and not followed by a reset. A persistent wedge (the
+	// only kind this exists for: it stays wedged until an operator clears the pin or
+	// the engine restarts) means count keeps climbing past MaxRetries on every
+	// subsequent skip; count != MaxRetries then falls through silently to the log line
+	// above for every one of those, so the comment fires exactly once (review feedback
+	// on this PR — a reset-after-escalate here turned "escalate once" into "escalate on
+	// a timer," reposting every MaxRetries skips indefinitely, sprayed across whichever
+	// item is anchor that poll). A genuinely new episode after recovery starts its own
+	// fresh count from resetMergeTrainCloneSkip's delete (see below) and gets its own
+	// single escalation when it reaches MaxRetries in turn.
+	if e.cfg.MaxRetries <= 0 || count != e.cfg.MaxRetries {
 		return
 	}
-
-	// Reset so that once an operator resolves the wedge, a future streak gets a fresh
-	// budget before escalating again — mirrors ejectMember's counter reset.
-	e.mergeTrainCloneSkipMu.Lock()
-	e.mergeTrainCloneSkipCounts[repoKey] = 0
-	e.mergeTrainCloneSkipMu.Unlock()
 
 	// The anchor is not always a bystander: on the very first ErrSkipItem for a repo
 	// (or any later recurrence before the anchor's own fabrik:paused has taken visible

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -614,6 +614,14 @@ func (e *Engine) prepareTrainWorker(ctx context.Context, state *mergeTrainWorker
 // inherently about one member), this is keyed per repo ("owner/repo") — the wedge is a
 // property of the repo's cloneInFlight entry, not of whichever item happens to be
 // batch[0] this poll.
+//
+// The anchor is not necessarily a bystander, though: on the very first ErrSkipItem for
+// a repo (MaxRetries: 1 is trivially reachable; the default MaxRetries: 3 is reachable
+// too, if the same anchor recurs across polls before its own fabrik:paused takes
+// visible effect), anchor IS the pinned owner. The message branches on
+// issueKey(anchor, ...) == ownerKey so it never claims a self-owning anchor's "own
+// clone was never attempted" or that it "has NOT been paused" when both are false
+// (review feedback on this PR).
 func (e *Engine) recordMergeTrainCloneSkip(repoKey string, anchor gh.ProjectItem) {
 	e.mergeTrainCloneSkipMu.Lock()
 	e.mergeTrainCloneSkipCounts[repoKey]++
@@ -641,15 +649,29 @@ func (e *Engine) recordMergeTrainCloneSkip(repoKey string, anchor gh.ProjectItem
 	e.mergeTrainCloneSkipCounts[repoKey] = 0
 	e.mergeTrainCloneSkipMu.Unlock()
 
-	ownerClause := "an earlier failed clone attempt"
-	if ownerKey != "" {
-		ownerClause = fmt.Sprintf("issue %s's failed clone attempt", ownerKey)
+	// The anchor is not always a bystander: on the very first ErrSkipItem for a repo
+	// (or any later recurrence before the anchor's own fabrik:paused has taken visible
+	// effect), anchor IS the pinned owner — its own clone attempt is what failed. The
+	// message must not claim otherwise (review feedback on this PR).
+	anchorIsOwner := ownerKey != "" && ownerKey == issueKey(anchor, e.defaultRepo())
+
+	var msg string
+	if anchorIsOwner {
+		msg = fmt.Sprintf(
+			"🏭 **Fabrik merge-train — repo clone wedged**\n\nThe merge train for `%s` has been unable to proceed for %d consecutive attempts. This item (#%d) is both the current train anchor and the issue whose own clone attempt failed and is pinning the retry gate — it already carries `fabrik:paused` and an explanatory \"cannot clone repo\" comment from that failure.\n\nFix the underlying clone issue and remove `fabrik:paused` here to retry.",
+			repoKey, count, anchor.Number,
+		)
+	} else {
+		ownerClause := "an earlier failed clone attempt"
+		if ownerKey != "" {
+			ownerClause = fmt.Sprintf("issue %s's failed clone attempt", ownerKey)
+		}
+		msg = fmt.Sprintf(
+			"🏭 **Fabrik merge-train — repo clone wedged**\n\nThe merge train for `%s` has been unable to proceed for %d consecutive attempts. This item (#%d) is the current train anchor, but its own clone was never attempted — the retry is pinned to %s, which must have its `fabrik:paused` label removed (after the underlying clone issue is fixed) before any anchor, including this one, can retry.\n\nThis item itself is otherwise healthy and has NOT been paused — it remains eligible for the next merge-train batch. No action is needed here; resolve the wedge by clearing `fabrik:paused` on the pinned issue above.",
+			repoKey, count, anchor.Number, ownerClause,
+		)
 	}
-	msg := fmt.Sprintf(
-		"🏭 **Fabrik merge-train — repo clone wedged**\n\nThe merge train for `%s` has been unable to proceed for %d consecutive attempts. This item (#%d) is the current train anchor, but its own clone was never attempted — the retry is pinned to %s, which must have its `fabrik:paused` label removed (after the underlying clone issue is fixed) before any anchor, including this one, can retry.\n\nThis item itself is otherwise healthy and has NOT been paused — it remains eligible for the next merge-train batch. No action is needed here; resolve the wedge by clearing `fabrik:paused` on the pinned issue above.",
-		repoKey, count, anchor.Number, ownerClause,
-	)
-	e.logf(anchor.Number, "escalate", "merge-train repo %s clone wedged after %d skips — notifying anchor (not pausing)\n", repoKey, count)
+	e.logf(anchor.Number, "escalate", "merge-train repo %s clone wedged after %d skips (anchor is pinned owner: %v)\n", repoKey, count, anchorIsOwner)
 	e.postItemComment(anchor, msg, true)
 }
 

--- a/engine/merge_train_test.go
+++ b/engine/merge_train_test.go
@@ -1070,6 +1070,46 @@ func TestRecordMergeTrainCloneSkip_MessageNamesPinnedOwner(t *testing.T) {
 	if !strings.Contains(body, "#50") {
 		t.Errorf("expected comment to reference the anchor issue #50, got: %s", body)
 	}
+	if !strings.Contains(body, "has NOT been paused") {
+		t.Errorf("anchor != owner: expected the 'has NOT been paused' bystander framing, got: %s", body)
+	}
+}
+
+// TestRecordMergeTrainCloneSkip_MessageWhenAnchorIsOwner verifies the escalation
+// message does not misdirect an operator when the anchor itself is the pinned owner —
+// reachable on the very first ErrSkipItem for a repo (trivially with MaxRetries: 1, and
+// also at the default MaxRetries with a recurring same anchor). An earlier revision
+// unconditionally claimed "its own clone was never attempted" and "has NOT been
+// paused," both false in this case since ensureRepoReady already paused this exact
+// item with its own "cannot clone repo" comment (review feedback on this PR).
+func TestRecordMergeTrainCloneSkip_MessageWhenAnchorIsOwner(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+	eng.cfg.MaxRetries = 1
+
+	anchor := makeTrainItem(50, "Anchor Issue")
+	repoKey := "owner/repo"
+	// The anchor's own issueKey ("owner/repo#50") is the pinned owner.
+	eng.cloneInFlight.Store(repoKey, &cloneCall{done: make(chan struct{}), ownerKey: "owner/repo#50"})
+
+	eng.recordMergeTrainCloneSkip(repoKey, anchor)
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.addCommentCalls) != 1 {
+		t.Fatalf("expected exactly 1 comment, got %d", len(client.addCommentCalls))
+	}
+	body := client.addCommentCalls[0].body
+	if strings.Contains(body, "own clone was never attempted") {
+		t.Errorf("anchor IS the owner: message must not claim its own clone was never attempted, got: %s", body)
+	}
+	if strings.Contains(body, "has NOT been paused") {
+		t.Errorf("anchor IS the owner: message must not claim it has NOT been paused (it already has fabrik:paused from its own failure), got: %s", body)
+	}
+	if !strings.Contains(body, "#50") {
+		t.Errorf("expected comment to reference the anchor/owner issue #50, got: %s", body)
+	}
 }
 
 // TestRecordMergeTrainCloneSkip_ResetAfterEscalationGivesFreshBudget verifies the

--- a/engine/merge_train_test.go
+++ b/engine/merge_train_test.go
@@ -1112,10 +1112,46 @@ func TestRecordMergeTrainCloneSkip_MessageWhenAnchorIsOwner(t *testing.T) {
 	}
 }
 
-// TestRecordMergeTrainCloneSkip_ResetAfterEscalationGivesFreshBudget verifies the
-// counter is reset once escalation fires, so a further single skip right after doesn't
-// immediately re-escalate — mirrors ejectMember's own reset-on-pause behavior.
-func TestRecordMergeTrainCloneSkip_ResetAfterEscalationGivesFreshBudget(t *testing.T) {
+// TestRecordMergeTrainCloneSkip_NoRepeatEscalationOnPersistentWedge verifies escalation
+// fires exactly once per streak, not on a repeating MaxRetries-poll cadence. An earlier
+// revision reset the counter to zero immediately after escalating, which (since the
+// anchor is deliberately never paused — no label exists to gate a repeat) turned one
+// escalation into a comment fired every MaxRetries skips for as long as the wedge
+// persisted, sprayed across whichever item happened to be anchor each time (review
+// feedback on this PR). A persistent wedge is simulated by many consecutive skips with
+// no intervening resetMergeTrainCloneSkip (success) call — the only way a real wedge
+// ends short of an engine restart.
+func TestRecordMergeTrainCloneSkip_NoRepeatEscalationOnPersistentWedge(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+	eng.cfg.MaxRetries = 2
+
+	anchor := makeTrainItem(7, "Anchor Issue")
+	repoKey := "owner/repo"
+
+	// Simulate a persistent wedge: 10 consecutive skips, well past MaxRetries, with no
+	// success in between.
+	for i := 0; i < 10; i++ {
+		eng.recordMergeTrainCloneSkip(repoKey, anchor)
+	}
+
+	client.mu.Lock()
+	comments := len(client.addCommentCalls)
+	client.mu.Unlock()
+	if comments != 1 {
+		t.Errorf("expected exactly 1 escalation comment across the entire persistent wedge, got %d", comments)
+	}
+}
+
+// TestRecordMergeTrainCloneSkip_NewEpisodeAfterRecoveryEscalatesAgain verifies that a
+// genuinely new wedge episode — one that starts only after resetMergeTrainCloneSkip has
+// cleared the counter on an intervening ensureRepoReady success — gets its own,
+// independent escalation. This is the fresh-budget-per-episode behavior
+// recordMergeTrainCloneSkip's doc comment promises, now delivered by
+// resetMergeTrainCloneSkip's delete rather than a reset-after-escalate inside this
+// function (review feedback on this PR).
+func TestRecordMergeTrainCloneSkip_NewEpisodeAfterRecoveryEscalatesAgain(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
 	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
@@ -1125,14 +1161,18 @@ func TestRecordMergeTrainCloneSkip_ResetAfterEscalationGivesFreshBudget(t *testi
 	repoKey := "owner/repo"
 
 	eng.recordMergeTrainCloneSkip(repoKey, anchor) // count=1
-	eng.recordMergeTrainCloneSkip(repoKey, anchor) // count=2, escalates + resets to 0
-	eng.recordMergeTrainCloneSkip(repoKey, anchor) // count=1 again, below threshold
+	eng.recordMergeTrainCloneSkip(repoKey, anchor) // count=2, escalates (comment 1)
+
+	eng.resetMergeTrainCloneSkip(repoKey) // operator fixed it; ensureRepoReady succeeded
+
+	eng.recordMergeTrainCloneSkip(repoKey, anchor) // new episode, count=1
+	eng.recordMergeTrainCloneSkip(repoKey, anchor) // count=2, escalates again (comment 2)
 
 	client.mu.Lock()
 	comments := len(client.addCommentCalls)
 	client.mu.Unlock()
-	if comments != 1 {
-		t.Errorf("expected exactly 1 escalation comment (counter reset after firing), got %d", comments)
+	if comments != 2 {
+		t.Errorf("expected exactly 2 escalation comments (one per episode), got %d", comments)
 	}
 }
 

--- a/engine/merge_train_test.go
+++ b/engine/merge_train_test.go
@@ -985,9 +985,15 @@ func TestEjectMember_PauseVisibleToCacheAndEcho(t *testing.T) {
 // test for #1543's follow-up: prepareTrainWorker's batch[0] repo anchor can be a
 // different item on every poll, so ADR-1543's identity-gated retry boundary can wedge
 // silently forever once it can never match. This proves recordMergeTrainCloneSkip
-// escalates (pauses the current anchor, posts a comment) once the skip streak reaches
+// escalates (posts a comment on the current anchor) once the skip streak reaches
 // e.cfg.MaxRetries, and stays silent below it — sequential, non-racing calls, mirroring
 // TestEjectMember_PausesAfterMaxEjections's shape for the sibling counter.
+//
+// It also asserts the anchor is NOT paused: an earlier revision called pauseIssue on
+// the (arbitrary, rotating) anchor, which permanently exiled a healthy Queued member
+// from dispatch eligibility every time the streak fired against a new anchor — review
+// feedback on this PR. The fix is comment-only; the anchor's dispatch eligibility must
+// be unaffected.
 func TestRecordMergeTrainCloneSkip_EscalatesAfterMaxRetries(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
@@ -1027,18 +1033,19 @@ func TestRecordMergeTrainCloneSkip_EscalatesAfterMaxRetries(t *testing.T) {
 	if comments != 1 {
 		t.Fatalf("expected exactly 1 comment on escalation, got %d", comments)
 	}
-	if !pausedAdded {
-		t.Error("expected fabrik:paused on the anchor after escalation")
+	if pausedAdded {
+		t.Error("expected the anchor NOT to receive fabrik:paused after escalation (would exile a healthy, rotating item)")
 	}
-	if !awaitingAdded {
-		t.Error("expected fabrik:awaiting-input on the anchor after escalation")
+	if awaitingAdded {
+		t.Error("expected the anchor NOT to receive fabrik:awaiting-input after escalation")
 	}
 }
 
 // TestRecordMergeTrainCloneSkip_MessageNamesPinnedOwner verifies the escalation comment
 // identifies the specific issue whose failed clone attempt pinned cloneInFlight's
-// ownerKey — the operator needs to know which issue's fabrik:paused to clear, since it's
-// not necessarily the anchor item being paused here (see #1543's follow-up discussion).
+// ownerKey — the operator needs to know which issue's fabrik:paused to clear, since the
+// escalation comment lands on the anchor item, which is never itself paused (see
+// #1543's follow-up discussion).
 func TestRecordMergeTrainCloneSkip_MessageNamesPinnedOwner(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
@@ -1133,17 +1140,20 @@ func TestRecordMergeTrainCloneSkip_CounterIsPerRepo(t *testing.T) {
 
 	client.mu.Lock()
 	defer client.mu.Unlock()
-	pausedIssues := make(map[int]bool)
+	commentedIssues := make(map[int]bool)
+	for _, c := range client.addCommentCalls {
+		commentedIssues[c.issueNumber] = true
+	}
+	if !commentedIssues[1] {
+		t.Error("expected anchor #1 (repoA) to receive the escalation comment after 3 skips")
+	}
+	if commentedIssues[2] {
+		t.Error("expected anchor #2 (repoB) NOT to receive the escalation comment after only 1 skip")
+	}
 	for _, c := range client.addLabelCalls {
 		if c.labelName == "fabrik:paused" {
-			pausedIssues[c.issueNumber] = true
+			t.Errorf("expected no fabrik:paused label anywhere (escalation is comment-only), got it on #%d", c.issueNumber)
 		}
-	}
-	if !pausedIssues[1] {
-		t.Error("expected anchor #1 (repoA) to be paused after 3 skips")
-	}
-	if pausedIssues[2] {
-		t.Error("expected anchor #2 (repoB) NOT to be paused after only 1 skip")
 	}
 }
 

--- a/engine/merge_train_test.go
+++ b/engine/merge_train_test.go
@@ -981,6 +981,172 @@ func TestEjectMember_PauseVisibleToCacheAndEcho(t *testing.T) {
 	}
 }
 
+// TestRecordMergeTrainCloneSkip_EscalatesAfterMaxRetries is the deterministic regression
+// test for #1543's follow-up: prepareTrainWorker's batch[0] repo anchor can be a
+// different item on every poll, so ADR-1543's identity-gated retry boundary can wedge
+// silently forever once it can never match. This proves recordMergeTrainCloneSkip
+// escalates (pauses the current anchor, posts a comment) once the skip streak reaches
+// e.cfg.MaxRetries, and stays silent below it — sequential, non-racing calls, mirroring
+// TestEjectMember_PausesAfterMaxEjections's shape for the sibling counter.
+func TestRecordMergeTrainCloneSkip_EscalatesAfterMaxRetries(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+	eng.cfg.MaxRetries = 3
+
+	anchor := makeTrainItem(42, "Anchor Issue")
+	repoKey := "owner/repo"
+
+	// First two skips: below threshold, no pause/comment.
+	eng.recordMergeTrainCloneSkip(repoKey, anchor)
+	eng.recordMergeTrainCloneSkip(repoKey, anchor)
+	client.mu.Lock()
+	commentsBefore := len(client.addCommentCalls)
+	client.mu.Unlock()
+	if commentsBefore != 0 {
+		t.Fatalf("expected no comment before threshold, got %d", commentsBefore)
+	}
+
+	// Third skip reaches MaxRetries: escalate.
+	eng.recordMergeTrainCloneSkip(repoKey, anchor)
+	client.mu.Lock()
+	comments := len(client.addCommentCalls)
+	var pausedAdded, awaitingAdded bool
+	for _, c := range client.addLabelCalls {
+		if c.issueNumber != 42 {
+			continue
+		}
+		if c.labelName == "fabrik:paused" {
+			pausedAdded = true
+		}
+		if c.labelName == "fabrik:awaiting-input" {
+			awaitingAdded = true
+		}
+	}
+	client.mu.Unlock()
+	if comments != 1 {
+		t.Fatalf("expected exactly 1 comment on escalation, got %d", comments)
+	}
+	if !pausedAdded {
+		t.Error("expected fabrik:paused on the anchor after escalation")
+	}
+	if !awaitingAdded {
+		t.Error("expected fabrik:awaiting-input on the anchor after escalation")
+	}
+}
+
+// TestRecordMergeTrainCloneSkip_MessageNamesPinnedOwner verifies the escalation comment
+// identifies the specific issue whose failed clone attempt pinned cloneInFlight's
+// ownerKey — the operator needs to know which issue's fabrik:paused to clear, since it's
+// not necessarily the anchor item being paused here (see #1543's follow-up discussion).
+func TestRecordMergeTrainCloneSkip_MessageNamesPinnedOwner(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+	eng.cfg.MaxRetries = 1
+
+	anchor := makeTrainItem(50, "Anchor Issue")
+	repoKey := "owner/repo"
+	eng.cloneInFlight.Store(repoKey, &cloneCall{done: make(chan struct{}), ownerKey: "owner/repo#99"})
+
+	eng.recordMergeTrainCloneSkip(repoKey, anchor)
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.addCommentCalls) != 1 {
+		t.Fatalf("expected exactly 1 comment, got %d", len(client.addCommentCalls))
+	}
+	body := client.addCommentCalls[0].body
+	if !strings.Contains(body, "owner/repo#99") {
+		t.Errorf("expected comment to name the pinned owner owner/repo#99, got: %s", body)
+	}
+	if !strings.Contains(body, "#50") {
+		t.Errorf("expected comment to reference the anchor issue #50, got: %s", body)
+	}
+}
+
+// TestRecordMergeTrainCloneSkip_ResetAfterEscalationGivesFreshBudget verifies the
+// counter is reset once escalation fires, so a further single skip right after doesn't
+// immediately re-escalate — mirrors ejectMember's own reset-on-pause behavior.
+func TestRecordMergeTrainCloneSkip_ResetAfterEscalationGivesFreshBudget(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+	eng.cfg.MaxRetries = 2
+
+	anchor := makeTrainItem(7, "Anchor Issue")
+	repoKey := "owner/repo"
+
+	eng.recordMergeTrainCloneSkip(repoKey, anchor) // count=1
+	eng.recordMergeTrainCloneSkip(repoKey, anchor) // count=2, escalates + resets to 0
+	eng.recordMergeTrainCloneSkip(repoKey, anchor) // count=1 again, below threshold
+
+	client.mu.Lock()
+	comments := len(client.addCommentCalls)
+	client.mu.Unlock()
+	if comments != 1 {
+		t.Errorf("expected exactly 1 escalation comment (counter reset after firing), got %d", comments)
+	}
+}
+
+// TestResetMergeTrainCloneSkip_ClearsStreakOnSuccess verifies that a successful
+// ensureRepoReady call (resetMergeTrainCloneSkip) clears an in-progress streak, so a
+// later unrelated skip doesn't inherit credit toward escalation from before the repo
+// last became ready — matching resetEjectionCount's post-landing-clear precedent.
+func TestResetMergeTrainCloneSkip_ClearsStreakOnSuccess(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+	eng.cfg.MaxRetries = 2
+
+	anchor := makeTrainItem(9, "Anchor Issue")
+	repoKey := "owner/repo"
+
+	eng.recordMergeTrainCloneSkip(repoKey, anchor) // count=1
+	eng.resetMergeTrainCloneSkip(repoKey)          // clears the streak
+	eng.recordMergeTrainCloneSkip(repoKey, anchor) // count=1 again, not 2
+
+	client.mu.Lock()
+	comments := len(client.addCommentCalls)
+	client.mu.Unlock()
+	if comments != 0 {
+		t.Errorf("expected no escalation (streak was reset), got %d comment(s)", comments)
+	}
+}
+
+// TestRecordMergeTrainCloneSkip_CounterIsPerRepo verifies the skip streak is tracked
+// independently per repo, mirroring TestEjectMember_EjectionCountIsPerMember's
+// per-member independence for the sibling counter.
+func TestRecordMergeTrainCloneSkip_CounterIsPerRepo(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+	eng.cfg.MaxRetries = 3
+
+	anchorA := makeTrainItem(1, "Repo A Anchor")
+	anchorB := makeTrainItem(2, "Repo B Anchor")
+
+	eng.recordMergeTrainCloneSkip("owner/repoA", anchorA)
+	eng.recordMergeTrainCloneSkip("owner/repoA", anchorA)
+	eng.recordMergeTrainCloneSkip("owner/repoA", anchorA) // escalates for repoA
+	eng.recordMergeTrainCloneSkip("owner/repoB", anchorB) // should NOT escalate for repoB
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	pausedIssues := make(map[int]bool)
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pausedIssues[c.issueNumber] = true
+		}
+	}
+	if !pausedIssues[1] {
+		t.Error("expected anchor #1 (repoA) to be paused after 3 skips")
+	}
+	if pausedIssues[2] {
+		t.Error("expected anchor #2 (repoB) NOT to be paused after only 1 skip")
+	}
+}
+
 // TestFireRunawayGuard_PauseVisibleToCacheAndEcho verifies the same cache/echo
 // write-through for the runaway-guard pause path.
 func TestFireRunawayGuard_PauseVisibleToCacheAndEcho(t *testing.T) {


### PR DESCRIPTION
Closes #1543

## Summary

## Problem

## Problem

`ensureRepoReady`'s singleflight (`engine/engine.go`) lets a second goroutine become a
second clone owner when the first owner's clone **fails**, duplicating both the clone
attempt and the user-facing "cannot clone repo" comment.

This is a real coordination defect in production code, not a flaky assertion. It is
currently surfacing as an intermittent CI failure that **blames innocent PRs**: it
failed a merge-train trial for #1450 on 2026-08-11, which paused a clean PR with
"fix the failing check(s) on this PR" — advice that cannot be acted on, because the
failure is not that PR's.

```
--- FAIL: TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt
    engine_extra_test.go:247: expected exactly 1 AddComment call, got 2
```

Evidence it is neither pre-existing-on-main nor caused by the PR it was blamed on:

- passes 5/5 on `origin/main`
- passes 40/40 under `-race` on `fabrik/issue-1450`
- #1450 does not touch `ensureRepoReady`, `cloneInFlight`, or `ensureBareClone`

## Approach

### Approach

The root cause is that `ensureRepoReady` (and, identically, `ensureSpawnTargetReady`) deletes the `cloneInFlight` entry for a failed clone *before* the failure has been fully handled, so any same-burst goroutine that hasn't yet reached `LoadOrStore` can slip in and become a second owner.

The fix removes the unconditional `Delete` entirely and replaces it with an **identity-gated retry boundary**: a failed `cloneInFlight` entry now records which item (`owner/repo#N`) owned the attempt. The entry is only ever cleared by a caller whose own identity matches that owner **and** whose own `item.Labels` (as passed into the call) no longer carries `fabrik:paused`. Concretely:

- Add `ownerKey string` to `cloneCall`, set (only on failure) to `issueKey(item, e.defaultRepo())`.
- On failure, stop calling `e.cloneInFlight.Delete(...)`. The entry persists.
- In the waiter branch, when `existing.err != nil`: if `existing.ownerKey` matches the *current caller's* issueKey and the current caller's own `item.Labels` no longer has `fabrik:paused`, clear the entry via `CompareAndDelete` and loop back to `LoadOrStore` as a fresh owner. Otherwise, behave exactly as today (silent `ErrSkipItem` for `ensureRepoReady`; `postSpawnCloneError` + error for `ensureSpawnTargetReady`).

Why this closes the gap for arbitrary N (not just `N <= MaxConcurrent`): only the *exact same item* that was paused can ever satisfy the identity check, and that item cannot be re-dispatched while `fabrik:paused` is present — dispatch admission already excludes paused items everywhere in this codebase. So the earliest any caller can pass the check is a **strictly later poll cycle**, after an operator has removed the label and the engine has redispatched that specific item. No sibling in the original burst — regardless of how the semaphore staggers it — can ever match, because it is a different item. This requires no live GitHub call, no new settle scan, and no change to `poll.go` — it's answerable entirely from data already in hand (the map entry's recorded owner + the caller's own already-fetched `item.Labels`).

This literally answers R3's "state what 'a later poll may retry' now means precisely": it means the specific item that owned the failed attempt is redispatched, which only happens after an operator clears `fabrik:paused` on it.

`ensureSpawnTargetReady` (R4) gets the identical treatment, keyed on `parentItem` instead of the repo-owning item. It was not exempted: closing the same-burst window there is more important than for `ensureRepoReady`, because a second owner there runs a second concurrent `git clone --bare` into the same directory — the exact directory-corruption race ADR-022 was written to prevent, not just a cosmetic duplicate comment.

A small test-only seam, `cloneAttemptHook func(nameWithOwner string)` (nil in production, mirroring the existing `trainRedBatchHook` precedent), is added and invoked once per genuine owner attempt, right before `ensureBareClone` is called. This gives tests a **direct, deterministic count of real clone attempts** — needed because for `ensureSpawnTargetReady` an `AddComment`/pause count is *not* a valid duplicate-clone proxy (every distinct parent legitimately posts its own comment by design), so R5's regression tests need a signal that isn't comment-counting.

R5's deterministic tests replace goroutine-barrier racing with **sequential, explicitly-ordered calls**: call with item A (fails), then call with a *different* item B for the same repo (must silently skip, zero extra clone attempts) — this directly proves the identity gate without relying on scheduling luck. A separate sequential test proves the retry path: call with item A while still "paused" (must not retry), then call with item A "unpaused" (must retry and, once the underlying cause is fixed, succeed).

### New/Modified Files

| File | Change |
|------|--------|
| `engine/engine.go` | Add `ownerKey` to `cloneCall`; add `cloneAttemptHook` field to `Engine`; rewrite `ensureRepoReady`'s and `ensureSpawnTargetReady`'s failure/waiter branches with the identity-gated retry-boundary loop |
| `engine/engine_extra_test.go` | Fix `TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt` to use distinct item numbers per goroutine (realistic burst modeling); add deterministic sequential tests for `ensureRepoReady` (no-duplicate-across-different-items, still-paused-no-retry, retry-after-unpause-and-fix); add new tests for `ensureSpawnTargetReady` (single-caller parity test, deterministic no-duplicate-clone test, retry-after-fix test) |
| `adrs/1543-clone-inflight-retry-boundary.md` | New ADR, superseding-in-part ADR-022's "Failure-path cleanup" / "Ordering invariant on failure" sections with the identity-gated protocol |

No `docs/state-machine.md` / `docs/stage-lifecycle.md` changes: external behavior (`ErrSkipItem` for all non-owners, `fabrik:paused`/`fabrik:awaiting-input` on the affected item, one comment per genuinely distinct failure) is unchanged in shape — only internal coordination correctness and the precise retry-boundary semantics improve, and those docs already describe this only at the "fails → pause/comment/skip" level. Confirmed with Research; no doc task needed beyond the ADR.

### Key Decisions

- **Identity-gated retry boundary, not a settle scan or live GitHub fetch.** Research's Constraints section flagged that a naive "just defer the `Delete`" fix is incomplete under `N > MaxConcurrent` bursts, and recommended a settle-scan tied to the paused label. A settle scan (new file, `poll.go` wiring) works but expands the diff outside the issue's stated scope (`engine/engine.go` + its test file only) and adds an extra GraphQL round-trip. The identity-gate achieves the *same* correctness guarantee — retry only after confirmed operator action on the specific paused item — using data already on hand (the map entry + the caller's own `item.Labels`), with zero new GitHub calls and zero new files. Rejected settle-scan and live-`FetchItemDetails`-per-waiter designs as unnecessary complexity for what the acceptance criteria actually test (AC3's "asserted by a test that fails, then succeeds on a later attempt" is exactly the same-item-two-calls scenario the identity gate is built for).
- **Rejected a pure time/generation-based cooldown** (Research's option C): it would silently retry (and re-fail, re-comment) on a fixed schedule even if the operator never fixed anything, contradicting the pause message's own "fix the clone issue and remove `fabrik:paused` to retry" instruction, and has no existing pattern in this codebase to build on.
- **`close(call.done)` ordering is unchanged** (still happens immediately on failure, before `pauseIssue`/`postSpawnCloneError`) — only the unconditional `Delete` is removed. Waiters still get fast release; the correctness fix is entirely in *what* the waiter branch does with a failed entry, not in resequencing the owner's own steps.
- **`ensureSpawnTargetReady` is fixed, not exempted (R4).** Its defect is worse than `ensureRepoReady`'s (concurrent-clone directory corruption, not just a duplicate comment), so no exemption is defensible. Keyed on `parentItem` since that's what `postSpawnCloneError` already targets; non-owner waiters keep posting their own comment on their own parent exactly as today (that's by-design, independent-parent behavior, not the bug).
- **New `cloneAttemptHook` test seam**, mirroring `trainRedBatchHook`. Needed because `ensureSpawnTargetReady`'s "one clone attempt" guarantee can't be verified via comment-counting (every distinct parent legitimately comments) the way `ensureRepoReady`'s can. Nil/zero-cost in production.
- **Fixing the existing flaky concurrent test's item-reuse.** It currently shares one `gh.ProjectItem{Number: 42, ...}` across all 8 goroutines. Under the identity-gated fix, that would make every goroutine trivially match the owner's identity (same item) with never-populated `Labels`, causing them to *all* treat themselves as retry-eligible — the opposite of what the test should prove, and a false test failure that doesn't reflect the actual bug. Distinct item numbers per goroutine is both more realistic (Research: "that's not what happens in production bursts") and required for the fix to be testable correctly under real concurrency.
- **Documented, accepted residual limitation for merge-train's `batch[0]` anchor** (`prepareTrainWorker`, `merge_train.go:496`): it calls `ensureRepoReady(ctx, batch[0])` using an arbitrary Queued-column member as the repo anchor. If that specific item (now paused) isn't reselected as `batch[0]` on a later poll (e.g., another Queued item sorts first), the repo's `cloneInFlight` entry stays failed and every merge-train pass for that repo keeps silently skipping (safe — never duplicates the clone or comment) rather than retrying, until either that item does become `batch[0]` again or the process restarts (an existing, uncontested reset boundary for `cloneInFlight`). This is a pre-existing characteristic of the batch-anchor design, not introduced or worsened by this fix (the old code's unconditional `Delete` traded away race-safety for unconditional retry-liveness); redesigning batch-anchor selection is out of this issue's scope. Called out explicitly in the ADR per R3's "state why."
- **ADR-1543 supersedes-in-part ADR-022**, per repo convention (new ADR numbered after the issue, not edited in place).

### Task Checklist

- [ ] Add `ownerKey string` field to `cloneCall` in `engine/engine.go`, with a doc comment explaining it's set only on failure and used by the retry-boundary check
- [ ] Add `cloneAttemptHook func(nameWithOwner string)` field to `Engine`, doc-commented like `trainRedBatchHook` (nil/zero-cost in production)
- [ ] Rewrite `ensureRepoReady`'s singleflight body as a `for` loop: owner branch invokes `cloneAttemptHook` before `ensureBareClone`, sets `call.ownerKey` on failure, no longer calls `cloneInFlight.Delete`; waiter branch on `existing.err != nil` checks identity+label match, clears via `CompareAndDelete` and `continue`s on match, else returns `ErrSkipItem` as today
- [ ] Rewrite `ensureSpawnTargetReady` symmetrically, keyed on `issueKey(parentItem, e.defaultRepo())`; non-matching waiters keep calling `postSpawnCloneError` + returning an error exactly as today
- [ ] Update `TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt` to give each of the 8 goroutines a distinct `gh.ProjectItem.Number` (same repo); confirm it still asserts exactly 1 `AddComment` and all callers return `ErrSkipItem`
- [ ] Add `TestEnsureRepoReady_DifferentItemAfterFailure_NoSecondCloneOrComment`: sequential (non-concurrent) calls — item A fails (1 clone attempt via `cloneAttemptHook` counter, 1 `AddComment`), then item B (same repo) is called and must return `ErrSkipItem` with zero additional clone attempts and zero additional comments
- [ ] Add `TestEnsureRepoReady_SameItemStillPaused_NoRetry`: item A fails; call again with item A whose `Labels` includes `fabrik:paused` — must return `ErrSkipItem` with no additional clone attempt or comment
- [ ] Add `TestEnsureRepoReady_SameItemUnpausedAfterFix_Retries`: item A fails (invalid `fabrikDir`); call again with item A whose `Labels` no longer includes `fabrik:paused`, after fixing `eng.fabrikDir` to a valid temp dir — must succeed (WM registered, `nil` error), demonstrating AC3's "fails, then succeeds on a later attempt"
- [ ] Add `TestEnsureSpawnTargetReady_CloneFailure_PostsCommentAndPausesParent`: single-caller parity test mirroring `ensureRepoReady`'s existing single-caller test
- [ ] Add `TestEnsureSpawnTargetReady_DifferentParentAfterFailure_NoSecondCloneAttempt`: sequential calls with two different `parentItem`s targeting the same new repo — exactly 1 clone attempt (via `cloneAttemptHook`) even though both parents legitimately each get their own comment
- [ ] Add `TestEnsureSpawnTargetReady_SameParentUnpausedAfterFix_Retries`: mirrors the `ensureRepoReady` retry test, keyed on the owning parent
- [ ] Manually verify AC5 non-vacuousness: temporarily reintroduce the inline `Delete` (or otherwise neutralize the identity gate), run the new tests with `-count=20`, confirm they fail every run; revert before committing. Note the result in the PR description
- [ ] Create ADR 1543: "Identity-Gated Retry Boundary for `cloneInFlight` Failures" (`adrs/1543-clone-inflight-retry-boundary.md`), headed `Supersedes (in part): ADR 022`, documenting the protocol, the precise "a later poll may retry" meaning, the rejected alternatives (settle scan, live fetch, time/generation cooldown), and the documented `batch[0]`-anchor residual limitation
- [ ] Run `go build ./...`, `go test -race ./...`, `go vet ./...`; confirm all green

### Risks

- **Getting the identity/label check backwards would silently reintroduce the bug or create a permanent wedge.** Mitigated by the three-test sequence (still-paused-no-retry, unpaused-retries, different-item-never-retries) each targeting one edge of the condition independently, plus the AC5 neutralize-and-verify step.
- **The `batch[0]`-anchor residual limitation** (documented above) could in principle leave a merge-train-only repo's clone failure stuck until an engine restart, in the specific case where the paused anchor item is never reselected as `batch[0]`. This is pre-existing risk shifted in shape (from "occasionally duplicates" to "occasionally doesn't retry via that path"), not new risk introduced by this fix, and is called out explicitly in the ADR as a candidate follow-up rather than solved here — expanding scope to redesign batch anchor selection would be a materially larger, riskier change than this issue asks for.
- **Test realism vs. existing coverage**: changing the existing concurrent test's item-reuse pattern changes what it asserts. Mitigated by keeping it (still real -race/concurrency coverage) while adding the new deterministic tests as the primary regression proof, per R5.

---
Used 17/100 turns, 1.2M input (21 raw + 1.1M cache-read + 138k cache-write) / 52k output tokens.

## Verification

(Populated by Implement on completion)

---

Closes #1543