### PR TITLE
docs(boardcache): record linkedPRFetchedAt as live-confirmation-only by design

### DIFF
--- a/adrs/1551-linked-pr-fetched-at-live-confirmation-only.md
+++ b/adrs/1551-linked-pr-fetched-at-live-confirmation-only.md
@@ -1,0 +1,243 @@
+# ADR 1551: `linkedPRFetchedAt` Records Live Confirmation Only, By Design
+
+**Date**: 2026-08-12
+**Status**: Accepted
+**Issue**: #1551 — boardcache: record that linkedPRFetchedAt tracks live confirmation
+only — the poll-path coupling is a guard, not a defect
+
+## Context
+
+`CacheImpl.FetchLinkedPR`'s cache-hit path (`boardcache.go`) serves a Store-backed
+`LinkedPR` record only when three conditions hold: the PR is linked, the record is
+fully populated (`Title != "" && HeadSHA != ""`), and the record is **fresh**:
+
+```go
+fresh := hasFetchedAt && time.Since(fetchedAt) < linkedPRCacheTTL
+```
+
+`fetchedAt` comes from `CacheImpl.linkedPRFetchedAt`, a `map[string]time.Time` keyed
+by item key (`"owner/repo#N"`). This field has exactly **one writer**: the line
+immediately after `c.fallback.FetchLinkedPR` returns from a live GitHub call. No
+webhook delta path writes it.
+
+That asymmetry is easy to misread as a bug. Five sites in `delta.go` apply
+`PRHeadSHAUpdated` — i.e. mutate the very `HeadSHA` field this TTL exists to
+guard — from a webhook delta, and none of them touch `linkedPRFetchedAt`:
+
+| site | function |
+|---|---|
+| normal path | `applyPullRequestDelta` (opened/closed/synchronize/reopened) |
+| auto-heal path | `applyPullRequestDelta` |
+| auto-heal path | `applyPullRequestReviewDelta` |
+| auto-heal path | `applyPullRequestReviewCommentDelta` |
+| auto-heal path | `applyCheckRunDelta` |
+
+`synchronize` — GitHub's force-push/rebase event — is exactly the case
+`linkedPRCacheTTL`'s own doc comment names as the failure mode: a webhook that
+updates the Store's `HeadSHA` correctly and immediately, but whose delivery cannot
+be trusted for correctness (only latency/cost), per ADR-003 and ADR-034 (see
+Rationale below). A webhook-refreshed record is therefore still judged stale by the
+TTL and gets refetched on the next `FetchLinkedPR` call. The cache can over-fetch;
+it can never serve a record whose freshness rests on a channel — webhook
+delivery — that may have silently dropped an event.
+
+Nothing in the code said so before this ADR. A reader arriving at any of the five
+write sites above, or at `linkedPRFetchedAt`'s own field comment, saw a delta path
+mutating exactly the field a TTL depends on without ever refreshing that TTL's
+trust — and no counter-signal explaining that this is intentional.
+
+### Why this reads like an ADR-036 violation, and isn't
+
+ADR-036 (`036-reactive-cache-single-owner.md`) establishes that all board-domain
+state should flow through a single owner, `internal/itemstate.Store`, observable via
+its mutation pipeline. Its own addenda record two precedents for exactly this kind
+of migration, framed as **defects that were fixed**:
+
+- **Phase 5 F2** (issue #562): `CacheImpl.linkedPRs` (PR detail fields — Title,
+  State, Merged, Draft) and `CacheImpl.prNumToKey` (the PR→issue routing index)
+  were both `CacheImpl`-local maps, invisible to the Store's observer pipeline.
+  Both were migrated into the Store (`PRDetailsUpdated`, `Store.prToKey`).
+- **Phase 5 F4** (issue #563): `CacheImpl.checkRuns`, a pre-linkage check-run
+  buffer, was migrated to `Store.pendingCheckRuns`. F4's own closing line: "After
+  F4, **every** per-item AND global pre-linkage state mutation flows through
+  `Store.Apply`."
+
+`linkedPRFetchedAt` is a bare `map[string]time.Time` on `CacheImpl`, guarded by
+`CacheImpl.mu`, invisible to the observer pipeline — structurally identical to the
+two maps F2 removed. A reader who arrives at `linkedPRFetchedAt` via those addenda,
+especially via F4's "every… mutation" sentence, has an explicit, repo-sanctioned
+template for "fixing" it the same way: migrate it into the Store, and stamp it from
+`store.Apply` call sites including the delta handlers.
+
+**That migration is exactly the change this ADR exists to reject.** Store membership
+is what made `linkedPRs`/`prNumToKey`/`checkRuns` natural targets for delta-path
+writes — that was the point of the migration for board-domain state that legitimately
+needs multiple writers and observability. `linkedPRFetchedAt` is a different kind of
+thing: it is not board-domain state describing what GitHub told us, it is
+cache-trust bookkeeping describing *how we found out* — read only by its own
+writer's sibling check (`FetchLinkedPR`'s freshness test), synchronously, under the
+same `c.mu` lock that guards the write. Nothing anywhere needs to observe a change to
+it; no `wakeChFlags` consumer, no dispatcher, no TUI. It fails every criterion F2/F4
+used to justify migrating its siblings — it is precisely the kind of field the F2/F4
+precedent does not apply to, and this ADR is the record that says so explicitly, so a
+future reader (including an autonomous one) does not conclude otherwise from F4's
+"every" alone.
+
+### `#1378` proposes reversing this
+
+Issue #1378 (open, `stage:Specify:complete` at the time of this ADR) proposes, as
+its "Direction 1," making freshness "a first-class, source-agnostic property... have
+*every* refresh path stamp it — poll, REST fallback, and webhook delta alike." Its
+"Direction 2" proposes gating trust on webhook health instead. This ADR is the
+argument against implementing either. #1378's other directions (cooldown-based
+backoff for parked items, narrowing which callers need a live `HeadSHA`) are
+cost-reduction work unaffected by this decision and remain #1378's to pursue.
+
+## Decision
+
+`linkedPRFetchedAt` continues to be stamped **only** by a live `FetchLinkedPR`
+fallback fetch. No webhook/delta handler may write it, regardless of how directly
+that handler's own mutation touches the field(s) the TTL guards (`HeadSHA` in
+particular). This applies to all five `PRHeadSHAUpdated` write sites in `delta.go`
+identified above, present and future — any new delta handler that writes
+`PRHeadSHAUpdated` or otherwise mutates `LinkedPR` state must not also stamp
+`linkedPRFetchedAt`.
+
+`linkedPRCacheTTL`'s meaning is therefore: time since the last **live** GitHub
+confirmation of this record, not time since the record's last mutation of any kind.
+
+This changes no runtime behavior — the code already worked this way. The change is
+that the reasoning is now recorded at the four sites in `boardcache.go`/`delta.go` a
+reader is likely to arrive at, and here.
+
+### Rejected alternatives
+
+1. **Stamp `linkedPRFetchedAt` from `applyPullRequestDelta` (or any delta handler)
+   on every SHA-tracking event** (`#1378` Direction 1). Rejected because it makes
+   TTL freshness a function of webhook delivery. ADR-034's own Trade-offs section
+   is explicit about the cost model this design already accepts: "Cache coherence
+   depends on the webhook stream. Missed events produce stale reads until the next
+   reconciliation (up to 60 min)." Stamping freshness from that same channel would
+   let an unconfirmed signal satisfy a freshness bound whose entire purpose is to
+   require confirmation. Per ADR-003 (`003-polling-over-webhooks.md`, "Superseded
+   by" section): "The core principle of this ADR — that polling is the reliable
+   foundation — is preserved: the cache reconciles against GitHub every 60 minutes
+   and falls back to live API calls when the webhook stream is unhealthy." Webhooks
+   exist to cut latency and cost between polls; per
+   `docs/cache-refactor/05-webhook-correctness-audit.md`, "if webhooks are disabled
+   or unhealthy, does the poll loop alone still converge on the correct GitHub
+   state? … the answer must always be yes." A delta-path stamp would make that
+   answer "no" for this field.
+
+2. **Gate trust on webhook health instead of a live stamp** (`#1378` Direction 2).
+   Rejected because health state itself lags and flaps — it doesn't eliminate the
+   missed-event risk, it only makes the resulting failure intermittent and harder
+   to reproduce. Measured on the dev instance over the same ~9h window cited below:
+   76 `unhealthy` transitions. A gate keyed on a signal that flaps 76 times in 9
+   hours is not a reliable substitute for a live confirmation.
+
+3. **Migrate `linkedPRFetchedAt` into the Store as a first-class field**, following
+   the ADR-036 Phase 5 F2/F4 template. Rejected because Store membership is exactly
+   what would make the field a natural target for delta-path writes later — the
+   whole point of migrating board-domain state into the Store is so more call sites
+   (including delta handlers) can legitimately mutate it and have the mutation
+   observed. `linkedPRFetchedAt` needs the opposite property: exactly one writer,
+   forever. It stays a `CacheImpl`-local field for that structural reason, not
+   because the F2/F4 migration was overlooked.
+
+## Evidence
+
+The trade-off (occasional redundant refetches, in exchange for never trusting an
+unconfirmed channel for correctness) is favorable, measured on the dev instance over
+a ~9h window (`.fabrik/fabrik.log`, `poll: 30`):
+
+- **Cost is negligible.** 102 `stale: FetchLinkedPR` events total (~11/hour),
+  against ~11,337 GraphQL units consumed (~1,260/hour, ~25% of the 5,000/hour
+  ceiling). The redundant refetches this decision costs are order-1% of budget.
+- **The cited items are already cooldown-gated, not refetched per poll.** The
+  worst offender (#1254, `stage:Validate:complete`, parked on a human merge
+  decision) refetches at ~327s intervals — `10 × PollSeconds` (300s) rounded to the
+  next poll boundary, i.e. `CooldownAt` (`engine/catch_up_handlers.go:322`,
+  `engine/poll.go:1126`). The 45s TTL is not the binding constraint for parked
+  items; the cooldown is.
+- **Webhook health on this instance cannot support gating freshness.** 76
+  `unhealthy` transitions in the same ~9h window — see rejected alternative 2 above.
+
+## `#1303` provenance
+
+`linkedPRCacheTTL`'s own doc comment cites `#1303`, and this ADR inherits that
+citation where it appears in code. That citation is **illustrative of the failure
+class, not the literal originating incident** — worth stating plainly here so a
+reader chasing `#1303` does not conclude the rationale is unfounded when the issue
+they find has nothing to do with `FetchLinkedPR`.
+
+`#1303`'s confirmed root cause was unrelated: `CacheImpl.FetchCheckRuns` used a
+denylist cache-trust check (refetch only when the cached classification would read
+as `FAILED`), so a cached `PENDING` classification was served forever on a
+webhook-less deployment, letting a transient state silently latch permanently.
+
+`linkedPRCacheTTL` and `linkedPRFetchedAt` were introduced in the same fix commit —
+`c64ba7b0`, "Apply user feedback: fix confirmed root cause and bound
+FetchLinkedPR" (2026-07-31) — but not as that incident's root-cause fix. The
+commit message says so directly:
+
+> boardcache: also bound `CacheImpl.FetchLinkedPR` with a TTL, so a cached
+> HeadSHA/MergeableState/State/Merged record can't go stale forever either — **an
+> earlier, retracted hypothesis in the same thread** but a real gap in its own right
+> (every sibling mergeability call already bypasses caching for this exact reason).
+
+So: the stale-`HeadSHA` concern was raised as a hypothesis for `#1303`, retracted
+once the actual `FetchCheckRuns` mechanism was confirmed, and kept anyway as
+independent hardening because it was a real gap on its own merits — every sibling
+mergeability call (`FetchPRMergeableFields`, `FetchPRMergeable`,
+`FetchPRMergeableState`, `FetchCombinedStatus`) already bypasses caching entirely
+for the same reason. This is stronger provenance than a vague incident reference: the
+gap was argued about, retracted for the incident it was proposed under, and retained
+on independent merit. The originating incident for the `HeadSHA`/`FetchLinkedPR` gap
+itself — as opposed to the `#1303` thread that surfaced and then set aside the
+hypothesis — is not separately recorded; `c64ba7b0` is the concrete, verifiable
+citation this ADR relies on instead of asserting one.
+
+## Consequences
+
+**Positive:**
+- The intentional asymmetry between `linkedPRFetchedAt`'s single writer and the five
+  webhook-delta sites that mutate PR head state is now documented at every site a
+  reader is likely to arrive at (`boardcache.go`'s field comment, TTL comment, and
+  single-writer site; `delta.go`'s `applyPullRequestDelta` SHA-tracking path and the
+  three sibling `PRHeadSHAUpdated` sites), plus here.
+- `#1378`'s Direction 1/2 are pre-empted with a citable rationale rather than left to
+  be independently re-derived (or missed) by whichever agent picks up that issue.
+- The `#1303` citation's oddity (an unrelated `awaiting-ci` incident, no mention of
+  `FetchLinkedPR`) is explained rather than left to confuse a future reader who
+  chases it.
+
+**Negative / Trade-offs:**
+- No code behavior changes; the cost/benefit numbers above (order-1% GraphQL budget)
+  were already being paid before this ADR and continue to be paid after it. This ADR
+  makes that cost legible, it does not change it.
+- Extending this same "live-confirmation-only" reasoning to the other cached fields
+  named in the issue (`FetchPRMergeableFields`, `FetchCheckRuns`'s own trust check,
+  `blockedBy`) is explicitly out of scope here — those follow-ups, if warranted, get
+  their own ADRs rather than being folded into this one by inference.
+
+## References
+
+- [ADR-036: Reactive Cache, Single State Owner](036-reactive-cache-single-owner.md) —
+  the Phase 5 F2/F4 addenda whose precedent this decision explicitly declines to
+  extend to `linkedPRFetchedAt`.
+- [ADR-034: Boardcache Event-Sourced Delta](034-boardcache-event-sourced-delta.md) —
+  Trade-offs section: "Cache coherence depends on the webhook stream. Missed events
+  produce stale reads until the next reconciliation (up to 60 min)."
+- [ADR-003: Polling Over Webhooks](003-polling-over-webhooks.md) — "Superseded by"
+  section, line 45: "The core principle of this ADR — that polling is the reliable
+  foundation — is preserved…"
+- `docs/cache-refactor/05-webhook-correctness-audit.md` — prior audit of this class
+  of freshness gap across other cached fields; source of the "the answer must
+  always be yes" framing quoted above.
+- #1378 — proposes the two directions this ADR argues against (Direction 1: stamp
+  freshness from every refresh path; Direction 2: gate trust on webhook health).
+  Its other directions are unaffected.
+- #1303 — the incident whose thread raised, then retracted, the hypothesis that
+  became `linkedPRCacheTTL`; see "`#1303` provenance" above for why it reads oddly
+  when chased directly, and commit `c64ba7b0` for the actual origin of the TTL.

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -170,6 +170,24 @@ const recentMissTTL = 10 * time.Minute
 // preserves the within-poll caching benefit (multiple callers for the same
 // item in one pass still share a single fetch) while ensuring staleness
 // cannot compound across polls the way it did in the incident.
+//
+// This TTL's meaning depends on linkedPRFetchedAt recording LIVE CONFIRMATION
+// ONLY (see that field's doc comment): "within linkedPRCacheTTL" means "within
+// linkedPRCacheTTL of the last live GitHub fetch," not "within linkedPRCacheTTL
+// of the record's last mutation of any kind." Webhook deltas (opened, closed,
+// synchronize, reopened, and the review/review-comment/check-run auto-heal
+// paths in delta.go) update the Store's HeadSHA correctly and immediately, but
+// deliberately do not stamp linkedPRFetchedAt — so a webhook-refreshed record
+// is still judged stale by this TTL and gets refetched. That is the intended
+// behavior, not a bug: if a delta stamp were added instead, this TTL would
+// bound time since last refresh-by-any-means, including a webhook delivery
+// that may silently have been dropped. The failure mode that reintroduces is
+// exactly what motivated this TTL in the first place: a stale HeadSHA
+// redirects every downstream check-run query at an abandoned pre-rebase
+// commit indefinitely, with the resulting stall producing no log output (see
+// settlePRMergeState's unlogged CheckRunsPending branch above). See ADR-1551
+// for the full rationale and the rejected alternative of stamping this field
+// from a delta path.
 const linkedPRCacheTTL = 45 * time.Second
 
 // parseItemKey parses "owner/repo#N" into (repo, number, true).
@@ -256,7 +274,21 @@ type CacheImpl struct {
 	// linkedPRFetchedAt records, per item key ("owner/repo#N"), the wall-clock
 	// time of the last successful live FetchLinkedPR fallback fetch. FetchLinkedPR
 	// consults this to bound how long a fully-populated Store record is trusted
-	// before being treated as a miss (see linkedPRCacheTTL, #1303).
+	// before being treated as a miss (see linkedPRCacheTTL for the failure mode
+	// this guards against).
+	//
+	// This field records LIVE CONFIRMATION ONLY, by design. It has exactly one
+	// writer in this file (the assignment immediately below the fallback fetch
+	// in FetchLinkedPR) and must never gain a second one. In particular, no
+	// webhook/delta handler in delta.go may stamp it — not even the ones that
+	// mutate the very PR head state (HeadSHA) this field's TTL exists to bound.
+	// A delta-path stamp would make freshness a function of webhook delivery,
+	// which this cache's own event-sourced design (ADR-034) admits is
+	// unconfirmed until the next reconciliation (up to 60 min). That is
+	// precisely the channel this field exists not to trust. See ADR-1551 for
+	// the full rationale, the rejected alternative (stamping on delta), and why
+	// this field is deliberately not a Store-migration candidate of the kind
+	// ADR-036's Phase 5 F2/F4 addenda record for its siblings.
 	linkedPRFetchedAt map[string]time.Time
 
 	// localDeltaAt records the last time a webhook bumped an item.
@@ -906,6 +938,8 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 			SHA:         pr.HeadSHA,
 		})
 	}
+	// This is linkedPRFetchedAt's single writer, by design — see its doc
+	// comment for why no delta path may join it here.
 	c.mu.Lock()
 	c.linkedPRFetchedAt[key] = time.Now()
 	c.mu.Unlock()

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -598,6 +598,21 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 	}
 
 	// --- SHA-tracking path (opened, closed, synchronize, reopened) ---
+	//
+	// Both PRHeadSHAUpdated calls below (the normal path at ~line 628 and the
+	// auto-heal path at ~line 663) deliberately do NOT stamp
+	// CacheImpl.linkedPRFetchedAt, even though synchronize is precisely the
+	// force-push/rebase event whose staleness linkedPRCacheTTL exists to bound.
+	// This is load-bearing, not an omission — do not "fix" it by adding a
+	// stamp here. linkedPRFetchedAt records live GitHub confirmation only, by
+	// design (see its doc comment in boardcache.go); a delta-path stamp would
+	// make FetchLinkedPR's freshness trust a function of webhook delivery,
+	// which this event-sourced cache's own design (ADR-034) admits can miss
+	// events until the next reconciliation (up to 60 min) — precisely the
+	// unconfirmed channel that TTL exists not to trust, and precisely the
+	// change #1378 proposed and ADR-1551 records the rejection of. See
+	// ADR-1551 for the full rationale.
+	//
 	// Echo-match for opened and closed PR mutations (synchronize/reopened are not tracked).
 	if c.matchEchoFn != nil && (p.Action == "opened" || p.Action == "closed") {
 		c.matchEchoFn("pull_request", p.Action, prKey(repo, prNum))
@@ -660,6 +675,8 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 		Merged:   p.PullRequest.Merged,
 		Draft:    p.PullRequest.Draft,
 	})
+	// Same non-stamping of linkedPRFetchedAt, and the same reason, as the
+	// normal-path PRHeadSHAUpdated call above — see that comment.
 	c.store.Apply(itemstate.PRHeadSHAUpdated{
 		Repo:        repo,
 		Number:      resolvedIssNum,
@@ -742,6 +759,9 @@ func (c *CacheImpl) applyPullRequestReviewDelta(payload []byte) {
 		return
 	}
 
+	// Deliberately does not stamp linkedPRFetchedAt — see the substantive
+	// comment on applyPullRequestDelta's SHA-tracking path (boardcache.go's
+	// linkedPRFetchedAt/linkedPRCacheTTL doc comments, and ADR-1551).
 	c.store.Apply(itemstate.PRHeadSHAUpdated{
 		Repo:        repo,
 		Number:      resolvedIssNum,
@@ -844,6 +864,9 @@ func (c *CacheImpl) applyPullRequestReviewCommentDelta(payload []byte) {
 		return
 	}
 
+	// Deliberately does not stamp linkedPRFetchedAt — see the substantive
+	// comment on applyPullRequestDelta's SHA-tracking path (boardcache.go's
+	// linkedPRFetchedAt/linkedPRCacheTTL doc comments, and ADR-1551).
 	c.store.Apply(itemstate.PRHeadSHAUpdated{
 		Repo:        repo,
 		Number:      resolvedIssNum,
@@ -951,6 +974,10 @@ func (c *CacheImpl) applyCheckRunDelta(payload []byte) {
 	// Update Store: set LinkedPRNum + SHA (updates shaToKey index). PRHeadSHAUpdated
 	// drains any pendingCheckRuns[sha] into the item's LinkedPR.CheckRuns automatically
 	// — no explicit CheckRunCompleted replay needed.
+	//
+	// Deliberately does not stamp linkedPRFetchedAt — see the substantive
+	// comment on applyPullRequestDelta's SHA-tracking path (boardcache.go's
+	// linkedPRFetchedAt/linkedPRCacheTTL doc comments, and ADR-1551).
 	c.store.Apply(itemstate.PRHeadSHAUpdated{
 		Repo:        repo,
 		Number:      resolvedIssNum,

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -599,10 +599,11 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 
 	// --- SHA-tracking path (opened, closed, synchronize, reopened) ---
 	//
-	// Both PRHeadSHAUpdated calls below (the normal path at ~line 628 and the
-	// auto-heal path at ~line 663) deliberately do NOT stamp
-	// CacheImpl.linkedPRFetchedAt, even though synchronize is precisely the
-	// force-push/rebase event whose staleness linkedPRCacheTTL exists to bound.
+	// Both PRHeadSHAUpdated calls below (the normal path, for an issue already
+	// known to the Store, and the auto-heal path, for one discovered via
+	// fallback lookup) deliberately do NOT stamp CacheImpl.linkedPRFetchedAt,
+	// even though synchronize is precisely the force-push/rebase event whose
+	// staleness linkedPRCacheTTL exists to bound.
 	// This is load-bearing, not an omission — do not "fix" it by adding a
 	// stamp here. linkedPRFetchedAt records live GitHub confirmation only, by
 	// design (see its doc comment in boardcache.go); a delta-path stamp would


### PR DESCRIPTION
Closes #1551

## What this does

Pure documentation change — no `.go` statement, expression, or signature is modified. It records, at the four code sites a reader is likely to arrive at plus a new ADR, that `linkedPRFetchedAt`'s poll-only stamping is a deliberate correctness guard, not an oversight.

## Background

`FetchLinkedPR`'s freshness test in `boardcache.go` is satisfied only by a timestamp that a live GitHub fetch writes (`linkedPRFetchedAt`). No webhook delta handler stamps it — including the five sites in `delta.go` that mutate PR head state (`PRHeadSHAUpdated`) from a webhook delta, `synchronize` (force-push/rebase) among them. That asymmetry reads like a bug (an ADR-034/ADR-036 layering violation) and is in fact intentional: it ensures the cache never trusts webhook delivery — an unconfirmed channel — for correctness, only for latency/cost. #1378 currently proposes reversing this (its Direction 1/2). This PR documents why that would reintroduce the #1303-class stale-HeadSHA silent-stall failure mode.

## Key changes

- `boardcache/boardcache.go`:
  - Extends `linkedPRFetchedAt`'s field doc comment: records live confirmation only, has exactly one writer by design, no delta path may stamp it.
  - Extends `linkedPRCacheTTL`'s doc comment: its meaning depends on that property (bounds time since last *live* confirmation, not since any refresh).
  - Adds a short pointer comment at the single-writer site.
- `boardcache/delta.go`:
  - Adds a substantive comment at `applyPullRequestDelta`'s SHA-tracking write site (the primary arrival point) explaining the omission is deliberate and load-bearing.
  - Adds short pointer comments at the three other `PRHeadSHAUpdated` write sites (`applyPullRequestReviewDelta`, `applyPullRequestReviewCommentDelta`, `applyCheckRunDelta`) that also mutate PR head state from a webhook delta without stamping freshness.
- `adrs/1551-linked-pr-fetched-at-live-confirmation-only.md` (new): records the decision, leads with the ADR-036 Phase 5 F2/F4 precedent and explains why `linkedPRFetchedAt` is deliberately *not* a migration candidate of that class, records three rejected alternatives (stamp-on-delta, health-gated trust, Store migration) with rationale, carries forward the issue's measured evidence (cost ~1% of GraphQL budget, webhook health flapping 76×/9h, cooldown vs. TTL for parked items), and corrects the `#1303` citation's provenance (commit `c64ba7b0` — a retracted hypothesis kept as independent hardening, not #1303's root-cause fix).

## How to test

- `git diff --stat origin/main...HEAD` — confined to `boardcache/*.go` and `adrs/`.
- Every added line in the two `.go` files is a comment or blank line (verified via `grep -vE '^\+\s*(//|$)'` returning nothing).
- `go build ./...` and `go vet ./...` pass clean.
- `go test -race ./boardcache/...` passes.
- No test added, removed, or modified, per the issue's own Verification Note (this change is not observable to a test by construction).

Note: a full `go test -race ./...` run in this sandbox intermittently times out in `tests/sim` (race-detector overhead under load) and fails `cmd`'s `TestExecute_ConfigYAMLApplied` (a SIGINT-timing test) — both reproduce identically on `origin/main` with none of this branch's changes present, confirmed by testing against a clean worktree of `origin/main`. Pre-existing environment flakiness, unrelated to this change.