### PR TITLE
fix(pruefer): four defects surfaced by the PR #1255 thread audit

### DIFF
--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -3,7 +3,6 @@ package pruefer
 import (
 	"context"
 	"fmt"
-	"hash/fnv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -93,12 +92,15 @@ type Daemon struct {
 	semOnce sync.Once
 	sem     chan struct{}
 
-	// prLocks is a small fixed-size set of stripe mutexes serializing
-	// concurrent review dispatch for the same PR across poll- and
-	// event-triggered paths — see prLock and runReview. A zero Daemon
-	// (struct literal) has a usable zero-value [prLockStripes]sync.Mutex,
-	// so no lazy-init is needed here unlike sem.
-	prLocks [prLockStripes]sync.Mutex
+	// prGates serializes concurrent review dispatch for the same PR across
+	// poll- and event-triggered paths — see acquirePRGate and runReview.
+	// Entries are reference-counted and removed when the last holder
+	// releases, so the map is bounded by in-flight dispatch (at most
+	// concurrency_cap + poll fan-out), not by the number of PRs the daemon
+	// has ever seen. Lazily created on first use, so a zero Daemon (struct
+	// literal) remains usable.
+	prGates   map[string]*prGate
+	prGatesMu sync.Mutex
 
 	// pollInFlight coalesces concurrent installation-event-triggered
 	// reconciliation polls — see triggerReconciliationPoll. A zero Daemon
@@ -107,20 +109,69 @@ type Daemon struct {
 	pollInFlight atomic.Bool
 }
 
-// prLockStripes bounds prLocks to a small fixed size instead of an
-// unbounded per-PR map that would grow for the daemon's entire lifetime.
-// Unrelated PRs occasionally hashing to the same stripe only costs
-// incidental contention (they still fully serialize against each other),
-// never a correctness gap — the property runReview needs is "no two
-// reviews of the *same* PR run concurrently," which holds regardless.
-const prLockStripes = 64
+// clientForOwner resolves the per-owner installation client, falling back to
+// a case-insensitive scan when the exact key misses. Clients is keyed by the
+// owner strings in WatchedRepos (operator-typed), but event-driven callers
+// look it up with the owner from a webhook payload (GitHub's canonical
+// casing) — see isWatchedRepo for why those two can diverge. Without the
+// fallback, a casing mismatch drops every event for that owner while
+// isWatchedRepo happily admits it.
+func (d *Daemon) clientForOwner(owner string) (GitHubLister, bool) {
+	if c, ok := d.Clients[owner]; ok {
+		return c, true
+	}
+	for k, c := range d.Clients {
+		if strings.EqualFold(k, owner) {
+			return c, true
+		}
+	}
+	return nil, false
+}
 
-// prLock returns the stripe mutex for owner/repo/prNumber, selected by
-// hashing the PR's identity. See prLocks and runReview.
-func (d *Daemon) prLock(owner, repo string, prNumber int) *sync.Mutex {
-	h := fnv.New32a()
-	fmt.Fprintf(h, "%s/%s#%d", owner, repo, prNumber)
-	return &d.prLocks[h.Sum32()%prLockStripes]
+// prGate is one PR's dispatch gate, plus the reference count that decides
+// when it can be dropped from prGates.
+type prGate struct {
+	mu   sync.Mutex
+	refs int
+}
+
+// acquirePRGate returns the gate for owner/repo/prNumber and a release func
+// the caller must invoke when done (after unlocking). The gate is exact: it
+// is keyed by the PR's identity, not by a hash bucket.
+//
+// This replaces an earlier fixed 64-stripe scheme. Striping was sound for
+// runReview, which *blocks* on the lock — two unrelated PRs sharing a stripe
+// only serialize unnecessarily. It was not sound for ReviewFromEvent, which
+// *TryLocks* and drops on failure: a stripe collision there made an unrelated
+// PR's in-flight review look like this PR's, so the event was discarded with
+// the log line "a review is already in flight for this PR" — which was false,
+// and the dropped review never happened.
+//
+// The key is lowercased so the same PR referred to with different owner/repo
+// casing resolves to one gate (see isWatchedRepo on why casing can vary).
+func (d *Daemon) acquirePRGate(owner, repo string, prNumber int) (*prGate, func()) {
+	key := fmt.Sprintf("%s/%s#%d", strings.ToLower(owner), strings.ToLower(repo), prNumber)
+
+	d.prGatesMu.Lock()
+	if d.prGates == nil {
+		d.prGates = make(map[string]*prGate)
+	}
+	g, ok := d.prGates[key]
+	if !ok {
+		g = &prGate{}
+		d.prGates[key] = g
+	}
+	g.refs++
+	d.prGatesMu.Unlock()
+
+	return g, func() {
+		d.prGatesMu.Lock()
+		defer d.prGatesMu.Unlock()
+		g.refs--
+		if g.refs <= 0 {
+			delete(d.prGates, key)
+		}
+	}
 }
 
 // semaphore returns the daemon's shared concurrency-capped semaphore,
@@ -348,7 +399,13 @@ func (d *Daemon) runEventDriven(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			d.poll(ctx)
+			// Route through triggerReconciliationPoll rather than calling
+			// d.poll directly: triggerReconciliationPoll documents "only one
+			// poll runs at a time", and calling poll here bypassed the
+			// pollInFlight guard entirely, so a fallback tick could run a full
+			// ListOpenPRs sweep concurrently with an install-event- or
+			// reconnect-triggered reconciliation poll.
+			d.triggerReconciliationPoll(ctx)
 		case err := <-sourceDone:
 			if ctx.Err() != nil {
 				return nil
@@ -517,9 +574,10 @@ func (d *Daemon) reviewOne(ctx context.Context, wg *sync.WaitGroup, client GitHu
 // and skip, restoring the single-flight-per-PR property the SHA-idempotency
 // guarantee assumes.
 func (d *Daemon) runReview(ctx context.Context, client GitHubLister, owner, repo string, pr gh.PRDetails) {
-	mu := d.prLock(owner, repo, pr.Number)
-	mu.Lock()
-	defer mu.Unlock()
+	g, release := d.acquirePRGate(owner, repo, pr.Number)
+	defer release()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	d.executeReview(ctx, client, owner, repo, pr)
 }
 
@@ -559,10 +617,17 @@ func (d *Daemon) executeReview(ctx context.Context, client GitHubLister, owner, 
 // "every connection visible to this API key," not scoped to watched repos —
 // so a webhook event for an unwatched repo under a watched owner is a
 // plausible real delivery, not just a hypothetical one.
+// Matching is case-insensitive: GitHub treats owner and repository names as
+// case-insensitive, and the two sides of this comparison have different
+// provenance — `owner`/`repo` come from the webhook payload's
+// `repository.owner.login`/`repository.name` (GitHub's canonical casing at
+// delivery time), while WatchedRepos is hand-typed config. A casing
+// divergence between them, including one introduced by a later owner or repo
+// rename, would otherwise silently drop every event for that repo.
 func (d *Daemon) isWatchedRepo(owner, repo string) bool {
 	target := owner + "/" + repo
 	for _, spec := range d.Config.WatchedRepos {
-		if spec == target {
+		if strings.EqualFold(spec, target) {
 			return true
 		}
 	}

--- a/pruefer/events/hookdeck/log.go
+++ b/pruefer/events/hookdeck/log.go
@@ -21,8 +21,18 @@ import (
 var logfHook atomic.Pointer[func(format string, args ...any)]
 
 // SetLogf installs the package-level logger hook. Safe to call at any time,
-// concurrently with logf's reads.
+// concurrently with logf's reads. SetLogf(nil) clears the hook, restoring the
+// stderr fallback.
+//
+// The nil case must store a nil pointer rather than &fn: &fn is always a
+// non-nil *T even when fn itself is nil, so storing it would make logf's
+// `p != nil` check pass and then call a nil func value — a panic on the next
+// log line, from a function documented as safe to call at any time.
 func SetLogf(fn func(format string, args ...any)) {
+	if fn == nil {
+		logfHook.Store(nil)
+		return
+	}
 	logfHook.Store(&fn)
 }
 

--- a/pruefer/events/hookdeck/log_nil_test.go
+++ b/pruefer/events/hookdeck/log_nil_test.go
@@ -1,0 +1,59 @@
+package hookdeck
+
+import "testing"
+
+// TestSetLogfNilDoesNotPanic is the regression test for SetLogf(nil) storing
+// &fn — always a non-nil *T even when fn is nil — which made logf's `p != nil`
+// check pass and then invoke a nil func value. The panic surfaced on the next
+// log line, not at the SetLogf call, from a function whose doc says it is safe
+// to call at any time.
+func TestSetLogfNilDoesNotPanic(t *testing.T) {
+	t.Cleanup(func() { logfHook.Store(nil) })
+
+	SetLogf(func(string, ...any) {})
+	SetLogf(nil)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logf panicked after SetLogf(nil): %v", r)
+		}
+	}()
+	logf("probe %d\n", 1)
+}
+
+// TestSetLogfNilRestoresStderrFallback: clearing the hook must fall back to
+// stderr rather than silently dropping output, which is what the doc comment
+// promises and what an operator debugging a live daemon depends on.
+func TestSetLogfNilRestoresStderrFallback(t *testing.T) {
+	t.Cleanup(func() { logfHook.Store(nil) })
+
+	called := 0
+	SetLogf(func(string, ...any) { called++ })
+	logf("first\n")
+	if called != 1 {
+		t.Fatalf("installed hook received %d calls, want 1", called)
+	}
+
+	SetLogf(nil)
+	logf("second\n")
+	if called != 1 {
+		t.Fatalf("hook received %d calls after SetLogf(nil), want it to stay at 1", called)
+	}
+	if p := logfHook.Load(); p != nil {
+		t.Fatal("SetLogf(nil) left a non-nil hook pointer, so logf would call through it")
+	}
+}
+
+// TestSetLogfReinstallAfterNil guards the round trip: clearing then reinstalling
+// must route to the new hook.
+func TestSetLogfReinstallAfterNil(t *testing.T) {
+	t.Cleanup(func() { logfHook.Store(nil) })
+
+	SetLogf(nil)
+	got := 0
+	SetLogf(func(string, ...any) { got++ })
+	logf("third\n")
+	if got != 1 {
+		t.Fatalf("reinstalled hook received %d calls, want 1", got)
+	}
+}

--- a/pruefer/eventsink.go
+++ b/pruefer/eventsink.go
@@ -49,7 +49,7 @@ import (
 // is always invoked in its own goroutine there) or it would stall acking
 // the current webhook and reading the next one off the same connection.
 func (d *Daemon) ReviewFromEvent(ctx context.Context, owner, repo string, prNumber int) {
-	client, ok := d.Clients[owner]
+	client, ok := d.clientForOwner(owner)
 	if !ok {
 		logf(prNumber, "warn", "event for %s/%s#%d: no client for owner %q — dropping\n", owner, repo, prNumber, owner)
 		return
@@ -67,12 +67,14 @@ func (d *Daemon) ReviewFromEvent(ctx context.Context, owner, repo string, prNumb
 	}
 	defer func() { <-sem }()
 
-	mu := d.prLock(owner, repo, prNumber)
-	if !mu.TryLock() {
+	g, release := d.acquirePRGate(owner, repo, prNumber)
+	if !g.mu.TryLock() {
+		release()
 		logf(prNumber, "info", "event for %s/%s#%d: a review is already in flight for this PR — dropping\n", owner, repo, prNumber)
 		return
 	}
-	defer mu.Unlock()
+	defer release()
+	defer g.mu.Unlock()
 
 	pr, err := client.FetchPRDetails(owner, repo, prNumber)
 	if err != nil {

--- a/pruefer/eventsink_test.go
+++ b/pruefer/eventsink_test.go
@@ -428,12 +428,13 @@ func TestDaemonEventSink_ReviewFromEvent_AcquiresSemaphoreBeforePRLock(t *testin
 		t.Fatal("bystander review never started")
 	}
 
-	// Simulate another in-flight review of PR #1 by holding its stripe lock
+	// Simulate another in-flight review of PR #1 by holding its gate
 	// directly — the same state runReview would have already established
 	// for a real in-flight review.
-	prLock := d.prLock("owner", "repo", 1)
-	prLock.Lock()
-	defer prLock.Unlock()
+	gate, releaseGate := d.acquirePRGate("owner", "repo", 1)
+	gate.mu.Lock()
+	defer releaseGate()
+	defer gate.mu.Unlock()
 
 	done := make(chan struct{})
 	go func() {

--- a/pruefer/fallback_coalesce_test.go
+++ b/pruefer/fallback_coalesce_test.go
@@ -1,0 +1,89 @@
+package pruefer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/handarbeit/fabrik/pruefer/events"
+)
+
+// blockingEventSource stands in for a live EventSource: it never returns until
+// ctx is cancelled, matching the documented contract, so runEventDriven's loop
+// is driven purely by the fallback ticker.
+type blockingEventSource struct{}
+
+func (blockingEventSource) Run(ctx context.Context, _ events.EventSink) error {
+	<-ctx.Done()
+	return nil
+}
+
+// TestFallbackTickerCoalescesWithInFlightPoll is the regression test for the
+// fallback ticker bypassing triggerReconciliationPoll's pollInFlight guard.
+//
+// triggerReconciliationPoll documents "Only one poll runs at a time", but the
+// ticker case called d.poll(ctx) directly, so a fallback tick could start a
+// full ListOpenPRs sweep while an install-event- or reconnect-triggered
+// reconciliation poll was already running. With pollInFlight already set, no
+// poll may start.
+func TestFallbackTickerCoalescesWithInFlightPoll(t *testing.T) {
+	client := newFakeLister()
+	client.prsByRepo["owner/repo"] = nil
+
+	d := &Daemon{
+		Clients:     map[string]GitHubLister{"owner": client},
+		EventSource: blockingEventSource{},
+		Config: Config{
+			WatchedRepos:                   []string{"owner/repo"},
+			ReconciliationFallbackInterval: 10 * time.Millisecond,
+		},
+	}
+
+	// Simulate a reconciliation poll already in flight, exactly as
+	// triggerReconciliationPoll would have left it.
+	if !d.pollInFlight.CompareAndSwap(false, true) {
+		t.Fatal("pollInFlight unexpectedly already set on a fresh Daemon")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	_ = d.runEventDriven(ctx)
+
+	// Many ticks fired during that window. Every one must have been coalesced
+	// away, so the fake never saw a listing call.
+	if got := client.listOpenPRsCallCount(); got != 0 {
+		t.Fatalf("fallback ticker ran %d poll(s) while a reconciliation poll was in flight; want 0 (coalesced)", got)
+	}
+}
+
+// TestFallbackTickerPollsWhenIdle is the companion: with nothing in flight, the
+// ticker must still drive reconciliation, or the fix above would have silently
+// disabled the fallback safety net.
+func TestFallbackTickerPollsWhenIdle(t *testing.T) {
+	client := newFakeLister()
+	client.prsByRepo["owner/repo"] = nil
+
+	d := &Daemon{
+		Clients:     map[string]GitHubLister{"owner": client},
+		EventSource: blockingEventSource{},
+		Config: Config{
+			WatchedRepos:                   []string{"owner/repo"},
+			ReconciliationFallbackInterval: 10 * time.Millisecond,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	_ = d.runEventDriven(ctx)
+
+	// triggerReconciliationPoll runs the poll in its own goroutine; give the
+	// last one a moment to land before sampling.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if client.listOpenPRsCallCount() > 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("fallback ticker never polled while idle — the reconciliation safety net is dead")
+}

--- a/pruefer/prgate_test.go
+++ b/pruefer/prgate_test.go
@@ -1,0 +1,162 @@
+package pruefer
+
+import (
+	"testing"
+)
+
+// TestAcquirePRGateDistinctPRsGetDistinctGates is the regression test for the
+// 64-stripe collision defect: ReviewFromEvent TryLocks the gate and drops the
+// event when the claim fails, so two unrelated PRs sharing a lock meant one
+// PR's in-flight review silently suppressed the other's — logged, misleadingly,
+// as "a review is already in flight for this PR".
+//
+// With the old fixed 64-stripe scheme this fails by construction: 200 distinct
+// PR numbers cannot map to 64 stripes without collisions (pigeonhole).
+func TestAcquirePRGateDistinctPRsGetDistinctGates(t *testing.T) {
+	d := &Daemon{}
+
+	const numPRs = 200
+	seen := make(map[*prGate]int, numPRs)
+	releases := make([]func(), 0, numPRs)
+	t.Cleanup(func() {
+		for _, r := range releases {
+			r()
+		}
+	})
+
+	for i := 1; i <= numPRs; i++ {
+		g, release := d.acquirePRGate("owner", "repo", i)
+		releases = append(releases, release)
+		if prev, dup := seen[g]; dup {
+			t.Fatalf("PR #%d shares a gate with PR #%d — a TryLock on one would falsely drop the other", i, prev)
+		}
+		seen[g] = i
+	}
+}
+
+// TestAcquirePRGateSamePRSharesGate is the other half of the contract: the
+// gate must still serialize two callers naming the same PR, which is the
+// single-flight property runReview depends on.
+func TestAcquirePRGateSamePRSharesGate(t *testing.T) {
+	d := &Daemon{}
+
+	g1, r1 := d.acquirePRGate("owner", "repo", 7)
+	defer r1()
+	g2, r2 := d.acquirePRGate("owner", "repo", 7)
+	defer r2()
+
+	if g1 != g2 {
+		t.Fatal("two callers for the same PR got different gates — concurrent duplicate reviews would be possible")
+	}
+	if !g1.mu.TryLock() {
+		t.Fatal("gate unexpectedly already locked")
+	}
+	defer g1.mu.Unlock()
+	if g2.mu.TryLock() {
+		g2.mu.Unlock()
+		t.Fatal("second caller claimed the same PR's gate while it was held")
+	}
+}
+
+// TestAcquirePRGateCaseInsensitive: the same PR referred to with different
+// owner/repo casing must resolve to one gate, or the casing divergence that
+// isWatchedRepo now tolerates would reintroduce concurrent duplicate reviews.
+func TestAcquirePRGateCaseInsensitive(t *testing.T) {
+	d := &Daemon{}
+
+	g1, r1 := d.acquirePRGate("Handarbeit", "Fabrik", 42)
+	defer r1()
+	g2, r2 := d.acquirePRGate("handarbeit", "fabrik", 42)
+	defer r2()
+
+	if g1 != g2 {
+		t.Fatal("same PR with different casing got different gates")
+	}
+}
+
+// TestAcquirePRGateReleasedGatesAreEvicted pins the bound that justified
+// replacing the fixed-size stripe array with a map: entries must not
+// accumulate for the daemon's lifetime.
+func TestAcquirePRGateReleasedGatesAreEvicted(t *testing.T) {
+	d := &Daemon{}
+
+	for i := 1; i <= 500; i++ {
+		_, release := d.acquirePRGate("owner", "repo", i)
+		release()
+	}
+
+	d.prGatesMu.Lock()
+	n := len(d.prGates)
+	d.prGatesMu.Unlock()
+
+	if n != 0 {
+		t.Fatalf("prGates retained %d entries after every holder released; expected 0", n)
+	}
+}
+
+// TestAcquirePRGateRefcountedAcrossHolders: a gate must survive one holder
+// releasing while another still holds it, or the surviving holder's lock stops
+// excluding anyone.
+func TestAcquirePRGateRefcountedAcrossHolders(t *testing.T) {
+	d := &Daemon{}
+
+	g1, r1 := d.acquirePRGate("owner", "repo", 3)
+	_, r2 := d.acquirePRGate("owner", "repo", 3)
+	r2()
+
+	g3, r3 := d.acquirePRGate("owner", "repo", 3)
+	defer r3()
+	if g1 != g3 {
+		t.Fatal("gate was evicted while a holder still had a reference")
+	}
+	r1()
+}
+
+// TestIsWatchedRepoCaseInsensitive: owner/repo arrive from the webhook payload
+// in GitHub's canonical casing, while WatchedRepos is hand-typed. A divergence
+// silently dropped every event for that repo.
+func TestIsWatchedRepoCaseInsensitive(t *testing.T) {
+	d := &Daemon{Config: Config{WatchedRepos: []string{"handarbeit/fabrik"}}}
+
+	for _, tc := range []struct {
+		owner, repo string
+		want        bool
+	}{
+		{"handarbeit", "fabrik", true},
+		{"Handarbeit", "Fabrik", true},
+		{"HANDARBEIT", "FABRIK", true},
+		{"handarbeit", "fabrik-test", false},
+		{"someoneelse", "fabrik", false},
+	} {
+		if got := d.isWatchedRepo(tc.owner, tc.repo); got != tc.want {
+			t.Errorf("isWatchedRepo(%q, %q) = %v, want %v", tc.owner, tc.repo, got, tc.want)
+		}
+	}
+}
+
+// TestClientForOwnerCaseInsensitive: Clients is keyed by the operator-typed
+// owner, looked up with the webhook's canonical casing. Without the fallback a
+// casing mismatch dropped every event for that owner — while isWatchedRepo
+// admitted it, so the two checks disagreed.
+func TestClientForOwnerCaseInsensitive(t *testing.T) {
+	client := newFakeLister()
+	d := &Daemon{Clients: map[string]GitHubLister{"handarbeit": client}}
+
+	if got, ok := d.clientForOwner("handarbeit"); !ok || got != GitHubLister(client) {
+		t.Error("exact-case lookup failed")
+	}
+	if got, ok := d.clientForOwner("Handarbeit"); !ok || got != GitHubLister(client) {
+		t.Errorf("case-insensitive fallback failed for %q", "Handarbeit")
+	}
+	if _, ok := d.clientForOwner("someoneelse"); ok {
+		t.Error("unknown owner resolved to a client")
+	}
+}
+
+// TestClientForOwnerNoClients guards the nil-map path.
+func TestClientForOwnerNoClients(t *testing.T) {
+	d := &Daemon{}
+	if _, ok := d.clientForOwner("handarbeit"); ok {
+		t.Error("resolved a client from a nil Clients map")
+	}
+}


### PR DESCRIPTION
Four real defects found by auditing the 53 review threads that were still unresolved when #1255 merged.

## Audit result

| | Count |
|---|---|
| Already fixed in code — thread simply never resolved | 5 |
| Deliberate, documented trade-offs (ack-200 policy, uncapped fan-out, `flexHeaders` shapes, forward-looking `Installation`/`Payload` fields) | ~19 |
| **Genuinely open** | **~29** |

Of the genuinely-open set, these four are bugs rather than commentary. The rest are smaller (config parse errors swallowed, `NewSource` not validating a "Required" secret, 401/403 retried as transient, the `DataString` byte-exactness assumption) and are left for a follow-up.

## Fixes

**1. `hookdeck.SetLogf(nil)` panicked on the next log line.** `&fn` is a non-nil `*T` even when `fn` is nil, so `logf`'s `p != nil` check passed and then invoked a nil func value — from a function whose doc says it is safe to call at any time. Now stores a nil pointer.

**2. The reconciliation fallback ticker bypassed poll coalescing.** It called `d.poll(ctx)` directly instead of `triggerReconciliationPoll`, so a fallback tick could run a full `ListOpenPRs` sweep concurrently with an install-event- or reconnect-triggered poll — contradicting `triggerReconciliationPoll`'s own *"Only one poll runs at a time"* doc comment. Three reviewers flagged this independently.

**3. Stripe-lock collisions silently dropped reviews.** The 64-way `prLock` array was sound for `runReview`, which *blocks* — two unrelated PRs sharing a stripe only serialize unnecessarily. It was not sound for `ReviewFromEvent`, which *TryLocks* and drops on failure: a collision made an unrelated PR's in-flight review look like this PR's, so the event was discarded with the log line *"a review is already in flight for this PR"* — false, and the review never happened. Replaced with an exact, reference-counted per-PR gate, bounded by in-flight dispatch rather than by PRs seen over the daemon's lifetime (the unbounded-map growth the stripes existed to avoid).

**4. Case-sensitive owner/repo matching.** `isWatchedRepo` and the `Daemon.Clients` lookup compared webhook-supplied names (GitHub's canonical casing) against hand-typed config. A divergence — including one introduced by a later owner/repo rename — silently dropped every event for that repo, while the two checks could also disagree with each other. Both are now case-insensitive, and the gate key is lowercased so one PR cannot acquire two gates.

## Verification

Every new test is demonstrated non-vacuous by neutralising its fix:

- log tests → `panic: invalid memory address or nil pointer dereference`
- coalescing test → `fallback ticker ran 15 poll(s) while a reconciliation poll was in flight; want 0`
- gate test → fails by pigeonhole against 64 stripes (200 distinct PRs)

`go test -race ./pruefer/...`, `go test ./...`, `go vet ./...`, and `gofmt` all clean.

## Note

Opened by hand rather than through the pipeline, so there is no `Closes #N`. Nothing here is Fabrik-discoverable; happy to file a tracking issue if you want it on the board.