### PR TITLE
config: warn on unrecognized config.yaml keys with mechanical flag/env suggestion

### DIFF
--- a/adrs/1544-unrecognized-config-key-warning.md
+++ b/adrs/1544-unrecognized-config-key-warning.md
@@ -1,0 +1,123 @@
+# ADR 1544: Unrecognized config.yaml Key Detection
+
+**Date**: 2026-08-12
+**Status**: Accepted
+**Issue**: #1544 — `config.yaml` silently discards unknown keys, so every CLI/env-only knob
+looks configured when it isn't
+
+## Context
+
+`LoadProjectConfig` (`config/config.go`) decodes `.fabrik/config.yaml` with a plain
+`yaml.Unmarshal` into `ProjectConfig`. go-yaml's default behavior is to silently discard any
+key with no matching struct field. `archive_after: 48h` sat in a production `config.yaml` for
+weeks under the belief that board archiving was on; it never ran once. The gap was only found
+by grepping the binary's own `yaml:"..."` struct tags by hand.
+
+At least six real, flag-and-env-backed knobs had no `config.yaml` equivalent at the time this
+issue was filed (`archive_after`, `archive_done`, `reconcile_interval`, `max_review_cycles`,
+`max_slice_retries`, `drain_deadline`). Research found the true count substantially higher (~20
+knobs), and the list grows by default every time a new CLI/env-only knob is added — nothing
+today forces a decision about `config.yaml` support when one is introduced. #992 added one such
+key (`merge_train`) reactively, after someone happened to notice it missing.
+
+Fabrik already has a structurally identical precedent: `stages/drift.go`'s stage-YAML drift
+warning prints `[startup] warning: ...` when a stage config file is *missing* fields present in
+newer embedded defaults. This issue is the mirror case — a config file has an *extra*,
+unrecognized key — and should read as the same family of diagnostic.
+
+## Decision
+
+### Detect, don't reject
+
+`LoadProjectConfig` itself is untouched — same signature, same behavior, unknown keys keep
+being silently ignored *functionally*. A new pure function, `config.UnrecognizedTopLevelKeys()`,
+runs as a side pass: it re-reads `.fabrik/config.yaml` into a `map[string]any`, reflects over
+`ProjectConfig`'s `yaml:"..."` struct tags to build the known-key set, and returns the sorted
+top-level keys present in the file but absent from that set. `yaml.KnownFields(true)` strict
+decoding (which fails the whole parse on the first unknown key) was explicitly rejected — existing
+installs may have accumulated dead keys from past experiments or typos, and failing startup over
+those would be a regression in its own right.
+
+Detection is top-level-only by construction: the second unmarshal only ever inspects the
+document's outermost keys, so values inside `RequiredStatusContexts` (the one map-typed field)
+are structurally never visited, never recursed into, and never misreported as unrecognized.
+
+Deriving the known-key set from the struct's own tags (rather than a second hand-maintained
+list) means it can never drift from what `LoadProjectConfig`'s own `yaml.Unmarshal` actually
+recognizes — the reflection walk and the real decode read the exact same tags.
+
+### Pure-detection / flag-aware-suggestion split
+
+`config.UnrecognizedTopLevelKeys()` returns a flag-registry-independent `[]string`. A separate
+function, `cmd.warnUnrecognizedConfigKeys(keys []string, w io.Writer)`, takes that list and does
+the flag-aware part: for each key it derives a candidate flag name
+(`strings.ReplaceAll(key, "_", "-")`) and env var name (`"FABRIK_" + strings.ToUpper(key)`), and
+checks `flag.CommandLine.Lookup(flagName)`. `cmd/root.go` always calls
+`flag.CommandLine.Parse()` before `config.LoadProjectConfig()` runs, so every real CLI flag is
+already registered in the global registry by the time this check executes — `flag.Lookup` is a
+live existence oracle, not a maintained table. A hit prints the suggestion clause naming both
+the flag and env var; a miss (a pure typo, or a genuinely env-only knob such as
+`FABRIK_ANTHROPIC_API_KEY`, which has no registered flag at all) prints only the base warning
+line.
+
+This split exists for testability, not layering purity: `config`'s test suite is table-driven
+and runs without any dependency on Go's global, order-sensitive `flag.CommandLine` registry
+(which panics on duplicate flag registration) today, and this change keeps it that way. `cmd`
+already imports both `flag` and `config`, and already has a `resetFlags()` test helper built for
+exactly this kind of registry-dependent test.
+
+### Naming-convention exceptions are a known, accepted limitation
+
+Every current CLI flag with **no** `config.yaml` support today follows the mechanical
+snake_case ↔ kebab-case ↔ `FABRIK_SCREAMING_SNAKE_CASE` convention cleanly — verified against
+all ~55 registered flags, not just the six named in the issue. Four flags whose triple *does*
+break the convention were found, but all four already have a recognized `config.yaml` key —
+they can never be the *subject* of this warning, only a source of a misleading suggestion if
+someone mistypes the recognized key in a way that happens to collide with the derived name:
+
+| `config.yaml` key | flag | env var |
+|---|---|---|
+| `git_ssh` | `--ssh` | `FABRIK_GIT_SSH` |
+| `tui` | `--notui` (inverted) | `FABRIK_TUI` |
+| `project` | `--project` | `FABRIK_PROJECT_NUMBER` |
+| `janitor_interval_hours` | `--janitor-interval` | `FABRIK_JANITOR_INTERVAL` |
+
+E.g. `janitor_interval:` (missing the `_hours` suffix) mechanically resolves to a real
+`--janitor-interval`/`FABRIK_JANITOR_INTERVAL` pair and prints "CLI/env-only" even though
+`janitor_interval_hours` **is** already supported, just spelled differently. This is documented
+as a known limitation in `docs/USER_GUIDE.md` rather than special-cased: special-casing four
+specific keys would recreate exactly the hand-maintained-exception-list problem this issue
+exists to eliminate, for a narrow edge case (typo of an already-recognized key) whose outcome
+is still directionally useful even when imprecisely worded.
+
+### Scope: stderr-only, `cmd/root.go`-only
+
+The warning is printed to stderr only — no `warnings.Record`/TUI Warnings-panel entry, and no
+fan-out to `.fabrik/fabrik.log`. `stages.WarnStageDrift` gets that fan-out via
+`io.MultiWriter(os.Stderr, e.logFile)` inside `engine.Run()`'s `poll()`, but this diagnostic
+fires from `cmd/root.go`'s `Execute()`, before `engine.New`/`Run` exist or the log file is open.
+The issue's own Requirements specify only a stderr line; duplicating the log/TUI fan-out would
+need real restructuring the issue doesn't ask for.
+
+Detection is wired into `cmd/root.go`'s daemon path only, immediately after the existing
+`config.WarnIfConfigIgnored()` call — not `fabrik watch`'s `LoadProjectConfig()` call site. The
+issue's Requirements text explicitly scopes this to "the main daemon startup path." `watch` also
+uses its own local `flag.NewFlagSet("watch", ...)`, not the global `flag.CommandLine` registry
+this detection's existence check relies on — extending coverage there would need a second,
+`watch`-specific existence check with narrower coverage (5 flags vs. ~55), not a trivial
+extension of the same code path.
+
+## Consequences
+
+- An operator with a stray or misspelled `config.yaml` key now gets a same-startup diagnostic
+  instead of silent, indefinite no-op behavior — closing the exact gap the `archive_after`
+  incident exposed.
+- The flag/env suggestion is self-maintaining: adding a new CLI/env-only knob to `cmd/root.go`
+  automatically makes its suggestion clause fire the moment someone tries the matching
+  `config.yaml` key, with no additional code change required.
+- The four naming exceptions (all already-recognized keys) can produce a misleading suggestion
+  for a narrow typo shape; documented, not fixed, per the trade-off above.
+- `fabrik watch` and TUI/log-file visibility are explicitly out of scope for this issue. Both are
+  reasonable, low-cost follow-ups if wanted later — `watch` needs its own `flag.FlagSet`-based
+  existence check, and TUI/log fan-out needs this detection to run somewhere `engine.Run()` can
+  reach with its own writer, mirroring `WarnStageDrift`'s call site in `engine/poll.go`.

--- a/cmd/config_key_warn.go
+++ b/cmd/config_key_warn.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// warnUnrecognizedConfigKeys prints one [startup] warning line per key in
+// keys, naming the offending .fabrik/config.yaml key. When a key
+// mechanically resolves to a real, currently-registered CLI flag — via
+// Fabrik's consistent snake_case (config.yaml) <-> kebab-case (flag) <->
+// FABRIK_SCREAMING_SNAKE_CASE (env var) naming convention — the warning also
+// names the flag/env var to use instead.
+//
+// The flag/env suggestion is derived mechanically and verified live against
+// flag.CommandLine.Lookup rather than a hand-maintained table: cmd/root.go
+// always calls flag.CommandLine.Parse before config.LoadProjectConfig runs,
+// so every real CLI flag is already registered by the time this is called.
+// A key with no matching registered flag (a pure typo, or a genuinely
+// env-only knob such as FABRIK_ANTHROPIC_API_KEY) gets only the base line.
+//
+// keys is expected to already be sorted (UnrecognizedTopLevelKeys returns a
+// sorted slice); this function reports them in the order given.
+func warnUnrecognizedConfigKeys(keys []string, w io.Writer) {
+	for _, key := range keys {
+		fmt.Fprintf(w, "[startup] warning: .fabrik/config.yaml: unrecognised key %q\n", key)
+
+		flagName := strings.ReplaceAll(key, "_", "-")
+		if flag.CommandLine.Lookup(flagName) == nil {
+			continue
+		}
+		envName := "FABRIK_" + strings.ToUpper(key)
+		fmt.Fprintf(w, "          (this knob is CLI/env-only — set %s or -%s)\n", envName, flagName)
+	}
+}

--- a/cmd/config_key_warn_test.go
+++ b/cmd/config_key_warn_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"bytes"
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestWarnUnrecognizedConfigKeys_NoMatchingFlag(t *testing.T) {
+	resetFlags()
+	var buf bytes.Buffer
+
+	warnUnrecognizedConfigKeys([]string{"totally_bogus_key"}, &buf)
+
+	got := buf.String()
+	if !strings.Contains(got, `[startup] warning: .fabrik/config.yaml: unrecognised key "totally_bogus_key"`) {
+		t.Errorf("missing base warning line, got: %q", got)
+	}
+	if strings.Contains(got, "CLI/env-only") {
+		t.Errorf("did not expect a suggestion clause for a key with no matching flag, got: %q", got)
+	}
+}
+
+func TestWarnUnrecognizedConfigKeys_MatchingFlag(t *testing.T) {
+	resetFlags()
+	flag.String("archive-after", "", "test flag")
+	var buf bytes.Buffer
+
+	warnUnrecognizedConfigKeys([]string{"archive_after"}, &buf)
+
+	got := buf.String()
+	if !strings.Contains(got, `[startup] warning: .fabrik/config.yaml: unrecognised key "archive_after"`) {
+		t.Errorf("missing base warning line, got: %q", got)
+	}
+	if !strings.Contains(got, "FABRIK_ARCHIVE_AFTER") {
+		t.Errorf("expected suggested env var FABRIK_ARCHIVE_AFTER, got: %q", got)
+	}
+	if !strings.Contains(got, "-archive-after") {
+		t.Errorf("expected suggested flag -archive-after, got: %q", got)
+	}
+}
+
+func TestWarnUnrecognizedConfigKeys_MultipleKeysAllReported(t *testing.T) {
+	resetFlags()
+	flag.String("archive-after", "", "test flag")
+	flag.String("reconcile-interval", "", "test flag")
+	var buf bytes.Buffer
+
+	warnUnrecognizedConfigKeys([]string{"archive_after", "reconcile_interval", "totally_bogus_key"}, &buf)
+
+	got := buf.String()
+	for _, want := range []string{
+		`unrecognised key "archive_after"`,
+		"FABRIK_ARCHIVE_AFTER",
+		"-archive-after",
+		`unrecognised key "reconcile_interval"`,
+		"FABRIK_RECONCILE_INTERVAL",
+		"-reconcile-interval",
+		`unrecognised key "totally_bogus_key"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected output to contain %q, got: %q", want, got)
+		}
+	}
+	// The bogus key must not get a suggestion clause.
+	bogusIdx := strings.Index(got, `unrecognised key "totally_bogus_key"`)
+	if bogusIdx == -1 {
+		t.Fatal("bogus key line not found")
+	}
+	if strings.Contains(got[bogusIdx:], "CLI/env-only") {
+		t.Errorf("did not expect a suggestion clause after the bogus key, got: %q", got[bogusIdx:])
+	}
+}
+
+func TestWarnUnrecognizedConfigKeys_Empty(t *testing.T) {
+	resetFlags()
+	var buf bytes.Buffer
+
+	warnUnrecognizedConfigKeys(nil, &buf)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for empty key list, got: %q", buf.String())
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -231,6 +231,14 @@ func Execute() error {
 	// Warn (non-fatal) if config.yaml is gitignored
 	config.WarnIfConfigIgnored()
 
+	// Warn (non-fatal) about any top-level config.yaml key with no matching
+	// ProjectConfig field — most commonly a knob that is actually CLI/env-only.
+	if unrecognized, err := config.UnrecognizedTopLevelKeys(); err != nil {
+		fmt.Fprintf(os.Stderr, "[startup] warning: checking .fabrik/config.yaml for unrecognized keys: %v\n", err)
+	} else {
+		warnUnrecognizedConfigKeys(unrecognized, os.Stderr)
+	}
+
 	// Token: flag > FABRIK_TOKEN > GITHUB_TOKEN
 	if cfg.Token == "" {
 		cfg.Token = config.Token()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -370,6 +370,53 @@ func TestExecute_FineGrainedTokenWarning(t *testing.T) {
 	}
 }
 
+// TestExecute_UnrecognizedConfigKeyWarning verifies that an unrecognized
+// .fabrik/config.yaml key produces a [startup] warning on stderr — with a
+// flag/env suggestion for a key that mechanically matches a real CLI flag,
+// and without one for a pure typo. The test does not use t.Parallel() to
+// avoid races on os.Stderr.
+func TestExecute_UnrecognizedConfigKeyWarning(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"),
+		[]byte("owner: o\narchive_after: 48h\ntotally_bogus_key: 1\n"), 0644)
+	chdirTest(t, dir)
+
+	resetFlags()
+	// Omit --user so Execute fails deterministically, after our warning
+	// code but before any engine/network work.
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--token", "tok"}
+
+	Execute() //nolint:errcheck — we only care about the stderr output
+
+	w.Close()
+	output, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading stderr pipe: %v", err)
+	}
+	got := string(output)
+
+	if !strings.Contains(got, `[startup] warning: .fabrik/config.yaml: unrecognised key "archive_after"`) {
+		t.Errorf("expected base warning for archive_after, got: %q", got)
+	}
+	if !strings.Contains(got, "FABRIK_ARCHIVE_AFTER") || !strings.Contains(got, "-archive-after") {
+		t.Errorf("expected CLI/env-only suggestion for archive_after, got: %q", got)
+	}
+	if !strings.Contains(got, `[startup] warning: .fabrik/config.yaml: unrecognised key "totally_bogus_key"`) {
+		t.Errorf("expected base warning for totally_bogus_key, got: %q", got)
+	}
+}
+
 func TestExecute_ReviewWaitTimeoutFlag(t *testing.T) {
 	resetFlags()
 	stagesDir := t.TempDir()

--- a/config/unknown_keys.go
+++ b/config/unknown_keys.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// UnrecognizedTopLevelKeys reads .fabrik/config.yaml from CWD and returns the
+// sorted list of top-level keys present in the file that have no matching
+// yaml:"..." struct tag on ProjectConfig. Detection is limited to the
+// document's outermost keys — values inside map- or slice-typed fields (e.g.
+// RequiredStatusContexts) are never inspected, so a nested key can never be
+// misreported as unrecognized.
+//
+// An absent or empty file returns (nil, nil), matching LoadProjectConfig's
+// own no-op behavior. This is a pure, side-channel diagnostic: it does not
+// affect LoadProjectConfig's return value, and a malformed file's parse
+// error is reported here rather than causing this function to panic or
+// silently swallow the problem.
+func UnrecognizedTopLevelKeys() ([]string, error) {
+	data, err := os.ReadFile(".fabrik/config.yaml")
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading .fabrik/config.yaml: %w", err)
+	}
+
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing .fabrik/config.yaml: %w", err)
+	}
+
+	known := knownConfigKeys()
+	var unrecognized []string
+	for k := range raw {
+		if !known[k] {
+			unrecognized = append(unrecognized, k)
+		}
+	}
+	sort.Strings(unrecognized)
+	return unrecognized, nil
+}
+
+// knownConfigKeys reflects over ProjectConfig's fields and returns the set of
+// yaml:"..." tag names declared on it. Deriving this from the struct itself
+// (rather than a hand-maintained list) guarantees it can never drift from
+// what LoadProjectConfig actually recognizes.
+func knownConfigKeys() map[string]bool {
+	t := reflect.TypeOf(ProjectConfig{})
+	keys := make(map[string]bool, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name != "" {
+			keys[name] = true
+		}
+	}
+	return keys
+}

--- a/config/unknown_keys_test.go
+++ b/config/unknown_keys_test.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestUnrecognizedTopLevelKeys_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	got, err := UnrecognizedTopLevelKeys()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("want nil for absent file, got %v", got)
+	}
+}
+
+func TestUnrecognizedTopLevelKeys_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte(""), 0644)
+
+	got, err := UnrecognizedTopLevelKeys()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("want nil for empty file, got %v", got)
+	}
+}
+
+func TestUnrecognizedTopLevelKeys_AllRecognized(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	yamlContent := "owner: org\nrepo: myrepo\nmax_retries: 3\n"
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte(yamlContent), 0644)
+
+	got, err := UnrecognizedTopLevelKeys()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("want no unrecognized keys, got %v", got)
+	}
+}
+
+func TestUnrecognizedTopLevelKeys_SingleUnrecognized(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	yamlContent := "owner: org\narchive_after: 48h\n"
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte(yamlContent), 0644)
+
+	got, err := UnrecognizedTopLevelKeys()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"archive_after"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestUnrecognizedTopLevelKeys_MultipleUnrecognizedSorted(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	yamlContent := "owner: org\nreconcile_interval: 60\narchive_after: 48h\ntotally_bogus_key: 1\n"
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte(yamlContent), 0644)
+
+	got, err := UnrecognizedTopLevelKeys()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"archive_after", "reconcile_interval", "totally_bogus_key"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v (all unrecognized keys must be reported, sorted)", got, want)
+	}
+}
+
+func TestUnrecognizedTopLevelKeys_NestedMapValuesNeverFlagged(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	yamlContent := "owner: org\n" +
+		"required_status_contexts:\n" +
+		"  o/r:\n" +
+		"    - ci\n" +
+		"    - lint\n" +
+		"archive_after: 48h\n"
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte(yamlContent), 0644)
+
+	got, err := UnrecognizedTopLevelKeys()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"archive_after"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v (nested required_status_contexts values must never be flagged)", got, want)
+	}
+}
+
+func TestKnownConfigKeys_MatchesProjectConfigTags(t *testing.T) {
+	known := knownConfigKeys()
+	// Spot-check a representative sample of ProjectConfig's yaml tags,
+	// including the map-typed field, to confirm the reflection walk sees
+	// every field kind without special-casing.
+	for _, key := range []string{
+		"owner", "repo", "project", "user", "max_retries", "merge_train",
+		"required_status_contexts", "ghes_host",
+	} {
+		if !known[key] {
+			t.Errorf("knownConfigKeys() missing %q — reflection walk should derive it from ProjectConfig's yaml tag", key)
+		}
+	}
+	if known["archive_after"] {
+		t.Error("knownConfigKeys() should not contain archive_after — it is CLI/env-only, no ProjectConfig field exists for it")
+	}
+}

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -873,6 +873,19 @@ FABRIK_USER=my-personal-username
 | `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` file at worktree setup time. Enables stage code to read credentials (e.g. `ANTHROPIC_API_KEY`) from `.env` without copying secrets. No-op when source `.env` is absent; never overwrites an existing `.env` in the worktree; also excluded from git stash via the worktree's git exclude file. Also `FABRIK_SYMLINK_ENV` | `false` |
 | `--ghes-host` | GitHub Enterprise Server hostname (no scheme, no trailing slash), e.g. `github.example.com`. Governs the REST/GraphQL API endpoints, bare-clone URLs, commit-author noreply email, `GH_HOST` in stage-worker environments, and the startup minimum-version preflight. Absent (default) means github.com, byte-identical to today's behavior. Also `FABRIK_GHES_HOST`. See [GitHub Enterprise Server Support](#github-enterprise-server-support). | `""` (github.com) |
 
+#### Unrecognized `config.yaml` Key Warnings
+
+go-yaml silently discards any `.fabrik/config.yaml` key with no matching field on Fabrik's internal config struct — so a typo, a stale key left over from a past experiment, or an entry for a knob that's actually CLI/env-only (see the table below) parses cleanly and does *nothing*, with no error anywhere. At startup, Fabrik now detects every such key and reports it — non-fatal, on stderr:
+
+```
+[startup] warning: .fabrik/config.yaml: unrecognised key "archive_after"
+          (this knob is CLI/env-only — set FABRIK_ARCHIVE_AFTER or -archive-after)
+```
+
+A key with no matching flag or env var at all (a plain typo, never a real knob) gets only the base warning line, with no suggestion clause. This never fails startup — it's purely diagnostic, mirroring the [Stage YAML Drift Warning](#stage-yaml-drift-warning)'s "warn, don't block" behavior for the inverse case (an *extra* key here, vs. a *missing* one there).
+
+The flag/env suggestion is derived mechanically from Fabrik's snake_case (`config.yaml`) ↔ kebab-case (CLI flag) ↔ `FABRIK_SCREAMING_SNAKE_CASE` (env var) naming convention, verified live against the registered flag set — not a hand-maintained list, so it can't go stale as new knobs are added. Four already-recognized `config.yaml` keys break that convention (`git_ssh` vs. `--ssh`, `tui` vs. `--notui`/`FABRIK_TUI` (inverted), `project` vs. `FABRIK_PROJECT_NUMBER`, `janitor_interval_hours` vs. `--janitor-interval`) — for these four only, typo'ing the key in a way that happens to match the *other* name can produce a misleading "CLI/env-only" suggestion even though a `config.yaml` key already exists, just spelled differently. See ADR-1544.
+
 ### Environment Variables
 
 | Variable | `config.yaml` key | Description | Default |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -871,6 +871,19 @@ FABRIK_USER=my-personal-username
 | `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` file at worktree setup time. Enables stage code to read credentials (e.g. `ANTHROPIC_API_KEY`) from `.env` without copying secrets. No-op when source `.env` is absent; never overwrites an existing `.env` in the worktree; also excluded from git stash via the worktree's git exclude file. Also `FABRIK_SYMLINK_ENV` | `false` |
 | `--ghes-host` | GitHub Enterprise Server hostname (no scheme, no trailing slash), e.g. `github.example.com`. Governs the REST/GraphQL API endpoints, bare-clone URLs, commit-author noreply email, `GH_HOST` in stage-worker environments, and the startup minimum-version preflight. Absent (default) means github.com, byte-identical to today's behavior. Also `FABRIK_GHES_HOST`. See [GitHub Enterprise Server Support](#github-enterprise-server-support). | `""` (github.com) |
 
+#### Unrecognized `config.yaml` Key Warnings
+
+go-yaml silently discards any `.fabrik/config.yaml` key with no matching field on Fabrik's internal config struct — so a typo, a stale key left over from a past experiment, or an entry for a knob that's actually CLI/env-only (see the table below) parses cleanly and does *nothing*, with no error anywhere. At startup, Fabrik now detects every such key and reports it — non-fatal, on stderr:
+
+```
+[startup] warning: .fabrik/config.yaml: unrecognised key "archive_after"
+          (this knob is CLI/env-only — set FABRIK_ARCHIVE_AFTER or -archive-after)
+```
+
+A key with no matching flag or env var at all (a plain typo, never a real knob) gets only the base warning line, with no suggestion clause. This never fails startup — it's purely diagnostic, mirroring the [Stage YAML Drift Warning](#stage-yaml-drift-warning)'s "warn, don't block" behavior for the inverse case (an *extra* key here, vs. a *missing* one there).
+
+The flag/env suggestion is derived mechanically from Fabrik's snake_case (`config.yaml`) ↔ kebab-case (CLI flag) ↔ `FABRIK_SCREAMING_SNAKE_CASE` (env var) naming convention, verified live against the registered flag set — not a hand-maintained list, so it can't go stale as new knobs are added. Four already-recognized `config.yaml` keys break that convention (`git_ssh` vs. `--ssh`, `tui` vs. `--notui`/`FABRIK_TUI` (inverted), `project` vs. `FABRIK_PROJECT_NUMBER`, `janitor_interval_hours` vs. `--janitor-interval`) — for these four only, typo'ing the key in a way that happens to match the *other* name can produce a misleading "CLI/env-only" suggestion even though a `config.yaml` key already exists, just spelled differently. See ADR-1544.
+
 ### Environment Variables
 
 | Variable | `config.yaml` key | Description | Default |


### PR DESCRIPTION
Closes #1544

## What this does

`.fabrik/config.yaml` is decoded with a plain `yaml.Unmarshal`, so any key with no matching `ProjectConfig` field parses cleanly and is silently discarded — with no warning anywhere. A real incident: `archive_after: 48h` sat in a production config for weeks under the belief board archiving was on; it never ran once.

This PR adds detection, not rejection: at startup, Fabrik now reports every unrecognized top-level `.fabrik/config.yaml` key on stderr, with a mechanically-derived flag/env suggestion when the key corresponds to a real CLI/env-only knob:

```
[startup] warning: .fabrik/config.yaml: unrecognised key "archive_after"
          (this knob is CLI/env-only — set FABRIK_ARCHIVE_AFTER or -archive-after)
```

A key with no matching flag/env at all (pure typo, or a genuinely env-only knob like `FABRIK_ANTHROPIC_API_KEY`) gets only the base warning line. This is purely diagnostic — startup never fails, `LoadProjectConfig`'s behavior is unchanged, and `TestLoadProjectConfig_UnknownKeysIgnored` passes unmodified.

## Key design points

- **`config.UnrecognizedTopLevelKeys()`** (new, pure) reflects over `ProjectConfig`'s `yaml:"..."` tags to build the known-key set — so it can never drift from what `LoadProjectConfig` itself recognizes — then diffs it against the file's top-level keys only. Nested map values (`required_status_contexts`) are never inspected.
- **`cmd.warnUnrecognizedConfigKeys()`** (new) derives the candidate flag (`kebab-case`) and env var (`FABRIK_SCREAMING_SNAKE_CASE`) name and verifies existence live via `flag.CommandLine.Lookup` — no hand-maintained table, so a future knob addition is covered automatically.
- Wired into `cmd/root.go`'s daemon startup path only (not `fabrik watch`, which uses its own local `flag.FlagSet`), per the issue's explicit scope.
- Four already-recognized keys break the snake/kebab/SCREAMING_SNAKE convention (`git_ssh`, `tui`, `project`, `janitor_interval_hours`) — documented as a known, accepted limitation rather than special-cased.

See `adrs/1544-unrecognized-config-key-warning.md` for the full rationale, and the new `docs/USER_GUIDE.md` subsection for user-facing documentation.

## Testing

- `config/unknown_keys_test.go`: no file, empty file, all-recognized, single/multiple unrecognized (sorted), nested map values never flagged.
- `cmd/config_key_warn_test.go`: no matching flag, matching flag, multiple keys, empty list.
- `cmd/root_test.go`: `TestExecute_UnrecognizedConfigKeyWarning` — end-to-end via `Execute()`, asserting both the suggestion-bearing and base-only warning lines on stderr.
- Full suite green (`go build`, `go vet`, `go test -race ./...`) except `TestExecute_ConfigYAMLApplied`, a pre-existing network-dependent flake confirmed to fail identically on `main` without this change.