### PR TITLE
docs: add ADR reference integrity check, fix dangling ADR-1303 citation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,14 @@ jobs:
       # a stderr warning rather than failing under set -euo pipefail.
       - name: backoff-detection regression test (#1527)
         run: bash scripts/e2e/backoff_detection_test.sh
+
+      # ADR citation integrity. ADRs are numbered after their originating
+      # issue (CLAUDE.md's "ADR numbering"), so issue and ADR numbers share
+      # one namespace and "ADR-1303" vs "#1303" is a one-token, invisible
+      # slip — one that shipped in adrs/1408-*.md and survived until a manual
+      # sweep. The docs-drift workflow does not cover this: it regenerates
+      # docs/llms-full.txt and diffs it, verifying the bundle matches its
+      # sources rather than verifying any claim. Pure text/filesystem check —
+      # no build, no network.
+      - name: ADR reference integrity
+        run: bash scripts/check-adr-references.sh

--- a/adrs/1408-ci-gate-pause-comment-reuse-on-resume.md
+++ b/adrs/1408-ci-gate-pause-comment-reuse-on-resume.md
@@ -202,7 +202,7 @@ This is not a new instance of the "dedicated `board.Items`-sourced settle scan" 
 (ADR-060/061/062/1097/1270/1387) — `settleAwaitingCIScan` already is that scan for
 `fabrik:awaiting-ci`. This issue is instead a correctness fix *within* that scan's own escalation
 path: the scan's admission was already correct (ADR-1270); its downstream handler-chain reachability
-was already correct (ADR-1303, §6.14.1); this fix corrects a divergent-outcome bug in the escalation
+was already correct (#1303, §6.14.1); this fix corrects a divergent-outcome bug in the escalation
 call itself, matching the "zero remaining owners" shape [ADR-1387](1387-closed-items-never-dispatched.md)
 names for a structurally different mechanism (closed-item dispatch), applied here to a resumed item's
 pause/re-escalation call instead.

--- a/scripts/check-adr-references.sh
+++ b/scripts/check-adr-references.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# scripts/check-adr-references.sh — fail on ADR citations that name no ADR.
+#
+# Why this exists: ADRs are numbered after the issue they come from (see
+# CLAUDE.md's "ADR numbering" section), so issue numbers and ADR numbers share
+# one namespace. "ADR-1303" and "#1303" are one token apart and look equally
+# plausible to a reader, but only one of them is true — #1303 is an issue with
+# no ADR. That exact slip shipped in adrs/1408-*.md and stood undetected until
+# a manual sweep found it.
+#
+# Nothing else in CI checks documentation claims. The docs-drift workflow
+# regenerates docs/llms-full.txt and diffs it, which verifies the bundle
+# matches its sources — a concatenation check, not a truth check. This script
+# does not check truth either, but it does check the one property that is
+# mechanically decidable: that every cited ADR exists.
+#
+# Scope: adrs/*.md, docs/*.md, and CLAUDE.md. Matches "ADR-N" and "ADR N"
+# (any case). A reference is satisfied by any adrs/<N>-*.md, trying the number
+# both as written and zero-padded to three digits, since legacy ADRs 001-073
+# are zero-padded and issue-numbered ones are not.
+#
+# Usage: scripts/check-adr-references.sh
+# Exit 0 if every cited ADR exists, 1 otherwise.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+sources=(CLAUDE.md)
+while IFS= read -r f; do sources+=("$f"); done < <(ls adrs/*.md docs/*.md 2>/dev/null)
+
+# Collect distinct referenced ADR numbers. The trailing sort -u keeps each
+# number once no matter how many times or in how many files it appears.
+refs=$(grep -ohiE "ADR[- ][0-9]{1,4}" "${sources[@]}" 2>/dev/null \
+  | grep -oE "[0-9]{1,4}" \
+  | sort -u || true)
+
+if [ -z "$refs" ]; then
+  echo "check-adr-references: no ADR references found — did the citation format change?" >&2
+  exit 1
+fi
+
+dangling=""
+count=0
+for n in $refs; do
+  count=$((count + 1))
+  # 10# forces base-10: bash reads a leading-zero literal as octal, so a
+  # citation like "ADR-008" would otherwise abort the script ("invalid octal").
+  padded=$(printf "%03d" "$((10#$n))")
+  if compgen -G "adrs/${n}-*.md" > /dev/null || compgen -G "adrs/${padded}-*.md" > /dev/null; then
+    continue
+  fi
+  dangling="${dangling}${n} "
+done
+
+if [ -n "$dangling" ]; then
+  echo "" >&2
+  echo "ADR reference integrity check FAILED." >&2
+  echo "" >&2
+  echo "These ADR numbers are cited but no matching adrs/<N>-*.md exists:" >&2
+  for n in $dangling; do
+    echo "" >&2
+    echo "  ADR-$n — cited at:" >&2
+    grep -rniE "ADR[- ]$n([^0-9]|$)" "${sources[@]}" 2>/dev/null | sed 's/^/    /' >&2
+  done
+  echo "" >&2
+  echo "Most often this means an *issue* number was written as an ADR number." >&2
+  echo "ADRs are numbered after their originating issue, so the two share a" >&2
+  echo "namespace: check whether the citation should read '#<N>' instead." >&2
+  echo "" >&2
+  exit 1
+fi
+
+echo "check-adr-references: OK — all $count cited ADRs exist"


### PR DESCRIPTION
Tactical follow-up to a documentation-integrity question raised while reviewing 0.0.79. No issue behind it — small, self-contained, and does not touch engine behaviour.

## What this fixes

`adrs/1408-ci-gate-pause-comment-reuse-on-resume.md:205` cited **ADR-1303**, which does not exist. `docs/state-machine.md:2266` defines §6.14.1 as *"Awaiting-CI Handler-Chain Stall (**issue #1303**)"* — so #1303 is an issue, and the citation should read `#1303`.

This is not a typo class that can be avoided by care. ADRs are **numbered after their originating issue** (CLAUDE.md's "ADR numbering"), so issue numbers and ADR numbers occupy one namespace. `ADR-1303` and `#1303` are one token apart and look equally plausible to a reader. It shipped and stood undetected until a manual sweep.

## Why a check rather than just the fix

Nothing in CI checks documentation claims. The `docs-drift` workflow regenerates `docs/llms-full.txt` and diffs it — that verifies the bundle matches its sources, a concatenation check, not a truth check. Meanwhile CLAUDE.md designates `docs/state-machine.md` (4,434 lines) and `docs/stage-lifecycle.md` as *authoritative as-built specifications*.

`scripts/check-adr-references.sh` doesn't check truth either — that isn't mechanically decidable. It checks the one property that is: **every cited ADR exists**. It scans `adrs/`, `docs/` and `CLAUDE.md`, resolves each reference against `adrs/<N>-*.md` both as written and zero-padded (legacy ADRs 001-073 are padded, issue-numbered ones are not), and on failure prints every citation site plus the likely cause.

Current corpus: **149 distinct cited ADRs, all resolving** after the fix.

## Verification

Non-vacuity — with the bad citation restored:

```
ADR reference integrity check FAILED.
  ADR-1303 — cited at:
    adrs/1408-ci-gate-pause-comment-reuse-on-resume.md:205: ...
exit 1
```

Corrected:

```
check-adr-references: OK — all 149 cited ADRs exist
exit 0
```

One implementation note worth recording: the first version aborted on `ADR-008` because bash reads a leading-zero literal as octal. Fixed with explicit base-10 (`10#$n`), which matters because every legacy ADR 001-073 is zero-padded — the check would have silently skipped a third of the corpus.

## Scope

- No canonical doc page touched, so no `docs/llms-full.txt` regeneration required.
- No engine behaviour changed.
- Checked and deliberately **not** included: two superseded ADRs (053, 070) are cited in canonical docs, but both are correctly annotated as superseded or cited historically. Automating a superseded-citation check would produce false positives without a marker convention first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TajVgJe5tceVVaa3egUgZi