### PR TITLE
ci: add gofmt -s gate, fix pre-existing drift on six files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,20 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # -s matches the -s (simplify) flag CONTRIBUTING.md already tells
+      # contributors to run locally (`gofmt -s -d .` / `gofmt -s -w .`).
+      # Cheapest check in the job (no build), so it runs first.
+      - name: gofmt
+        run: |
+          files=$(gofmt -s -l .)
+          if [ -n "$files" ]; then
+            echo "The following files are not gofmt -s clean:"
+            echo "$files"
+            echo ""
+            echo "Run 'gofmt -s -w .' and commit the result."
+            exit 1
+          fi
+
       # -tags e2e so the build-tagged e2e suite is vetted too. Without the tag
       # `go vet ./...` matches no packages under tests/e2e, so that code is
       # never vetted at all.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ go vet ./...
 gofmt -s -d .         # fix with: gofmt -s -w .
 ```
 
-CI runs `go test -race`, `go vet`, and the docs-drift check on every PR.
+CI runs `go test -race`, `go vet`, `gofmt -s -l`, and the docs-drift check on every PR.
 
 ## Documentation bundle
 

--- a/cmd/refresh_stages.go
+++ b/cmd/refresh_stages.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mattn/go-isatty"
 	"github.com/handarbeit/fabrik/stages"
+	"github.com/mattn/go-isatty"
 	"gopkg.in/yaml.v3"
 )
 

--- a/engine/session_test.go
+++ b/engine/session_test.go
@@ -160,8 +160,8 @@ func TestFormatStatsFooter(t *testing.T) {
 				TurnsUsed: 3, MaxTurns: 10,
 				InputTokens: 100, CacheReadTokens: 5000,
 			},
-			completed: true,
-			wantEmpty: false,
+			completed:   true,
+			wantEmpty:   false,
 			wantNotSubs: []string{"cache-write"},
 		},
 	}
@@ -217,9 +217,9 @@ func TestFormatStatsLogLine(t *testing.T) {
 			},
 		},
 		{
-			name:      "no max turns",
-			stats:     TokenUsage{TurnsUsed: 10, InputTokens: 500, OutputTokens: 100},
-			wantSubs:  []string{"used 10 turns", "in: 500", "out: 100", "cache_read: 0", "cache_write: 0"},
+			name:     "no max turns",
+			stats:    TokenUsage{TurnsUsed: 10, InputTokens: 500, OutputTokens: 100},
+			wantSubs: []string{"used 10 turns", "in: 500", "out: 100", "cache_read: 0", "cache_write: 0"},
 		},
 		{
 			name:      "cache-only usage is not suppressed",

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -68,7 +68,7 @@ type SpawnBlock struct {
 // located with a bare strings.Index anywhere in the body, so a Plan that
 // mentioned the marker in prose — e.g. a markdown checklist item
 //
-//	- [ ] Emit `FABRIK_SPAWN_CHILD_BEGIN owner/repo` block scoping the child work
+//   - [ ] Emit `FABRIK_SPAWN_CHILD_BEGIN owner/repo` block scoping the child work
 //
 // — was treated as a real block opener. The parser then ran forward to the
 // *real* END marker, swallowed the authentic block as that phantom block's

--- a/github/types.go
+++ b/github/types.go
@@ -103,8 +103,8 @@ type PRReview struct {
 // MergeQueueEntry holds the merge-queue position and state for a pull request.
 // The pointer on ProjectItem and PRDetails is nil when no merge queue entry exists.
 type MergeQueueEntry struct {
-	State        string // e.g. "QUEUED", "AWAITING_CHECKS", "MERGEABLE", "UNMERGEABLE"
-	Position     int    // 1-indexed position in the queue; 0 when not yet positioned
+	State         string // e.g. "QUEUED", "AWAITING_CHECKS", "MERGEABLE", "UNMERGEABLE"
+	Position      int    // 1-indexed position in the queue; 0 when not yet positioned
 	EnqueuerLogin string // GitHub login of the user who enqueued the PR
 }
 

--- a/plugin/known_embedded_versions.go
+++ b/plugin/known_embedded_versions.go
@@ -12,8 +12,9 @@ package plugin
 // disk hash that is not any known embedded hash).
 //
 // Historical bootstrapping:
-//   v0.0.64–v0.0.65: 80638a6ed85feb0e1b1516886e13cc3c803eea4ebcf77a24d537a9c977ea4ef0
-//   v0.0.66–current: 72e9c60393cc1c0015c6823fde643b83da246b13585cf17604c6c8636b77aefc
+//
+//	v0.0.64–v0.0.65: 80638a6ed85feb0e1b1516886e13cc3c803eea4ebcf77a24d537a9c977ea4ef0
+//	v0.0.66–current: 72e9c60393cc1c0015c6823fde643b83da246b13585cf17604c6c8636b77aefc
 var KnownEmbeddedVersions = []string{
 	"80638a6ed85feb0e1b1516886e13cc3c803eea4ebcf77a24d537a9c977ea4ef0", // v0.0.64–v0.0.65
 	"72e9c60393cc1c0015c6823fde643b83da246b13585cf17604c6c8636b77aefc", // v0.0.66–current


### PR DESCRIPTION
Closes #1573

## What this does

Adds a CI gate that fails a PR when any tracked `.go` file isn't `gofmt -s`-clean, and fixes the six files on `main` that had already drifted so the new gate lands green.

## Key changes

- **`style: gofmt -s -w fix pre-existing drift on six files`** — reformats `cmd/refresh_stages.go`, `engine/session_test.go`, `engine/spawn.go`, `github/types.go`, `plugin/known_embedded_versions.go`, `tests/sim/assertions.go`. Pure whitespace/comment/import-ordering diffs only — no identifiers, logic, or literals touched. Verified by diffing each file's `gofmt -s -d` output before applying, and by `go test -race ./...` passing unchanged before and after.
- **`ci: add gofmt -s gate to Test and vet job`** — adds a `gofmt` step to `.github/workflows/ci.yml`'s existing `test` job (right after checkout/setup-go, before `go vet`, as the cheapest check). Uses `gofmt -s -l .` to match the `-s` flag `CONTRIBUTING.md` already documents for local use; on failure it names the offending file(s) and points at the fix command, mirroring `docs-drift.yml`'s and `scripts/check-adr-references.sh`'s existing failure-message shape. Also updates `CONTRIBUTING.md`'s CI-checks summary sentence to mention the new gate.

## Design choice

The gate rides the existing `test` job rather than a new sibling workflow (unlike `docs-drift.yml`'s shape). This follows ADR-1339's precedent: a new workflow's check-run name isn't automatically enrolled in `main`'s required status checks, and that enrollment step was missed once already in this repo (ADR-1234). I confirmed `"Test and vet"` is already in `main`'s `required_status_checks.contexts` via the GitHub API, so this gate is immediately blocking on merge — no follow-up branch-protection change needed.

## How to test

- `gofmt -s -l .` → empty output on this branch.
- `go vet ./...` → clean.
- `go test -race -timeout 5m -skip TestExecute_ConfigYAMLApplied ./...` → all packages pass (the skipped test is pre-existing, documented SIGINT-timing flakiness in `ci.yml`, unrelated to this change — reproduced identically on unmodified `main`).
- To sanity-check the gate itself: drop a badly-formatted `.go` file into any package and run the new `gofmt` step's script locally — it correctly names the offending file and exits 1.

Addresses R1/R1a/R2/R3/R4 and Acceptance criteria 1, 3, 4, 5 from the issue. Acceptance criterion 2 (a PR with a misformatted file failing CI) will be demonstrated live once this workflow change is on `main`.