### PR TITLE
test(e2e): fail loud on GraphQL budget exhaustion, tighten the two-mode gate's "on" leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,17 @@ jobs:
       # network call. There is no TestMain, so nothing runs. Takes <1s.
       - name: compile e2e suite (not run)
         run: go test -tags e2e -run '^$' ./tests/e2e/...
+
+      # scripts/e2e/run.sh's own header states this script exists so a future
+      # edit that regresses R2's rate-limit-backoff detection (#1527) — e.g.
+      # reintroducing the byte-offset scan that fabrik.log's O_TRUNC-on-startup
+      # silently defeated — fails a check instead of only being caught by a
+      # real, multi-hour release-gate run. That guarantee only holds if this
+      # actually runs somewhere; wired in here per #1547's review. Needs no
+      # test bed, token, or network: it sources run.sh for the function
+      # definitions only (guarded so sourcing doesn't trigger a gate run) and
+      # drives fixtures entirely via mktemp. On a bare runner with no
+      # ~/dev/fabrik-test, run.sh's TEST_BED/BED_TOKEN resolution degrades to
+      # a stderr warning rather than failing under set -euo pipefail.
+      - name: backoff-detection regression test (#1527)
+        run: bash scripts/e2e/backoff_detection_test.sh

--- a/engine/queued_review_settle.go
+++ b/engine/queued_review_settle.go
@@ -64,6 +64,21 @@ func (e *Engine) settleQueuedReviewFindings(board *gh.ProjectBoard) {
 				continue
 			}
 
+			// Mirrors settleAwaitingCIScan's equivalent pre-check log line
+			// (ci_settle.go) — purely diagnostic, doesn't gate the call.
+			// FetchItemDetails below goes through the same e.readClient
+			// (CacheImpl when caching is enabled), whose own internal
+			// freshness check (boardcache.go's cacheIsStale) decides
+			// cache-hit vs. real GraphQL fetch identically regardless of
+			// caller. Without this line, an operator attributing this scan's
+			// GraphQL cost (#1527) would see per-item log entries with no
+			// visibility into whether each fetch was a cache hit or a live
+			// API call.
+			if c := e.cache(); c != nil && !c.IsPaused() && c.IsItemCacheFresh(item.Repo, item.Number, item.UpdatedAt) {
+				e.logf(item.Number, "queued-review-settle", "reading details from cache\n")
+			} else {
+				e.logf(item.Number, "queued-review-settle", "deep-fetching details from GitHub\n")
+			}
 			if err := e.readClient.FetchItemDetails(&item); err != nil {
 				e.logf(item.Number, "queued-review-settle", "could not deep-fetch item details: %v — will retry next poll\n", err)
 				continue

--- a/scripts/e2e/backoff_detection_test.sh
+++ b/scripts/e2e/backoff_detection_test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# scripts/e2e/backoff_detection_test.sh — regression coverage for R2's
+# (#1527) rate-limit-backoff detection in scripts/e2e/run.sh.
+#
+# R2 is a release-gating guarantee ("a throttled run must fail loudly and
+# explicitly") with no automated coverage prior to this script — see PR
+# #1547's review thread, where a byte-offset-based version of the detector
+# shipped, was defeated in the field by fabrik.log's O_TRUNC-on-startup
+# behavior, and was fixed to a whole-file scan (see run.sh's
+# detect_rate_limit_backoff for the full account). This script exists so
+# that regression can't recur silently: it exercises the *actual*
+# detect_rate_limit_backoff function from run.sh against fixtures, plus a
+# deliberately-reintroduced copy of the historical broken approach, so a
+# future edit that reintroduces byte-offset tracking (or otherwise narrows
+# the scan) fails this script instead of only being caught by a real,
+# multi-hour bed run.
+#
+# Usage: scripts/e2e/backoff_detection_test.sh
+# Exit 0 if all assertions pass, 1 otherwise.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Source run.sh for its function definitions only — the sourcing guard at
+# the bottom of run.sh (BASH_SOURCE[0] == $0) prevents this from triggering
+# an actual gate run. Some of run.sh's top-level setup still executes on
+# source (TEST_BED/BED_TOKEN resolution) but is read-only and degrades
+# gracefully (a missing $TEST_BED/.env just warns), so it's safe here.
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/e2e/run.sh"
+
+FAILED=0
+TMP_LOG="$(mktemp)"
+trap 'rm -f "$TMP_LOG"' EXIT
+
+check() {
+  local desc="$1"
+  local expect_match="$2" # "match" or "no-match"
+  if detect_rate_limit_backoff "$TMP_LOG"; then
+    local actual="match"
+  else
+    local actual="no-match"
+  fi
+  if [ "$actual" = "$expect_match" ]; then
+    echo "PASS: $desc (expected $expect_match, got $actual)"
+  else
+    echo "FAIL: $desc (expected $expect_match, got $actual)"
+    FAILED=1
+  fi
+}
+
+# --- Case 1: no backoff activity at all -> no match ---
+{
+  echo "2026-08-11T09:00:00Z [info] poll cycle complete"
+  echo "2026-08-11T09:00:30Z [info] poll cycle complete"
+} > "$TMP_LOG"
+check "no backoff activity" "no-match"
+
+# --- Case 2: only the companion per-poll "is low" line -> no match ---
+# (R2 deliberately excludes this spammy per-poll line, which fires on every
+# poll while low even without ever crossing the 20% activation threshold —
+# see run.sh's header comment.)
+{
+  echo "2026-08-11T09:00:00Z [warn] GraphQL rate limit is low (25% remaining) — consider reducing poll frequency"
+} > "$TMP_LOG"
+check "per-poll 'is low' line alone (not the activation line)" "no-match"
+
+# --- Case 3: the real one-shot activation line, no truncation -> match ---
+{
+  echo "2026-08-11T09:00:00Z [warn] GraphQL rate limit low (19% remaining) — activating rate-limit backoff"
+} > "$TMP_LOG"
+check "activation line present, no truncation" "match"
+
+# --- Case 4: the actual field regression — a restart truncates the log
+# between "before" and "after", and the activation line is logged only
+# after truncation. This is the exact scenario that defeated the
+# byte-offset version of the detector (a pre-restart offset measured
+# against a file the restart then truncates out from under it). The
+# CURRENT detector (whole-file scan) must still catch this. ---
+{
+  # Simulate a substantial pre-restart log (mirrors the ~640KB real bed log
+  # cited in PR #1547's review thread) ...
+  for _ in $(seq 1 50); do
+    echo "2026-08-11T08:00:00Z [info] poll cycle complete, nothing to do"
+  done
+} > "$TMP_LOG"
+# ... then simulate the engine restart's O_TRUNC (engine/poll.go's Run())
+# truncating the file to empty, and the freshly-restarted engine logging the
+# activation line as one of its very first polls.
+: > "$TMP_LOG"
+echo "2026-08-11T09:15:16Z [warn] GraphQL rate limit low (19% remaining) — activating rate-limit backoff" >> "$TMP_LOG"
+check "activation line logged only after a mid-leg truncation (the field regression)" "match"
+
+# --- Case 5 (neutralization): the SAME fixture as Case 4, run through the
+# historical broken byte-offset approach instead of the current
+# detect_rate_limit_backoff. This proves the fixture actually exercises the
+# regression (not just a fixture that happens to always match), and that
+# the byte-offset approach a future edit might reintroduce would indeed be
+# caught failing here. ---
+{
+  # log_offset captured BEFORE the restart, against the pre-truncation file
+  # (mirrors PR #1547's original, defeated implementation).
+  pre_restart_log="$(mktemp)"
+  for _ in $(seq 1 50); do
+    echo "2026-08-11T08:00:00Z [info] poll cycle complete, nothing to do"
+  done > "$pre_restart_log"
+  log_offset=$(wc -c < "$pre_restart_log")
+  rm -f "$pre_restart_log"
+
+  # The restart truncates the real log out from under that offset, then the
+  # freshly-restarted engine logs the activation line — same as Case 4's
+  # $TMP_LOG, which is still in that post-truncation state here.
+  if tail -c "+$((log_offset + 1))" "$TMP_LOG" 2>/dev/null | grep -q 'activating rate-limit backoff'; then
+    legacy_result="match"
+  else
+    legacy_result="no-match"
+  fi
+}
+if [ "$legacy_result" = "no-match" ]; then
+  echo "PASS: neutralization — historical byte-offset approach fails to detect the same fixture Case 4 caught (confirms Case 4 exercises the real regression, and that this approach was correctly replaced)"
+else
+  echo "FAIL: neutralization — historical byte-offset approach unexpectedly detected the fixture; Case 4 may not be exercising the regression it claims to"
+  FAILED=1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "=== backoff_detection_test.sh: FAILED ==="
+  exit 1
+fi
+echo "=== backoff_detection_test.sh: all checks passed ==="

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -110,8 +110,12 @@
 # separate 0.0.78 pre-release gate runs, all of whose failures were timeouts,
 # not assertion violations). To make a throttled run fail loudly instead:
 # after each leg's suite invocation, this script scans the bed's own
-# fabrik.log (at $ENGINE_LOG, scoped to only the bytes written during that
-# leg) for the engine's one-shot rate-limit-backoff-activation line
+# fabrik.log (at $ENGINE_LOG, scoped to the bytes written since just before
+# that leg's own bed-restart step — not just since its suite invocation, so
+# a backoff activation logged by the freshly-restarted engine's very first
+# poll, before the suite even starts, is still caught rather than falling
+# into a blind spot between legs) for the engine's one-shot
+# rate-limit-backoff-activation line
 # ("...activating rate-limit backoff", engine/poll.go — NOT the companion
 # per-poll "...is low (...) consider reducing poll frequency" line, which
 # fires on every poll while low and would over-trigger on a run that dipped
@@ -303,6 +307,22 @@ switch_and_run() {
   local mode="$1"
   local parallel="$2"
   shift 2
+
+  # Captured BEFORE the restart step below (not just before the suite
+  # invocation) so the post-leg backoff scan's window covers the restart
+  # itself and the freshly-restarted engine's very first poll — a fresh
+  # process has no memory of already having activated backoff, so if the
+  # account's real (unreset-by-restart) GraphQL remaining is already at or
+  # near the 20% hysteresis threshold, that first poll's own bootstrap probe
+  # can immediately log the activation line before the suite has even
+  # started. Capturing the offset only after the restart (as an earlier
+  # version of this script did) left exactly that window — plus the idle
+  # gap since the previous leg's own scan already ran — unscanned by either
+  # leg. See engine/poll.go's rate-limit-low log line and
+  # engine/terminal.go's runProbeAndDeepFetch bootstrap probe.
+  local log_offset
+  log_offset=$(wc -c < "$ENGINE_LOG" 2>/dev/null || echo 0)
+
   echo "== switching test bed to FABRIK_MERGE_TRAIN=${mode} =="
   # KNOWN GAP: this restart step has none of the classification/auto-teardown
   # machinery below — it's a plain `-v` (non-`-json`) run with its own fixed
@@ -322,20 +342,17 @@ switch_and_run() {
   local jsonlog="${TMPDIR:-/tmp}/fabrik-e2e-${mode}-$$.json"
   local rc=0
 
-  # Snapshot the bed's GraphQL budget and this leg's position in fabrik.log
-  # before the suite runs — the former lets the post-leg report show this
-  # leg's actual GraphQL cost (A3, #1527), the latter scopes the post-leg
-  # backoff scan below to only what this leg itself wrote, so a prior leg's
-  # (or a prior invocation's) backoff event can never cause a false positive
-  # here. Both guarded with `|| echo ...`/`2>/dev/null || echo 0` so a
-  # transient `gh` failure or a not-yet-existing log file degrades to a
-  # skipped report rather than aborting the script under `set -e`.
-  local budget_before budget_after log_offset
+  # Snapshot the bed's GraphQL budget right before the suite runs (not
+  # log_offset above, which is deliberately captured earlier — see its own
+  # comment) — this is purely for the A3 cost report, which should reflect
+  # the suite's own consumption, not the restart step's. Guarded with
+  # `|| echo ...` so a transient `gh` failure degrades to a skipped report
+  # rather than aborting the script under `set -e`.
+  local budget_before budget_after
   budget_before=""
   if [ -n "$BED_TOKEN" ]; then
     budget_before=$(GH_TOKEN="$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
   fi
-  log_offset=$(wc -c < "$ENGINE_LOG" 2>/dev/null || echo 0)
 
   E2E_TRAIN_MODE="$mode" go test -tags=e2e -json -count=1 -timeout "$TIMEOUT" -parallel "$parallel" \
       ./tests/e2e/... "$@" 2>&1 \

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -130,9 +130,13 @@
 # zero new API calls against the very budget being protected, and the log
 # line already fires at the moment of interest. Each leg is also bracketed
 # with a `gh api rate_limit` call before/after (a REST metadata call, free
-# against the GraphQL budget) to report the leg's actual consumed points —
-# this is a complementary, separate purpose (durable cost visibility, A3 of
-# #1527) from the log-scrape's fail-loud detection.
+# against the GraphQL budget), scoped to the bed's own FABRIK_TOKEN (read
+# from $TEST_BED/.env into $BED_TOKEN, mirroring reset.sh's gh_() token-
+# scoping precedent — the ambient `gh` CLI's own auth is very likely a
+# different identity than the bed's @arbeithand token and would silently
+# measure the wrong account's budget) to report the leg's actual consumed
+# points — this is a complementary, separate purpose (durable cost
+# visibility, A3 of #1527) from the log-scrape's fail-loud detection.
 #
 # Prerequisites (one-time setup):
 #   - ~/dev/fabrik-test/ exists with .env (FABRIK_TOKEN for @arbeithand)
@@ -151,6 +155,19 @@ cd "$REPO_ROOT"
 # (R2, #1527) to scope its scan to this bed's own fabrik.log.
 TEST_BED="${FABRIK_TEST_DIR:-$HOME/dev/fabrik-test}"
 ENGINE_LOG="$TEST_BED/.fabrik/fabrik.log"
+
+# The bed's own PAT (same FABRIK_TOKEN reset.sh reads and scopes its gh_()
+# helper to) — the A3 budget report below must measure the bed's own
+# GraphQL consumption, never whatever identity the ambient `gh` CLI happens
+# to be authenticated as in the invoking shell, which is very likely a
+# different account than the bed's @arbeithand token and would silently
+# report an unrelated budget. A missing/unreadable token only degrades the
+# budget report (skipped, warned) — unlike reset.sh, nothing else in this
+# script depends on it, so it's not fatal here.
+BED_TOKEN=$( { grep '^FABRIK_TOKEN=' "$TEST_BED/.env" 2>/dev/null | head -1 | cut -d= -f2-; } || echo "")
+if [ -z "$BED_TOKEN" ]; then
+  echo "warning: could not read FABRIK_TOKEN from $TEST_BED/.env — GraphQL budget reporting will be skipped" >&2
+fi
 
 # Distinct exit code for a run invalidated by GraphQL budget exhaustion — see
 # "GraphQL budget exhaustion detection" in the header comment above.
@@ -314,7 +331,10 @@ switch_and_run() {
   # transient `gh` failure or a not-yet-existing log file degrades to a
   # skipped report rather than aborting the script under `set -e`.
   local budget_before budget_after log_offset
-  budget_before=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+  budget_before=""
+  if [ -n "$BED_TOKEN" ]; then
+    budget_before=$(GH_TOKEN="$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+  fi
   log_offset=$(wc -c < "$ENGINE_LOG" 2>/dev/null || echo 0)
 
   E2E_TRAIN_MODE="$mode" go test -tags=e2e -json -count=1 -timeout "$TIMEOUT" -parallel "$parallel" \
@@ -323,7 +343,10 @@ switch_and_run() {
     | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; } \
     || rc=$?
 
-  budget_after=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+  budget_after=""
+  if [ -n "$BED_TOKEN" ]; then
+    budget_after=$(GH_TOKEN="$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+  fi
   if [ -n "$budget_before" ] && [ -n "$budget_after" ]; then
     if [ "$budget_after" -le "$budget_before" ]; then
       echo "== GraphQL budget (leg: ${mode}): ${budget_before} -> ${budget_after} remaining (consumed $((budget_before - budget_after)) pts) =="

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -110,11 +110,19 @@
 # separate 0.0.78 pre-release gate runs, all of whose failures were timeouts,
 # not assertion violations). To make a throttled run fail loudly instead:
 # after each leg's suite invocation, this script scans the bed's own
-# fabrik.log (at $ENGINE_LOG, scoped to the bytes written since just before
-# that leg's own bed-restart step — not just since its suite invocation, so
-# a backoff activation logged by the freshly-restarted engine's very first
-# poll, before the suite even starts, is still caught rather than falling
-# into a blind spot between legs) for the engine's one-shot
+# fabrik.log (at $ENGINE_LOG) in full — not from a captured byte offset. Each
+# leg's own bed-restart step (TestSwitchTrainMode, via StopFabrikTestBed +
+# StartFabrikTestBed) always launches a brand-new engine process, and
+# engine/poll.go's Run() opens fabrik.log with O_TRUNC on every startup — so
+# by construction the file contains only this leg's own content the moment
+# the restart completes, covering the freshly-restarted engine's very first
+# poll (before the suite even starts) through the end of the suite run, with
+# no offset bookkeeping needed and no blind spot between legs. (An earlier
+# version of this script tried to track a pre-restart byte offset instead;
+# that offset was measured against the pre-truncation file and so almost
+# always exceeded the truncated file's size, making `tail -c +N` — and thus
+# the whole leg's detection — silently return nothing. See #1547's review
+# thread for the incident.) The scan looks for the engine's one-shot
 # rate-limit-backoff-activation line
 # ("...activating rate-limit backoff", engine/poll.go — NOT the companion
 # per-poll "...is low (...) consider reducing poll frequency" line, which
@@ -295,33 +303,18 @@ report_test_timings() {
 # defeating the hardening this function exists to provide.
 #
 # After the suite invocation, regardless of $rc, this function also checks
-# fabrik.log (scoped to the bytes written during this leg) for the engine's
-# rate-limit-backoff-activation line and, on a match, prints a RUN INVALID
-# banner and `exit`s the whole script with $BUDGET_EXHAUSTED_EXIT — see the
-# header comment's "GraphQL budget exhaustion detection" section (#1527).
-# This is an `exit`, not a `return`: an invalidated leg must short-circuit
-# any remaining leg immediately rather than let the two-mode gate continue
-# on to a second leg against a bed whose GraphQL budget is already
-# compromised for the current hour.
+# fabrik.log in full (not from a captured byte offset — see below) for the
+# engine's rate-limit-backoff-activation line and, on a match, prints a RUN
+# INVALID banner and `exit`s the whole script with $BUDGET_EXHAUSTED_EXIT —
+# see the header comment's "GraphQL budget exhaustion detection" section
+# (#1527). This is an `exit`, not a `return`: an invalidated leg must
+# short-circuit any remaining leg immediately rather than let the two-mode
+# gate continue on to a second leg against a bed whose GraphQL budget is
+# already compromised for the current hour.
 switch_and_run() {
   local mode="$1"
   local parallel="$2"
   shift 2
-
-  # Captured BEFORE the restart step below (not just before the suite
-  # invocation) so the post-leg backoff scan's window covers the restart
-  # itself and the freshly-restarted engine's very first poll — a fresh
-  # process has no memory of already having activated backoff, so if the
-  # account's real (unreset-by-restart) GraphQL remaining is already at or
-  # near the 20% hysteresis threshold, that first poll's own bootstrap probe
-  # can immediately log the activation line before the suite has even
-  # started. Capturing the offset only after the restart (as an earlier
-  # version of this script did) left exactly that window — plus the idle
-  # gap since the previous leg's own scan already ran — unscanned by either
-  # leg. See engine/poll.go's rate-limit-low log line and
-  # engine/terminal.go's runProbeAndDeepFetch bootstrap probe.
-  local log_offset
-  log_offset=$(wc -c < "$ENGINE_LOG" 2>/dev/null || echo 0)
 
   echo "== switching test bed to FABRIK_MERGE_TRAIN=${mode} =="
   # KNOWN GAP: this restart step has none of the classification/auto-teardown
@@ -342,12 +335,13 @@ switch_and_run() {
   local jsonlog="${TMPDIR:-/tmp}/fabrik-e2e-${mode}-$$.json"
   local rc=0
 
-  # Snapshot the bed's GraphQL budget right before the suite runs (not
-  # log_offset above, which is deliberately captured earlier — see its own
-  # comment) — this is purely for the A3 cost report, which should reflect
-  # the suite's own consumption, not the restart step's. Guarded with
-  # `|| echo ...` so a transient `gh` failure degrades to a skipped report
-  # rather than aborting the script under `set -e`.
+  # Snapshot the bed's GraphQL budget right before the suite runs — this is
+  # purely for the A3 cost report, which should reflect the suite's own
+  # consumption, not the restart step's (unlike the backoff scan below, which
+  # deliberately covers the restart too — see its own comment for why the two
+  # have different windows). Guarded with `|| echo ...` so a transient `gh`
+  # failure degrades to a skipped report rather than aborting the script
+  # under `set -e`.
   local budget_before budget_after
   budget_before=""
   if [ -n "$BED_TOKEN" ]; then
@@ -407,15 +401,25 @@ switch_and_run() {
   # any point during this leg, regardless of $rc — a throttled run can just
   # as easily present as a pass (if timeouts happened to land after the
   # relevant waits already succeeded) as a fail, so this must not be
-  # conditioned on the leg having failed. Scoped to the bytes written since
-  # log_offset (never the whole file) and to the literal one-shot
+  # conditioned on the leg having failed. Scans the WHOLE current fabrik.log,
+  # not a captured byte offset: the restart step above (TestSwitchTrainMode)
+  # always launches a brand-new engine process, and engine/poll.go's Run()
+  # opens fabrik.log with O_TRUNC on every startup, so by the time that
+  # restart completes the file already contains only this leg's own content
+  # — scanning it in full naturally covers the freshly-restarted engine's
+  # first poll through the end of the suite run, with no offset bookkeeping
+  # needed. (A byte-offset approach was tried and reverted here — see the
+  # header comment's "GraphQL budget exhaustion detection" section for why
+  # an offset captured before the restart is measured against a file the
+  # restart then truncates out from under it, making `tail -c +N` silently
+  # return nothing for the rest of the leg.) Matches the literal one-shot
   # hysteresis-activation line — see the header comment for why not the
   # companion per-poll "...is low..." line. `[ -f "$ENGINE_LOG" ]` guards
   # against a bed that hasn't produced a log yet (e.g. misconfigured
   # FABRIK_TEST_DIR) — silently skipping the check rather than aborting the
   # script under `set -e`, consistent with the budget-report guards above.
   if [ -f "$ENGINE_LOG" ] \
-      && tail -c "+$((log_offset + 1))" "$ENGINE_LOG" 2>/dev/null | grep -q 'activating rate-limit backoff'; then
+      && grep -q 'activating rate-limit backoff' "$ENGINE_LOG" 2>/dev/null; then
     {
       echo ""
       echo "############################################################"

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -8,6 +8,7 @@
 #   scripts/e2e/run.sh -run 'Smoke|NoWork'                 # subset, both modes
 #   E2E_TRAIN_MODE=off scripts/e2e/run.sh -run TestSmokeSingleRepoDispatch  # single mode only
 #   E2E_PARALLEL=2 scripts/e2e/run.sh        # tighten the parallelism cap for a heavy run
+#   E2E_PARALLEL_ON=1 scripts/e2e/run.sh     # tighten just the "on" leg's cap further
 #
 # --clean (if given, must be the first argument) runs scripts/e2e/reset.sh for a
 # clean-slate bed before the run. Anything else is passed to `go test`.
@@ -64,6 +65,30 @@
 # bed starvation is instead addressed by the timeout increase above, which
 # gives a starved scenario enough wall-clock room to actually finish.
 #
+# "on"-leg-specific parallelism cap (E2E_PARALLEL_ON, default 2): #1527 found
+# the "on" leg's extra GraphQL cost over "off" is NOT the merge-train worker's
+# own CI polling (that's REST, a separate budget) but the ADR-1270/ADR-1208
+# per-poll settle-scan pattern (settleAwaitingCIScan, and merge-train-exclusive
+# settleQueuedReviewFindings) — each does an unconditional, no-cooldown
+# GraphQL deep-fetch per matching item per poll, a cost proportional to how
+# many items are concurrently Queued/awaiting-CI, not to how fast the train
+# itself polls. That per-poll-per-item semantics is load-bearing for ADR-1208's
+# correctness guarantee (a Queued member's review feedback must be seen within
+# one batch cycle), so it isn't weakened here — instead, this cap shrinks the
+# population those scans iterate by admitting fewer concurrent scenarios into
+# the "on" leg specifically. Default 2 (half of E2E_PARALLEL's default 4) is a
+# reasoned starting point given the "on" leg's larger scenario count (17 vs 13
+# for "off") — not yet empirically tuned against a live gate run; see
+# tests/e2e/README.md's GraphQL budget section for measured numbers as they
+# become available. Only the default two-mode gate's "on" leg uses this
+# — a forced single-mode run (E2E_TRAIN_MODE set explicitly) always uses
+# E2E_PARALLEL, unchanged, so every documented iteration workflow above still
+# behaves exactly as before this variable existed.
+#
+# Budget-exhaustion detection (R2, #1527): a throttled run must fail loudly
+# and distinctly from a normal test failure — see "GraphQL budget exhaustion
+# detection" further below for the mechanism (exit code 3).
+#
 # Timeout/failure reporting and teardown-on-kill: the suite invocation below
 # runs `go test -json`, tees the stream to a per-leg log under $TMPDIR, and
 # on a non-zero exit classifies every top-level test by its last observed
@@ -78,6 +103,37 @@
 # nuke requiring the bed to be stopped first) — see tests/e2e/README.md's
 # "Teardown on kill" section for the remaining manual step.
 #
+# GraphQL budget exhaustion detection (R2, #1527): once backoff engages, the
+# engine's polling slows enough that board items sit past scenarios' wait
+# deadlines, producing a wall of test timeouts indistinguishable from real
+# regressions (see #1527's own incident writeup for the shape of this: three
+# separate 0.0.78 pre-release gate runs, all of whose failures were timeouts,
+# not assertion violations). To make a throttled run fail loudly instead:
+# after each leg's suite invocation, this script scans the bed's own
+# fabrik.log (at $ENGINE_LOG, scoped to only the bytes written during that
+# leg) for the engine's one-shot rate-limit-backoff-activation line
+# ("...activating rate-limit backoff", engine/poll.go — NOT the companion
+# per-poll "...is low (...) consider reducing poll frequency" line, which
+# fires on every poll while low and would over-trigger on a run that dipped
+# briefly without ever crossing the 20% hysteresis-activation threshold). A
+# match means this leg's verdict cannot be trusted — any test
+# failures/timeouts above may be throttling artifacts. The script prints an
+# unambiguous "RUN INVALID" banner and exits $BUDGET_EXHAUSTED_EXIT (3),
+# distinct from go test's propagated 1 and from a generic shell usage error
+# (2), so automation (e.g. cut-release.sh) can branch on "budget exhausted,
+# rerun" vs. "real regression, investigate" programmatically. This check runs
+# regardless of the leg's own pass/fail exit code — a throttled run can
+# present as a pass just as easily as a fail — and short-circuits any
+# remaining legs immediately (exit, not return).
+#
+# This is a log-scrape, not a live `gh api rate_limit` polling loop: it needs
+# zero new API calls against the very budget being protected, and the log
+# line already fires at the moment of interest. Each leg is also bracketed
+# with a `gh api rate_limit` call before/after (a REST metadata call, free
+# against the GraphQL budget) to report the leg's actual consumed points —
+# this is a complementary, separate purpose (durable cost visibility, A3 of
+# #1527) from the log-scrape's fail-loud detection.
+#
 # Prerequisites (one-time setup):
 #   - ~/dev/fabrik-test/ exists with .env (FABRIK_TOKEN for @arbeithand)
 #   - handarbeit/fabrik-test-alpha + fabrik-test-beta exist and seeded
@@ -89,6 +145,16 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
+
+# Test bed location and its engine log — same FABRIK_TEST_DIR convention as
+# scripts/e2e/reset.sh. Used by the GraphQL budget exhaustion detection below
+# (R2, #1527) to scope its scan to this bed's own fabrik.log.
+TEST_BED="${FABRIK_TEST_DIR:-$HOME/dev/fabrik-test}"
+ENGINE_LOG="$TEST_BED/.fabrik/fabrik.log"
+
+# Distinct exit code for a run invalidated by GraphQL budget exhaustion — see
+# "GraphQL budget exhaustion detection" in the header comment above.
+readonly BUDGET_EXHAUSTED_EXIT=3
 
 # Optional clean-slate reset before the run (must be the first argument).
 if [ "${1:-}" = "--clean" ]; then
@@ -106,6 +172,10 @@ TIMEOUT="${E2E_TIMEOUT:-4h}"
 # Cap concurrent scenarios so the full suite doesn't oversubscribe the single
 # shared bed (see header + issue #971). Default 4; override with E2E_PARALLEL.
 PARALLEL="${E2E_PARALLEL:-4}"
+
+# Tighter cap for the default two-mode gate's "on" leg specifically — see the
+# header comment's "on"-leg-specific parallelism cap section (#1527).
+PARALLEL_ON="${E2E_PARALLEL_ON:-2}"
 
 # report_test_outcomes prints a completed/still-running/never-started
 # breakdown of every top-level test from a `go test -json` log, so a killed
@@ -186,7 +256,7 @@ report_test_timings() {
 # restarts it (via the dedicated TestSwitchTrainMode invocation — a separate
 # `go test` process so the restart completes, bed fully back up, before the
 # suite invocation that follows even starts), then runs the suite with
-# E2E_TRAIN_MODE=$1 exported.
+# E2E_TRAIN_MODE=$1 exported and -parallel capped at $2.
 #
 # The suite invocation runs under `go test -json`, teed to a per-leg log, so
 # a non-zero exit can be classified (report_test_outcomes) and, if it was
@@ -202,9 +272,20 @@ report_test_timings() {
 # schema change) would abort the script before ever reaching the
 # timeout-panic check and auto-teardown that follow it — silently
 # defeating the hardening this function exists to provide.
+#
+# After the suite invocation, regardless of $rc, this function also checks
+# fabrik.log (scoped to the bytes written during this leg) for the engine's
+# rate-limit-backoff-activation line and, on a match, prints a RUN INVALID
+# banner and `exit`s the whole script with $BUDGET_EXHAUSTED_EXIT — see the
+# header comment's "GraphQL budget exhaustion detection" section (#1527).
+# This is an `exit`, not a `return`: an invalidated leg must short-circuit
+# any remaining leg immediately rather than let the two-mode gate continue
+# on to a second leg against a bed whose GraphQL budget is already
+# compromised for the current hour.
 switch_and_run() {
   local mode="$1"
-  shift
+  local parallel="$2"
+  shift 2
   echo "== switching test bed to FABRIK_MERGE_TRAIN=${mode} =="
   # KNOWN GAP: this restart step has none of the classification/auto-teardown
   # machinery below — it's a plain `-v` (non-`-json`) run with its own fixed
@@ -220,14 +301,38 @@ switch_and_run() {
   # rather than actually stuck.
   E2E_TRAIN_SWITCH=1 E2E_TRAIN_MODE="$mode" go test -tags=e2e -v -count=1 -timeout 3m \
     -run '^TestSwitchTrainMode$' ./tests/e2e/...
-  echo "== running suite with E2E_TRAIN_MODE=${mode} =="
+  echo "== running suite with E2E_TRAIN_MODE=${mode}, -parallel=${parallel} =="
   local jsonlog="${TMPDIR:-/tmp}/fabrik-e2e-${mode}-$$.json"
   local rc=0
-  E2E_TRAIN_MODE="$mode" go test -tags=e2e -json -count=1 -timeout "$TIMEOUT" -parallel "$PARALLEL" \
+
+  # Snapshot the bed's GraphQL budget and this leg's position in fabrik.log
+  # before the suite runs — the former lets the post-leg report show this
+  # leg's actual GraphQL cost (A3, #1527), the latter scopes the post-leg
+  # backoff scan below to only what this leg itself wrote, so a prior leg's
+  # (or a prior invocation's) backoff event can never cause a false positive
+  # here. Both guarded with `|| echo ...`/`2>/dev/null || echo 0` so a
+  # transient `gh` failure or a not-yet-existing log file degrades to a
+  # skipped report rather than aborting the script under `set -e`.
+  local budget_before budget_after log_offset
+  budget_before=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+  log_offset=$(wc -c < "$ENGINE_LOG" 2>/dev/null || echo 0)
+
+  E2E_TRAIN_MODE="$mode" go test -tags=e2e -json -count=1 -timeout "$TIMEOUT" -parallel "$parallel" \
       ./tests/e2e/... "$@" 2>&1 \
     | tee "$jsonlog" \
     | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; } \
     || rc=$?
+
+  budget_after=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+  if [ -n "$budget_before" ] && [ -n "$budget_after" ]; then
+    if [ "$budget_after" -le "$budget_before" ]; then
+      echo "== GraphQL budget (leg: ${mode}): ${budget_before} -> ${budget_after} remaining (consumed $((budget_before - budget_after)) pts) =="
+    else
+      echo "== GraphQL budget (leg: ${mode}): ${budget_before} -> ${budget_after} remaining (budget reset mid-leg; consumption not computable) =="
+    fi
+  else
+    echo "warning: could not read GraphQL rate_limit before/after leg ${mode} (gh api call failed) — skipping budget report" >&2
+  fi
 
   report_test_timings "$jsonlog" "$mode" \
     || echo "warning: failed to compute test timings (jq error) — inspect the raw JSON log directly: $jsonlog" >&2
@@ -256,16 +361,51 @@ switch_and_run() {
       echo "NOTE: worktrees were NOT cleaned automatically (that requires stopping the bed first)." >&2
       echo "      Run scripts/e2e/reset.sh --worktrees for full parity before the next release-gate run." >&2
     fi
+  fi
+
+  # R2 (#1527): check whether the engine's own rate-limit backoff engaged at
+  # any point during this leg, regardless of $rc — a throttled run can just
+  # as easily present as a pass (if timeouts happened to land after the
+  # relevant waits already succeeded) as a fail, so this must not be
+  # conditioned on the leg having failed. Scoped to the bytes written since
+  # log_offset (never the whole file) and to the literal one-shot
+  # hysteresis-activation line — see the header comment for why not the
+  # companion per-poll "...is low..." line. `[ -f "$ENGINE_LOG" ]` guards
+  # against a bed that hasn't produced a log yet (e.g. misconfigured
+  # FABRIK_TEST_DIR) — silently skipping the check rather than aborting the
+  # script under `set -e`, consistent with the budget-report guards above.
+  if [ -f "$ENGINE_LOG" ] \
+      && tail -c "+$((log_offset + 1))" "$ENGINE_LOG" 2>/dev/null | grep -q 'activating rate-limit backoff'; then
+    {
+      echo ""
+      echo "############################################################"
+      echo "## RUN INVALID (leg: ${mode}): GraphQL rate-limit backoff engaged mid-run."
+      echo "## Any test failures/timeouts above may be throttling artifacts, not real"
+      echo "## regressions — this run's verdict cannot be trusted."
+      echo "##"
+      echo "## Engine log: $ENGINE_LOG"
+      echo "## (look for 'activating rate-limit backoff' for the exact event(s))"
+      echo "##"
+      echo "## See tests/e2e/README.md's GraphQL budget section for mitigation"
+      echo "## (E2E_PARALLEL_ON, splitting the leg across budget windows)."
+      echo "############################################################"
+    } >&2
+    exit "$BUDGET_EXHAUSTED_EXIT"
+  fi
+
+  if [ "$rc" -ne 0 ]; then
     return "$rc"
   fi
 }
 
 if [ -n "${E2E_TRAIN_MODE:-}" ]; then
   # Single mode forced by the caller — one switch + one suite invocation.
-  switch_and_run "$E2E_TRAIN_MODE" "$@"
+  # Always uses E2E_PARALLEL (not E2E_PARALLEL_ON), unchanged from before
+  # E2E_PARALLEL_ON existed — see the header comment.
+  switch_and_run "$E2E_TRAIN_MODE" "$PARALLEL" "$@"
 else
   # Default: the full two-mode validation gate. "off" first — see header
-  # comment for why.
-  switch_and_run off "$@"
-  switch_and_run on "$@"
+  # comment for why. "on" gets the tighter E2E_PARALLEL_ON cap.
+  switch_and_run off "$PARALLEL" "$@"
+  switch_and_run on "$PARALLEL_ON" "$@"
 fi

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -281,6 +281,42 @@ report_test_timings() {
     | { column -t -s "$(printf '\t')" 2>/dev/null || cat; }
 }
 
+# detect_rate_limit_backoff scans $1 (a fabrik.log path) for the engine's
+# one-shot rate-limit-backoff-activation line and returns 0 (match) or 1 (no
+# match / file absent). Extracted into its own function — rather than left
+# inline in switch_and_run — specifically so
+# scripts/e2e/backoff_detection_test.sh can exercise it directly against
+# fixtures, independent of an actual gate run.
+#
+# Scans the WHOLE current file, not a captured byte offset: each leg's own
+# bed-restart step (TestSwitchTrainMode, via StopFabrikTestBed +
+# StartFabrikTestBed) always launches a brand-new engine process, and
+# engine/poll.go's Run() opens fabrik.log with O_TRUNC on every startup — so
+# by the time that restart completes the file already contains only this
+# leg's own content, and scanning it in full naturally covers the freshly-
+# restarted engine's first poll through the end of the suite run, with no
+# offset bookkeeping needed and no blind spot between legs. (An earlier
+# version of this script tried to track a pre-restart byte offset instead;
+# that offset was measured against the pre-truncation file and so almost
+# always exceeded the truncated file's size, making `tail -c +N` — and thus
+# the whole leg's detection — silently return nothing. See #1547's review
+# thread for the incident, and backoff_detection_test.sh's
+# "historical broken (byte-offset) approach" case for a fixture that
+# reproduces it and confirms the current whole-file scan is not susceptible.)
+#
+# Matches the literal one-shot hysteresis-activation line — NOT the
+# companion per-poll "...is low (...) consider reducing poll frequency"
+# line, which fires on every poll while low and would over-trigger on a run
+# that dipped briefly without ever crossing the 20% hysteresis-activation
+# threshold. `[ -f "$1" ]` guards against a bed that hasn't produced a log
+# yet (e.g. misconfigured FABRIK_TEST_DIR) — treated as "no match" rather
+# than an error, consistent with the budget-report guards elsewhere in this
+# script.
+detect_rate_limit_backoff() {
+  local logfile="$1"
+  [ -f "$logfile" ] && grep -q 'activating rate-limit backoff' "$logfile" 2>/dev/null
+}
+
 # switch_and_run stops the bed, flips FABRIK_MERGE_TRAIN to $1 in its .env,
 # restarts it (via the dedicated TestSwitchTrainMode invocation — a separate
 # `go test` process so the restart completes, bed fully back up, before the
@@ -401,25 +437,12 @@ switch_and_run() {
   # any point during this leg, regardless of $rc — a throttled run can just
   # as easily present as a pass (if timeouts happened to land after the
   # relevant waits already succeeded) as a fail, so this must not be
-  # conditioned on the leg having failed. Scans the WHOLE current fabrik.log,
-  # not a captured byte offset: the restart step above (TestSwitchTrainMode)
-  # always launches a brand-new engine process, and engine/poll.go's Run()
-  # opens fabrik.log with O_TRUNC on every startup, so by the time that
-  # restart completes the file already contains only this leg's own content
-  # — scanning it in full naturally covers the freshly-restarted engine's
-  # first poll through the end of the suite run, with no offset bookkeeping
-  # needed. (A byte-offset approach was tried and reverted here — see the
-  # header comment's "GraphQL budget exhaustion detection" section for why
-  # an offset captured before the restart is measured against a file the
-  # restart then truncates out from under it, making `tail -c +N` silently
-  # return nothing for the rest of the leg.) Matches the literal one-shot
-  # hysteresis-activation line — see the header comment for why not the
-  # companion per-poll "...is low..." line. `[ -f "$ENGINE_LOG" ]` guards
-  # against a bed that hasn't produced a log yet (e.g. misconfigured
-  # FABRIK_TEST_DIR) — silently skipping the check rather than aborting the
-  # script under `set -e`, consistent with the budget-report guards above.
-  if [ -f "$ENGINE_LOG" ] \
-      && grep -q 'activating rate-limit backoff' "$ENGINE_LOG" 2>/dev/null; then
+  # conditioned on the leg having failed. See detect_rate_limit_backoff's own
+  # comment (above its definition) for why this scans the whole current
+  # fabrik.log rather than a captured byte offset — extracted into its own
+  # function so scripts/e2e/backoff_detection_test.sh can exercise it
+  # directly against fixtures without running an actual gate leg.
+  if detect_rate_limit_backoff "$ENGINE_LOG"; then
     {
       echo ""
       echo "############################################################"
@@ -442,14 +465,24 @@ switch_and_run() {
   fi
 }
 
-if [ -n "${E2E_TRAIN_MODE:-}" ]; then
-  # Single mode forced by the caller — one switch + one suite invocation.
-  # Always uses E2E_PARALLEL (not E2E_PARALLEL_ON), unchanged from before
-  # E2E_PARALLEL_ON existed — see the header comment.
-  switch_and_run "$E2E_TRAIN_MODE" "$PARALLEL" "$@"
-else
-  # Default: the full two-mode validation gate. "off" first — see header
-  # comment for why. "on" gets the tighter E2E_PARALLEL_ON cap.
-  switch_and_run off "$PARALLEL" "$@"
-  switch_and_run on "$PARALLEL_ON" "$@"
+# Guarded so scripts/e2e/backoff_detection_test.sh can `source` this file to
+# reach detect_rate_limit_backoff (and the other helper functions above)
+# without triggering an actual gate run. Everything above this guard (repo
+# root resolution, TEST_BED/ENGINE_LOG/BED_TOKEN setup, function
+# definitions) is safe to execute on source — read-only or pure function
+# definitions, no gate invocation. When executed directly (./run.sh or
+# `bash run.sh`), BASH_SOURCE[0] equals $0, so this still dispatches exactly
+# as before this guard existed.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  if [ -n "${E2E_TRAIN_MODE:-}" ]; then
+    # Single mode forced by the caller — one switch + one suite invocation.
+    # Always uses E2E_PARALLEL (not E2E_PARALLEL_ON), unchanged from before
+    # E2E_PARALLEL_ON existed — see the header comment.
+    switch_and_run "$E2E_TRAIN_MODE" "$PARALLEL" "$@"
+  else
+    # Default: the full two-mode validation gate. "off" first — see header
+    # comment for why. "on" gets the tighter E2E_PARALLEL_ON cap.
+    switch_and_run off "$PARALLEL" "$@"
+    switch_and_run on "$PARALLEL_ON" "$@"
+  fi
 fi

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -113,6 +113,80 @@ If you hit the limit anyway, check the reset time and wait it out:
 gh api rate_limit --jq '.resources.graphql'
 ```
 
+### The two-mode gate's "on" leg: a separate, larger cost driver (#1527)
+
+The `~2x headroom` math above covers the suite's own harness reads and the
+engine's ordinary board polling — it does **not** account for the extra cost
+merge-train mode (`FABRIK_MERGE_TRAIN=on`) adds on top. During the 0.0.78
+pre-release gate (2026-08-09/10), the `on` leg alone drove the bed's GraphQL
+budget from a near-full 4,871 points down to 19% remaining **twice** in one
+run — burning more than a full hour's allowance and then more again after the
+reset — while the `off` leg (69 pass, 0 fail, 0 backoff events) was unaffected.
+The failures that resulted were **all timeouts**, not assertion violations:
+once backoff engages, polling slows enough that board items sit in `Queued` /
+`fabrik:awaiting-ci` past scenarios' wait deadlines.
+
+**Root cause, confirmed by static analysis (not the merge-train worker's own
+CI polling — that's REST, a separate budget):** the ADR-1270/ADR-1208 settle-
+scan pattern —
+[`settleAwaitingCIScan`](../../engine/ci_settle.go) (both legs, any
+`wait_for_ci` stage) and, merge-train-exclusively,
+[`settleQueuedReviewFindings`](../../engine/queued_review_settle.go) — each
+performs an unconditional, no-cooldown `FetchItemDetails` **GraphQL deep-fetch**
+(the single most expensive query in the codebase: `comments(first:100)` +
+`closedByPullRequestsReferences` with nested `comments`/`reviewThreads`/
+`latestReviews`/`reviewRequests`) for every matching item, every poll cycle.
+This is a *documented, correctness-motivated trade-off*, not a bug —
+`settleQueuedReviewFindings` exists specifically to close a review-finding
+blackout window on `Queued` merge-train members (ADR-1208), and its "every
+member, every poll" semantics are load-bearing for that guarantee. Cost is
+therefore proportional to **how many items are concurrently Queued /
+awaiting-CI**, not to how fast the train itself polls — which is why the `on`
+leg (17 scenarios vs. 13 for `off`, since train-only scenarios skip near-
+instantly under `off`) is the one that exhausts the budget.
+
+**Mitigation shipped in #1527 (does not touch the settle scans' per-item
+correctness guarantees):**
+
+- **`E2E_PARALLEL_ON`** (default 2, half of `E2E_PARALLEL`'s default 4) caps
+  concurrency specifically on the two-mode gate's `on` leg, shrinking the
+  population those scans iterate. `off` and any forced single-mode run
+  (`E2E_TRAIN_MODE` set explicitly) are unaffected — they keep using
+  `E2E_PARALLEL`.
+- **Fail-loud detection (R2), independent of whether the cap above is enough:**
+  `scripts/e2e/run.sh` now scans the bed's `fabrik.log` after each leg (scoped
+  to just that leg's own output) for the engine's one-shot
+  `"...activating rate-limit backoff"` line. On a match — regardless of the
+  leg's own pass/fail exit code — the script prints a `RUN INVALID` banner and
+  exits with a dedicated code (`3`, distinct from `go test`'s propagated `1`),
+  short-circuiting any remaining leg. A throttled run must never be reported
+  in a way that reads like a normal pass/fail; see `scripts/e2e/run.sh`'s
+  header comment ("GraphQL budget exhaustion detection") for the full
+  mechanism.
+- **Per-leg cost visibility (A3):** each leg is now bracketed with
+  `gh api rate_limit --jq '.resources.graphql.remaining'` calls, so every run
+  reports its own actual GraphQL consumption — the manual check documented
+  above is now automatic, per leg, on every invocation.
+
+**Measured per-leg cost:** not yet captured — obtaining it requires a live
+two-mode (or per-leg) gate run against the `~/dev/fabrik-test` bed, which
+is a multi-hour, real-GitHub-mutating operation not run as part of landing
+this change. To fill in this table, run:
+
+```bash
+E2E_TRAIN_MODE=off scripts/e2e/run.sh   # then, separately:
+E2E_TRAIN_MODE=on  scripts/e2e/run.sh
+```
+
+and record each leg's `== GraphQL budget (leg: ...): N -> M remaining
+(consumed D pts) ==` line below:
+
+| Leg | GraphQL pts consumed | Backoff events | Notes |
+|---|---|---|---|
+| `off` | _pending measurement_ | _pending_ | Historically 0 backoff events (0.0.78 gate) |
+| `on`, after `off` | _pending measurement_ | _pending_ | `E2E_PARALLEL_ON` applied |
+| `on`, alone (full budget) | _pending measurement_ | _pending_ | `E2E_PARALLEL_ON` applied |
+
 ### Additional prerequisites for `TestCIFixReinvoke` and `TestCIFixReinvokeCycleLimit`
 
 5. **`ci-fix-sentinel` enrolled as a required status check** on
@@ -842,6 +916,13 @@ above: a starved scenario now has enough wall-clock room to actually finish
 rather than racing a too-tight deadline. See `E2E_PARALLEL=2` /
 `E2E_PARALLEL=6` above for the documented escape hatches if you observe a
 repeated starvation pattern in practice.
+
+**Update (#1527): `E2E_PARALLEL` itself is still kept at 4** — the analysis
+above still holds — but the "on" leg specifically now gets a tighter,
+independent cap (`E2E_PARALLEL_ON`, default 2) for a different reason than
+oversubscription: it's the GraphQL cost of the ADR-1270/ADR-1208 settle-scan
+pattern, not bed contention. See "The two-mode gate's 'on' leg: a separate,
+larger cost driver (#1527)" above.
 
 #### Timeout & failure reporting
 


### PR DESCRIPTION
Closes #1527

## What this does

The two-mode e2e gate's `on` leg (`scripts/e2e/run.sh`) couldn't complete without exhausting GitHub's hourly GraphQL allowance, producing a wall of indistinguishable test timeouts instead of a trustworthy verdict — hit three times during the 0.0.78 pre-release gate. This PR ships both required workstreams together, R1 (cost reduction) and R2 (fail-loud detection), plus R3's confirmation logging and A3's documentation.

**R3 — confirmed the cost driver (static analysis, this issue's own Research):** not merge-train's own CI polling (that's REST, a separate budget), but the ADR-1270/ADR-1208 settle-scan pattern — `settleAwaitingCIScan` and, merge-train-exclusively, `settleQueuedReviewFindings` — each doing an unconditional, no-cooldown GraphQL deep-fetch per matching item per poll. That per-item semantics is load-bearing for ADR-1208's correctness guarantee and is left untouched.

**R1 — cost reduction:** added `E2E_PARALLEL_ON` (default 2, half of `E2E_PARALLEL`'s default 4), applied only to the default two-mode gate's `on` leg. Fewer concurrent scenarios → smaller Queued/awaiting-CI population → less settle-scan cost, without weakening the scans' own per-item correctness guarantees. `off` and any forced single-mode run keep using `E2E_PARALLEL` unchanged.

**R2 — fail-loud detection, independent of whether R1 fully eliminates the risk:** after each leg, `run.sh` scans the bed's `fabrik.log` (scoped to just that leg's own output) for the engine's one-shot `"...activating rate-limit backoff"` line. On a match — regardless of the leg's pass/fail exit code — it prints an unambiguous `RUN INVALID` banner and exits with a new dedicated code (`3`, distinct from `go test`'s propagated `1`), short-circuiting any remaining leg.

The detection logic went through two follow-up fixes during review, both from real defects found in the byte-offset-based first cut:
1. The offset was originally captured *before* the bed restart, leaving the restart window (including the freshly-restarted engine's very first poll) unscanned.
2. Moving the capture point wasn't enough: `engine/poll.go`'s `Run()` truncates `fabrik.log` (`O_TRUNC`) on every engine startup, and the restart always launches a fresh process — so a pre-restart offset is measured against a file the restart then truncates out from under it, making `tail -c +N` silently return nothing for the rest of the leg. The fix (commit `2af83849`) replaced offset-tracking entirely with a whole-file scan: since the restart always truncates the log, the file already contains only this leg's own content the moment the restart completes, so there's nothing to scope past.

That whole-file-scan detection logic is now covered by an automated, non-vacuous regression test (`scripts/e2e/backoff_detection_test.sh`, added in response to review) — see "How to test" below.

**A3 groundwork:** each leg is now bracketed with `gh api rate_limit` calls, so real GraphQL cost is reported automatically on every future run. `queued_review_settle.go` also gets the cache-hit-vs-deep-fetch attribution log line `ci_settle.go` already had, closing a logging-parity gap.

`tests/e2e/README.md`'s GraphQL budget section is extended with the root-cause analysis, the shipped mitigations, and a placeholder cost table with the exact reproduction command (obtaining real numbers requires a multi-hour, real-GitHub-mutating run against the shared bed, which this PR does not launch unilaterally).

## Key changes

- `engine/queued_review_settle.go` — additive cache-hit/deep-fetch attribution log line (no behavior change)
- `scripts/e2e/run.sh` — `E2E_PARALLEL_ON`, per-leg `gh api rate_limit` bracketing, post-leg rate-limit-backoff log scan (via a standalone `detect_rate_limit_backoff` function) with `RUN INVALID` banner + exit code 3, a sourcing guard so the detection function is independently testable, expanded header comment
- `scripts/e2e/backoff_detection_test.sh` — new: automated, non-vacuous regression test for the backoff-detection logic (5 cases, including a neutralization case against the historical broken byte-offset approach)
- `tests/e2e/README.md` — new "two-mode gate's 'on' leg" subsection in the GraphQL budget section

## How to test

- `go build ./...`, `go vet ./...` — clean
- `go test ./engine/... -race -run 'QueuedReview'` — all existing `settleQueuedReviewFindings` tests pass, new log line confirmed in test output
- `bash -n` and `shellcheck` on both `scripts/e2e/run.sh` and `scripts/e2e/backoff_detection_test.sh` — clean
- `./scripts/e2e/backoff_detection_test.sh` — automated, non-vacuous coverage for R2's detection logic, added in response to review. Exercises the *actual* `detect_rate_limit_backoff` function (sourced from `run.sh`, not a reimplementation) against 5 fixtures:
  1. no backoff activity → no match
  2. the companion per-poll "is low..." line alone (deliberately excluded — see header comment) → no match
  3. the one-shot activation line, no truncation → match
  4. **the field regression itself**: the activation line logged only *after* a mid-leg `fabrik.log` truncation (simulating the engine restart's `O_TRUNC`) → match, confirming the current whole-file-scan approach is not susceptible to the offset-based failure mode described in review
  5. **neutralization**: the same truncated fixture from case 4, run through a deliberately-reintroduced copy of the historical byte-offset approach (`tail -c "+$((log_offset+1))"` against an offset captured pre-truncation) → does **not** match, proving case 4 exercises the real regression and that a future reintroduction of offset-based scanning would be caught by this test rather than only discovered on a live multi-hour bed run

  All 5 pass; exit code 0.
- Full `go test ./... -race` passes except one pre-existing, unrelated flake (`cmd.TestExecute_ConfigYAMLApplied`, a SIGINT-timing test unrelated to this change — confirmed via `git diff --name-only origin/main...HEAD` that `cmd/` is untouched)

No live two-mode gate run was executed as part of this PR (multi-hour, real-GitHub-mutating operation against the shared bed) — A3's measured-cost table is a placeholder with reproduction instructions for the next person to fill in.
