### PR TITLE
test(sim): cover dependency-unblock, backoff, stale-worker-reap, and reinvoke-cycle-counter scenarios

### DIFF
--- a/adrs/1592-sim-bed-backoff-and-startup-cleanup-seams.md
+++ b/adrs/1592-sim-bed-backoff-and-startup-cleanup-seams.md
@@ -1,0 +1,122 @@
+# ADR 1592: Sim Bed Backoff, Observer-Registration, and Startup-Cleanup Seams
+
+**Date**: 2026-08-15
+**Status**: Accepted
+**Issue**: #1592 — Cover four sequence-shaped engine behaviours the sim bed does not reach
+
+## Context
+
+#1592 set out to write four `tests/sim` scenarios for engine behaviour that only manifests
+across multiple polls or across two interacting items. Two of the four (dependency
+blocking/unblocking, the review/no-op reinvoke-cycle counters) turned out to be reachable
+through the existing `Engine.PollOnce` seam (ADR-1449) with no engine change — every code path
+they exercise runs inside `poll()`'s own catch-up-handler chain, which every existing sim
+scenario already drives.
+
+The other two, and one seam Research did not anticipate, were not:
+
+- **GraphQL rate-limit backoff** (`engine/backoff.go`): its five pure functions
+  (`shouldPauseForRESTRateLimit`, `idleBackoffMultiplier`, `nextRateLimitLow`,
+  `isRateLimitNearZero`, `computeEffectiveInterval`) had exactly one caller each, all inside
+  `Engine.Run()`'s `doPollCycle` closure — never `poll()` itself. `PollOnce` calls `poll()`
+  directly and reaches none of it.
+- **Stale-worker-label reaping** (`engine/worker_liveness.go`): the five one-shot startup scans
+  (`runStartupCleanup` and four siblings) are unexported and called only from `Run()`,
+  immediately after its first successful poll cycle — never from `poll()`/`PollOnce`.
+- **`PushUnblockObserver` and every other reactive `itemstate.Store` observer** (discovered
+  empirically while writing gap 1's scenario, not anticipated by Research/Plan): the entire
+  observer-registration block — `mayNeedWorkObserver`, `InvocationObserver`,
+  `StageChangeObserver`, `PushUnblockObserver`, `CommentBreakerObserver`, and the
+  `cacheImpl`-gated `WebhookHealthObserver` subscription — also lived only inside `Run()`,
+  executed once before entering its poll loop. `NewWithDeps` (the sim harness's engine
+  constructor) never registered any of them. Gap 1's blocker-closes-and-unblocks scenario is
+  entirely mediated by `PushUnblockObserver`, so without this seam gap 1 would have been
+  unreachable too — a gap the original Research pass missed because nothing about
+  `PushUnblockObserver`'s own code signals that its registration, not just its logic, is
+  `Run()`-only.
+
+All three are the same shape ADR-1449 already established a precedent for: production logic
+that is real and correct, sitting in a code path only `Run()`'s long-lived loop reaches, with no
+behavior-preserving way to reach it from a single deterministic poll cycle without exposing a
+new, minimal, additive seam.
+
+## Decision
+
+### Three new exported `Engine` methods, each a verbatim extraction
+
+**`Engine.RegisterObservers() (unregister func())`** (`engine/poll.go`) moves the entire
+observer-registration block out of `Run()` into its own method — same observers, same
+construction, same order — and returns an unsubscribe function. `Run()` now calls
+`e.RegisterObservers()` and defers the returned function, exactly replacing the block it used to
+inline. `tests/sim`'s `NewEnv` and `RestartEnv` each call it once, immediately after
+constructing the `Engine`, mirroring where `Run()` calls it in production (immediately before
+entering the poll loop). Registering twice on one `Engine` (e.g. a test that both calls this
+directly and later calls `Run()`) subscribes every observer twice — never done in production,
+and not a scenario this method guards against; a caller that also invokes `Run()` must not call
+this itself.
+
+**`Engine.PollWithBackoff(ctx, configuredInterval) (PollBackoffResult, error)`**
+(`engine/poll.go`) moves `doPollCycle`'s entire body — the REST/core rate-limit hard gate,
+`poll()` itself, idle-timer bookkeeping, GraphQL rate-limit two-threshold hysteresis, and the
+resulting effective next-poll interval — into its own method. `PollBackoffResult` carries only
+`NextInterval`; `Run()`'s `doPollCycle` closure collapses to calling `PollWithBackoff` and
+resetting its own ticker from the returned value. The five pieces of state the closure held as
+locals (`prevMultiplier`, `rateLimitLow`, `rateLimitRatio`, `lastRemainingCount`,
+`restRateLimitPaused`) become `Engine` fields (`backoffPrevMultiplier`, `backoffRateLimitLow`,
+`backoffRateLimitRatio`, `backoffLastRemaining`, `backoffRestPaused`), mirroring the existing
+`idleStart` field's precedent — necessary because the method must now be callable repeatedly,
+across successive polls, from a test. Unlike `idleStart`'s zero value (a genuine "not idle"
+sentinel), `backoffPrevMultiplier` and `backoffRateLimitRatio` have non-zero starting values (1
+and 1.0) that both `New()` and `NewWithDeps()` set explicitly.
+
+**`Engine.RunStartupCleanup()`** (`engine/worker_liveness.go`) delegates, in order, to the five
+one-shot startup scans `Run()` has always run after its first successful poll cycle
+(`runStartupCleanup`, `runStartupOrphanedInProgressScan`, `runStartupBareInProgressScan`,
+`runStartupTransientLabelScan`, `runStartupTerminalScan`). `Run()`'s five separate calls collapse
+to one call to this method. Deliberately excludes the periodic
+`runWorktreeJanitor`/`runLogJanitor`/`runSessionJanitor` calls `Run()` makes alongside these
+scans (gated separately on `cfg.JanitorIntervalHours > 0`) — those are a distinct, ongoing
+concern, not part of the one-shot startup recovery pass this method names.
+
+All three read as "moved," not "changed": every log line, every TUI event, every mutation is
+identical to what `Run()` already did, in the same order, confirmed by the full existing
+`go test ./engine/...` suite passing unmodified.
+
+### `PollWithBackoff`'s REST hard gate: `e.now()`, not `time.Now()`
+
+One genuine, minimal behavior widening rides along with the extraction, discovered while writing
+gap 2's REST-hard-gate scenario: `shouldPauseForRESTRateLimit`'s `now` argument and the
+`NextInterval` computed from `restStats.Reset` both used `time.Now()` directly in the
+pre-extraction closure. `restStats.Reset` is computed by the read client relative to whatever
+clock it uses — `tests/sim/simgh`'s `RateLimitStats` reads the injected `Clock`, which
+`tests/sim/env.go` anchors at 2026-01-01 by default (ADR-1449's `SetClock`/`e.now()` seam).
+Comparing that against real `time.Now()` (today's actual date) meant the REST budget always
+looked "already reset, ages ago" — the gate could never be observed active in a sim scenario at
+all, regardless of how exhausted the seeded budget was.
+
+Both call sites now use `e.now()` instead. This is the same widening ADR-1449 documents for its
+own clock seam ("a future contributor adding a new timing gate ... should check whether it is
+... engine-local"): `e.now()` falls back to `time.Now()` whenever no `Clock` is injected (see
+`engine/clock.go`), so production — where `New()` never calls `SetClock` — is byte-identical
+before and after, confirmed by the same full `engine` test suite. Only a scenario that injects a
+`Clock` (every `tests/sim` scenario) observes the difference, and only at this one call site.
+
+## Consequences
+
+- `PollBackoffResult` (`engine/poll.go`) and the five `backoff*` `Engine` fields are new,
+  additive production surface, alongside the two new exported methods. No existing call site's
+  *behavior* changes; both are confirmed byte-identical to prior behavior by the full existing
+  `go test ./engine/...` suite.
+- `tests/sim/dependency_unblock_test.go` (gap 1), `tests/sim/backoff_test.go` (gap 2), and
+  `tests/sim/stale_worker_reap_test.go` (gap 3) are the first sim scenarios to depend on
+  `RegisterObservers`, `PollWithBackoff`, and `RunStartupCleanup` respectively — every other
+  existing `tests/sim` scenario continues to use `PollOnce` alone and is unaffected by any of the
+  three (`RegisterObservers` was silently a no-op for them before this issue, since none of the
+  observers it registers gate any assertion those scenarios already made).
+- A future contributor writing a new sim scenario that exercises engine behavior gated by a
+  reactive `itemstate.Store` observer, GraphQL/REST rate-limit response, or a one-shot
+  startup-recovery scan should reach for these three methods directly rather than re-deriving
+  `Run()`'s own preamble — the same guidance ADR-1449 gives for `PollOnce`/`SetClock`.
+- Mirrors ADR-1449's own closing note: a future timing gate should be checked for whether it
+  compares a GitHub-read timestamp against `time.Now()` rather than `e.now()` — this issue found
+  a second instance of exactly that gap, in code that predates the Clock seam itself.

--- a/adrs/1592-sim-bed-backoff-and-startup-cleanup-seams.md
+++ b/adrs/1592-sim-bed-backoff-and-startup-cleanup-seams.md
@@ -48,12 +48,26 @@ new, minimal, additive seam.
 observer-registration block out of `Run()` into its own method — same observers, same
 construction, same order — and returns an unsubscribe function. `Run()` now calls
 `e.RegisterObservers()` and defers the returned function, exactly replacing the block it used to
-inline. `tests/sim`'s `NewEnv` and `RestartEnv` each call it once, immediately after
-constructing the `Engine`, mirroring where `Run()` calls it in production (immediately before
-entering the poll loop). Registering twice on one `Engine` (e.g. a test that both calls this
-directly and later calls `Run()`) subscribes every observer twice — never done in production,
-and not a scenario this method guards against; a caller that also invokes `Run()` must not call
-this itself.
+inline. Registering twice on one `Engine` (e.g. a test that both calls this directly and later
+calls `Run()`) subscribes every observer twice — never done in production, and not a scenario
+this method guards against; a caller that also invokes `Run()` must not call this itself.
+
+`tests/sim`'s `NewEnv`/`RestartEnv` deliberately do **not** call this by default, unlike the
+other two seams below (which change no scenario's behavior merely by existing). Registering
+every observer for every scenario in the package changes dispatch *timing*, not just
+reachability: `mayNeedWorkObserver` populates a fast-path (`cycleSet`) that bypasses
+`itemMayNeedWork`'s cooldown-based admission gate, so once active, an item that changed for any
+tracked reason is re-admitted for deep-fetch immediately instead of waiting out its cooldown.
+Wiring it in unconditionally, during Implement, broke four pre-existing, unrelated scenarios —
+some raced an item through multiple stages before an intermediate status checkpoint could
+observe it, one hung the whole package past its 10-minute test timeout — none of which was a
+`mayNeedWorkObserver` defect; those scenarios' own timing assumptions simply predated this
+observer ever being reachable from `tests/sim` at all. `tests/sim/env.go`'s `NewEnv` doc comment
+records this finding in full. The two scenario files that do need it call
+`env.Engine.RegisterObservers()` themselves: `dependency_unblock_test.go` (gap 1, for
+`PushUnblockObserver` itself) and `reinvoke_cycle_counters_test.go` (gap 4, for a different,
+also-discovered-empirically reason — see that file's own doc comment on
+`reinvokeCycleCountersEnv`).
 
 **`Engine.PollWithBackoff(ctx, configuredInterval) (PollBackoffResult, error)`**
 (`engine/poll.go`) moves `doPollCycle`'s entire body — the REST/core rate-limit hard gate,
@@ -107,12 +121,17 @@ before and after, confirmed by the same full `engine` test suite. Only a scenari
   additive production surface, alongside the two new exported methods. No existing call site's
   *behavior* changes; both are confirmed byte-identical to prior behavior by the full existing
   `go test ./engine/...` suite.
-- `tests/sim/dependency_unblock_test.go` (gap 1), `tests/sim/backoff_test.go` (gap 2), and
-  `tests/sim/stale_worker_reap_test.go` (gap 3) are the first sim scenarios to depend on
-  `RegisterObservers`, `PollWithBackoff`, and `RunStartupCleanup` respectively — every other
-  existing `tests/sim` scenario continues to use `PollOnce` alone and is unaffected by any of the
-  three (`RegisterObservers` was silently a no-op for them before this issue, since none of the
-  observers it registers gate any assertion those scenarios already made).
+- `tests/sim/backoff_test.go` (gap 2) and `tests/sim/stale_worker_reap_test.go` (gap 3) are the
+  first sim scenarios to depend on `PollWithBackoff` and `RunStartupCleanup` respectively; both
+  are called explicitly only by the scenario that needs them, so every other existing `tests/sim`
+  scenario continues to use `PollOnce` alone, unaffected. `RegisterObservers` is different:
+  unlike the other two, it is never called by default at all — see the Decision section above and
+  `tests/sim/env.go`'s `NewEnv` doc comment for why an unconditional call broke four unrelated,
+  pre-existing scenarios during Implement. `tests/sim/dependency_unblock_test.go` (gap 1) and
+  `tests/sim/reinvoke_cycle_counters_test.go` (gap 4) each call it themselves, for two distinct
+  reasons neither Research nor Plan anticipated (`PushUnblockObserver`'s own registration for
+  gap 1; a cooldown-suppression interaction specific to advisory-mode multi-round reinvokes for
+  gap 4 — see that file's own doc comment).
 - A future contributor writing a new sim scenario that exercises engine behavior gated by a
   reactive `itemstate.Store` observer, GraphQL/REST rate-limit response, or a one-shot
   startup-recovery scan should reach for these three methods directly rather than re-deriving

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -125,6 +125,19 @@ type Engine struct {
 	idleCount                int                      // consecutive idle polls; triggers self-upgrade at threshold
 	idleStart                time.Time                // when consecutive idle polls began; zero value = not idle
 	pollsUntilStalenessCheck int                      // countdown to next checkSourceStaleness; 0 fires on next poll (#1464)
+	// backoffPrevMultiplier, backoffRateLimitLow, backoffRateLimitRatio,
+	// backoffLastRemaining, and backoffRestPaused are PollWithBackoff's
+	// persistent state (engine/poll.go) — promoted from doPollCycle closure
+	// locals to Engine fields (ADR-1592) so a test driving successive
+	// PollWithBackoff calls sees correctly-persisted backoff state, mirroring
+	// idleStart's own precedent. Unlike idleStart's zero-value ("not idle"),
+	// backoffPrevMultiplier and backoffRateLimitRatio have non-zero starting
+	// values that both New() and NewWithDeps() set explicitly.
+	backoffPrevMultiplier int
+	backoffRateLimitLow   bool
+	backoffRateLimitRatio float64
+	backoffLastRemaining  int
+	backoffRestPaused     bool
 	// stalenessCompareFn overrides selfupgrade.CompareDevBuild when non-nil.
 	// Used by tests to inject a synthetic DevBuildStatus without real git
 	// subprocesses. Production leaves this nil.
@@ -320,6 +333,8 @@ func New(cfg Config) (*Engine, error) {
 		mergeTrainRunawayAlerted:  make(map[string]int),
 		queuedReviewEjects:        make(map[string]map[int]int),
 		pauseIssueMu:              make(map[string]*pauseIssueMuEntry),
+		backoffPrevMultiplier:     1,
+		backoffRateLimitRatio:     1.0,
 	}
 
 	// Migrate any old-style worktrees (issue-N/) to the new per-repo layout.
@@ -381,6 +396,8 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		mergeTrainRunawayAlerted:  make(map[string]int),
 		queuedReviewEjects:        make(map[string]map[int]int),
 		pauseIssueMu:              make(map[string]*pauseIssueMuEntry),
+		backoffPrevMultiplier:     1,
+		backoffRateLimitRatio:     1.0,
 	}
 	if worktrees != nil {
 		worktrees.logfFn = eng.logf

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -512,126 +512,17 @@ func (e *Engine) Run() error {
 	ticker := time.NewTicker(configuredInterval)
 	defer ticker.Stop()
 
-	prevMultiplier := 1
-	rateLimitLow := false
-	rateLimitRatio := 1.0
-	lastRemainingCount := 0
-	restRateLimitPaused := false
-
-	// doPollCycle runs poll(), updates idle/backoff state, emits PollCompletedEvent,
-	// and resets the ticker to the effective interval. Returns the error from poll().
+	// doPollCycle runs PollWithBackoff (REST hard gate, poll(), idle/backoff
+	// bookkeeping, PollCompletedEvent) and resets the ticker to the returned
+	// effective interval. Returns the error from poll(). See
+	// Engine.PollWithBackoff's own doc comment for why the backoff state
+	// itself lives on Engine, not as closure locals here.
 	doPollCycle := func() error {
-		// REST/core rate-limit hard gate. The GraphQL-driven interval backoff below
-		// conserves the GraphQL budget (spent by the poll read) but does nothing for
-		// the REST/core budget, which is spent by per-item mutations (reactions,
-		// labels, comments, merges) and janitor fetches. When REST is exhausted,
-		// skip the ENTIRE work phase — fetch, dispatch, and mutations — until
-		// GitHub's hourly reset, rather than hammering 403s in a retry storm.
-		// restStats are refreshed from the headers of every REST response (including
-		// 403s), so Reset is authoritative even once the budget is at zero.
-		restStats, _ := e.client.RateLimitStats()
-		if shouldPauseForRESTRateLimit(restStats.Remaining, restStats.Limit, restStats.Reset, time.Now()) {
-			if !restRateLimitPaused {
-				e.logf(0, "warn", "REST rate limit exhausted (%d/%d remaining) — pausing all work until reset at %s\n",
-					restStats.Remaining, restStats.Limit, restStats.Reset.Format(time.RFC3339))
-				e.emitStructural(tui.RateLimitAlertEvent{Bucket: tui.RateLimitBucketREST, Exhausted: true, Reset: restStats.Reset})
-				restRateLimitPaused = true
-			}
-			ticker.Reset(time.Until(restStats.Reset) + rateLimitResetBuffer)
-			return nil
-		}
-		if restRateLimitPaused {
-			e.logf(0, "info", "REST rate limit reset (%d/%d remaining) — resuming work\n",
-				restStats.Remaining, restStats.Limit)
-			e.emitStructural(tui.RateLimitAlertEvent{Bucket: tui.RateLimitBucketREST, Exhausted: false})
-			restRateLimitPaused = false
-		}
-
-		result, err := e.poll(ctx)
+		result, err := e.PollWithBackoff(ctx, configuredInterval)
 		if err != nil {
 			return err
 		}
-
-		// Update idle timer.
-		if result.Active {
-			if !e.idleStart.IsZero() {
-				e.logf(0, "poll", "activity detected — idle backoff reset\n")
-			}
-			e.idleStart = time.Time{}
-		} else if e.idleStart.IsZero() {
-			e.idleStart = time.Now()
-		}
-
-		// Update rate-limit state using two-threshold hysteresis:
-		// activate when ratio drops below 20%; clear only when ratio rises above 50%.
-		// Activity detection does NOT reset rate-limit backoff — it is a separate concern.
-		_, graphqlStats := e.client.RateLimitStats()
-		if graphqlStats.Limit > 0 {
-			ratio := float64(graphqlStats.Remaining) / float64(graphqlStats.Limit)
-			newRateLimitLow := nextRateLimitLow(rateLimitLow, ratio)
-			if newRateLimitLow && !rateLimitLow {
-				e.logf(0, "warn", "GraphQL rate limit low (%.0f%% remaining) — activating rate-limit backoff\n", ratio*100)
-			} else if !newRateLimitLow && rateLimitLow {
-				if isRateLimitNearZero(lastRemainingCount, graphqlStats.Limit) {
-					e.logf(0, "info", "GraphQL rate limit recovered (%d/%d remaining) — triggering immediate probe\n", graphqlStats.Remaining, graphqlStats.Limit)
-					if e.wakeCh != nil {
-						select {
-						case e.wakeCh <- struct{}{}:
-						default:
-						}
-					}
-				} else {
-					e.logf(0, "poll", "GraphQL rate limit recovered (%.0f%% remaining)\n", ratio*100)
-				}
-				e.emitStructural(tui.RateLimitAlertEvent{Bucket: tui.RateLimitBucketGraphQL, Exhausted: false})
-			}
-			rateLimitLow = newRateLimitLow
-			if rateLimitLow {
-				rateLimitRatio = ratio
-			} else {
-				rateLimitRatio = 1.0
-			}
-			lastRemainingCount = graphqlStats.Remaining
-		}
-
-		// Compute and apply effective interval.
-		var idleDuration time.Duration
-		if !e.idleStart.IsZero() {
-			idleDuration = time.Since(e.idleStart)
-		}
-		webhookHealthy := e.webhookMgr != nil && e.webhookMgr.IsHealthyOrStartingUp()
-		if e.webhookMgr != nil && e.webhookMgr.IsDisabled() {
-			e.logf(0, "webhook", "poll-only mode active — webhook subscription disabled; restart Fabrik to retry\n")
-		}
-		effectiveInterval := computeEffectiveInterval(configuredInterval, idleDuration, rateLimitRatio, webhookHealthy)
-
-		// Notify webhook manager of any new repos discovered during this poll.
-		if e.webhookMgr != nil && result.SeenRepos != nil {
-			e.webhookMgr.UpdateRepos(result.SeenRepos)
-		}
-
-		// Log backoff level transitions.
-		mult := idleBackoffMultiplier(idleDuration)
-		if mult != prevMultiplier && !e.idleStart.IsZero() {
-			if mult == 0 {
-				e.logf(0, "poll", "idle backoff: max (%v)\n", effectiveInterval)
-			} else if mult > 1 {
-				e.logf(0, "poll", "idle backoff: %dx (%v)\n", mult, effectiveInterval)
-			}
-			prevMultiplier = mult
-		}
-		if result.Active {
-			prevMultiplier = 1
-		}
-
-		ticker.Reset(effectiveInterval)
-
-		e.emitStructural(tui.PollCompletedEvent{
-			ItemCount:         result.ItemCount,
-			Dispatched:        result.Dispatched,
-			GraphQLStats:      tui.RateLimitStats{Limit: graphqlStats.Limit, Remaining: graphqlStats.Remaining, Reset: graphqlStats.Reset},
-			EffectiveInterval: effectiveInterval,
-		})
+		ticker.Reset(result.NextInterval)
 		return nil
 	}
 
@@ -656,11 +547,7 @@ func (e *Engine) Run() error {
 	// Only runs after a successful first poll cycle so the store is populated.
 	// Skipped on poll failure to avoid scanning an empty/partial store.
 	if firstPollErr == nil {
-		e.runStartupCleanup()
-		e.runStartupOrphanedInProgressScan()
-		e.runStartupBareInProgressScan()
-		e.runStartupTransientLabelScan()
-		e.runStartupTerminalScan()
+		e.RunStartupCleanup()
 		if e.cfg.JanitorIntervalHours > 0 {
 			e.runWorktreeJanitor(ctx)
 			e.runLogJanitor(ctx)
@@ -995,6 +882,182 @@ func (e *Engine) RegisterObservers() (unregister func()) {
 			unsub()
 		}
 	}
+}
+
+// PollBackoffResult carries PollWithBackoff's computed next-poll interval —
+// the one piece of state a caller needs to act on (resetting its own
+// ticker). See PollWithBackoff's own doc comment.
+type PollBackoffResult struct {
+	// NextInterval is the interval the caller should use for its next poll
+	// cycle — computed from idle backoff, GraphQL rate-limit hysteresis, and
+	// (for the REST hard-gate short-circuit) time until the REST budget
+	// resets. Zero when PollWithBackoff returns a non-nil error: mirrors
+	// Run()'s original behavior of leaving the ticker on its prior schedule
+	// when poll() itself fails, rather than resetting to some fallback value.
+	NextInterval time.Duration
+}
+
+// PollWithBackoff is a verbatim extraction of what Run()'s doPollCycle
+// closure has always done around a single poll() call: the REST/core
+// rate-limit hard gate (skip the whole work phase, including poll(), until
+// GitHub's hourly reset), idle-timer bookkeeping, GraphQL rate-limit
+// hysteresis (two-threshold: activate below 20%, clear above 50%), and the
+// resulting effective next-poll interval. Run() itself now calls this
+// instead of inlining the block — same statements, same order, same log
+// lines and TUI events, just under a name an external caller can reach. The
+// one unavoidable reordering: emitStructural(PollCompletedEvent) now happens
+// inside this method, before the caller can reset its own ticker from the
+// returned interval (previously the ticker reset came first) — the two have
+// no ordering dependency on each other, so this is not a behavior change.
+//
+// This is a test seam (ADR-1592, mirroring PollOnce/ADR-1449 and
+// RegisterObservers above): PollOnce drives poll() directly and reaches none
+// of this — backoff.go's five pure functions (shouldPauseForRESTRateLimit,
+// idleBackoffMultiplier, nextRateLimitLow, isRateLimitNearZero,
+// computeEffectiveInterval) have no call site outside Run()'s own closure,
+// so without this seam gap 2 (#1592) — GraphQL rate-limit backoff across
+// successive polls — is 100% unreachable from tests/sim, the same shape of
+// gap RegisterObservers closes for the reactive-observer registration block.
+//
+// The five pieces of state doPollCycle's closure locals held
+// (prevMultiplier, rateLimitLow, rateLimitRatio, lastRemainingCount,
+// restRateLimitPaused) are now Engine fields (backoffPrevMultiplier,
+// backoffRateLimitLow, backoffRateLimitRatio, backoffLastRemaining,
+// backoffRestPaused) so state persists correctly across a scenario's
+// successive PollWithBackoff calls, mirroring the existing idleStart field's
+// precedent. Unlike idleStart's zero-value (a genuine "not idle" sentinel),
+// backoffPrevMultiplier and backoffRateLimitRatio have non-zero starting
+// values (1 and 1.0 respectively) that both New() and NewWithDeps() set
+// explicitly.
+//
+// configuredInterval is the base poll interval (cfg.PollSeconds as a
+// Duration, in Run(); a scenario may pass whatever it wants to test
+// against). Deliberately does NOT reset any ticker itself — Run() owns its
+// own ticker and resets it from the returned NextInterval; a test driving
+// this repeatedly has no ticker to reset in the first place.
+func (e *Engine) PollWithBackoff(ctx context.Context, configuredInterval time.Duration) (PollBackoffResult, error) {
+	// REST/core rate-limit hard gate. The GraphQL-driven interval backoff below
+	// conserves the GraphQL budget (spent by the poll read) but does nothing for
+	// the REST/core budget, which is spent by per-item mutations (reactions,
+	// labels, comments, merges) and janitor fetches. When REST is exhausted,
+	// skip the ENTIRE work phase — fetch, dispatch, and mutations — until
+	// GitHub's hourly reset, rather than hammering 403s in a retry storm.
+	// restStats are refreshed from the headers of every REST response (including
+	// 403s), so Reset is authoritative even once the budget is at zero.
+	//
+	// Both time references below use e.now(), not time.Now() directly (a
+	// change from this block's pre-#1592 shape, when it lived inline in
+	// Run()'s doPollCycle closure): byte-identical to the prior behavior in
+	// production (e.now() falls back to time.Now() whenever no Clock is
+	// injected — see engine/clock.go), and required for this method to be
+	// meaningfully testable at all — restStats.Reset is computed relative to
+	// whatever clock the read client uses (tests/sim/simgh's RateLimitStats
+	// reads the injected Clock), so comparing it against real time.Now()
+	// from tests/sim's default 2026-01-01 clock start would report the
+	// budget as permanently already-reset. Widens e.now()'s existing
+	// CooldownAt-scoped contract (engine/clock.go) to this call site; see
+	// ADR-1592.
+	restStats, _ := e.client.RateLimitStats()
+	if shouldPauseForRESTRateLimit(restStats.Remaining, restStats.Limit, restStats.Reset, e.now()) {
+		if !e.backoffRestPaused {
+			e.logf(0, "warn", "REST rate limit exhausted (%d/%d remaining) — pausing all work until reset at %s\n",
+				restStats.Remaining, restStats.Limit, restStats.Reset.Format(time.RFC3339))
+			e.emitStructural(tui.RateLimitAlertEvent{Bucket: tui.RateLimitBucketREST, Exhausted: true, Reset: restStats.Reset})
+			e.backoffRestPaused = true
+		}
+		return PollBackoffResult{NextInterval: restStats.Reset.Sub(e.now()) + rateLimitResetBuffer}, nil
+	}
+	if e.backoffRestPaused {
+		e.logf(0, "info", "REST rate limit reset (%d/%d remaining) — resuming work\n",
+			restStats.Remaining, restStats.Limit)
+		e.emitStructural(tui.RateLimitAlertEvent{Bucket: tui.RateLimitBucketREST, Exhausted: false})
+		e.backoffRestPaused = false
+	}
+
+	result, err := e.poll(ctx)
+	if err != nil {
+		return PollBackoffResult{}, err
+	}
+
+	// Update idle timer.
+	if result.Active {
+		if !e.idleStart.IsZero() {
+			e.logf(0, "poll", "activity detected — idle backoff reset\n")
+		}
+		e.idleStart = time.Time{}
+	} else if e.idleStart.IsZero() {
+		e.idleStart = time.Now()
+	}
+
+	// Update rate-limit state using two-threshold hysteresis:
+	// activate when ratio drops below 20%; clear only when ratio rises above 50%.
+	// Activity detection does NOT reset rate-limit backoff — it is a separate concern.
+	_, graphqlStats := e.client.RateLimitStats()
+	if graphqlStats.Limit > 0 {
+		ratio := float64(graphqlStats.Remaining) / float64(graphqlStats.Limit)
+		newRateLimitLow := nextRateLimitLow(e.backoffRateLimitLow, ratio)
+		if newRateLimitLow && !e.backoffRateLimitLow {
+			e.logf(0, "warn", "GraphQL rate limit low (%.0f%% remaining) — activating rate-limit backoff\n", ratio*100)
+		} else if !newRateLimitLow && e.backoffRateLimitLow {
+			if isRateLimitNearZero(e.backoffLastRemaining, graphqlStats.Limit) {
+				e.logf(0, "info", "GraphQL rate limit recovered (%d/%d remaining) — triggering immediate probe\n", graphqlStats.Remaining, graphqlStats.Limit)
+				if e.wakeCh != nil {
+					select {
+					case e.wakeCh <- struct{}{}:
+					default:
+					}
+				}
+			} else {
+				e.logf(0, "poll", "GraphQL rate limit recovered (%.0f%% remaining)\n", ratio*100)
+			}
+			e.emitStructural(tui.RateLimitAlertEvent{Bucket: tui.RateLimitBucketGraphQL, Exhausted: false})
+		}
+		e.backoffRateLimitLow = newRateLimitLow
+		if e.backoffRateLimitLow {
+			e.backoffRateLimitRatio = ratio
+		} else {
+			e.backoffRateLimitRatio = 1.0
+		}
+		e.backoffLastRemaining = graphqlStats.Remaining
+	}
+
+	// Compute and apply effective interval.
+	var idleDuration time.Duration
+	if !e.idleStart.IsZero() {
+		idleDuration = time.Since(e.idleStart)
+	}
+	webhookHealthy := e.webhookMgr != nil && e.webhookMgr.IsHealthyOrStartingUp()
+	if e.webhookMgr != nil && e.webhookMgr.IsDisabled() {
+		e.logf(0, "webhook", "poll-only mode active — webhook subscription disabled; restart Fabrik to retry\n")
+	}
+	effectiveInterval := computeEffectiveInterval(configuredInterval, idleDuration, e.backoffRateLimitRatio, webhookHealthy)
+
+	// Notify webhook manager of any new repos discovered during this poll.
+	if e.webhookMgr != nil && result.SeenRepos != nil {
+		e.webhookMgr.UpdateRepos(result.SeenRepos)
+	}
+
+	// Log backoff level transitions.
+	mult := idleBackoffMultiplier(idleDuration)
+	if mult != e.backoffPrevMultiplier && !e.idleStart.IsZero() {
+		if mult == 0 {
+			e.logf(0, "poll", "idle backoff: max (%v)\n", effectiveInterval)
+		} else if mult > 1 {
+			e.logf(0, "poll", "idle backoff: %dx (%v)\n", mult, effectiveInterval)
+		}
+		e.backoffPrevMultiplier = mult
+	}
+	if result.Active {
+		e.backoffPrevMultiplier = 1
+	}
+
+	e.emitStructural(tui.PollCompletedEvent{
+		ItemCount:         result.ItemCount,
+		Dispatched:        result.Dispatched,
+		GraphQLStats:      tui.RateLimitStats{Limit: graphqlStats.Limit, Remaining: graphqlStats.Remaining, Reset: graphqlStats.Reset},
+		EffectiveInterval: effectiveInterval,
+	})
+	return PollBackoffResult{NextInterval: effectiveInterval}, nil
 }
 
 // PollOnce runs exactly one poll cycle and reports only whether it errored —

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -405,71 +405,18 @@ func (e *Engine) Run() error {
 
 	// In production wiring readClient is always *CacheImpl; the cast may return
 	// (nil, false) when called from tests that use the pass-through GitHub adapter
-	// directly via NewWithDeps. Code paths that depend on cacheImpl must check nil.
+	// directly via NewWithDeps. Code paths below that depend on cacheImpl must
+	// check nil. RegisterObservers performs this identical cast internally for
+	// its own cacheImpl-gated observer.
 	cacheImpl, _ := e.readClient.(*boardcache.CacheImpl)
 
-	// Register reactive observers. All returned unsubscribe funcs are collected
-	// and called when Run returns. Observers on cacheImpl are gated on cacheImpl != nil;
-	// observers on engine.store are always registered.
-	{
-		var unsubs []func()
-		defer func() {
-			for _, unsub := range unsubs {
-				unsub()
-			}
-		}()
-
-		// wakeChObserver fires on board-state changes. After store unification, the
-		// shared store receives both engine-side mutations (LockChanged) and webhook/
-		// reconcile-side mutations (Status/Labels/Comments/LinkedPR). Register once
-		// on the shared store — no cacheImpl registration needed or allowed.
-		if e.wakeCh != nil {
-			wakeObs := newWakeChObserver(e.wakeCh)
-			unsubs = append(unsubs, e.store.Subscribe(wakeObs))
-		}
-
-		// mayNeedWorkObserver populates e.mayNeedWork when items change. Register
-		// once on the shared store; all mutation types flow through it post-unification.
-		mwnObs := newMayNeedWorkObserver(&e.mayNeedWorkMu, &e.mayNeedWork)
-		unsubs = append(unsubs, e.store.Subscribe(mwnObs))
-
-		// InvocationObserver fires on InvocationRecorded mutations (engine-side).
-		invObs := &InvocationObserver{Stages: e.cfg.Stages, Emit: e.emitStructural}
-		unsubs = append(unsubs, e.store.Subscribe(invObs))
-
-		// StageChangeObserver fires on StatusChanged mutations. After store unification
-		// it registers on the shared store (not cacheImpl) so it sees all status changes.
-		stageObs := &StageChangeObserver{Emit: e.emitStructural}
-		unsubs = append(unsubs, e.store.Subscribe(stageObs))
-
-		// PushUnblockObserver fires on StateChanged (issue close) and removes
-		// fabrik:blocked from dependents whose all blockers are now resolved.
-		// StateChanged is not in wakeChFlags so this registration has no effect on
-		// poll-wake behaviour. Registered on e.store only (post store-unification).
-		pushUnblockObs := &PushUnblockObserver{
-			Store:  e.store,
-			Remove: func(owner, repo string, n int) { e.removeBlockedIfResolved(owner, repo, n) },
-			Logf:   func(format string, args ...any) { e.logf(0, "push-unblock", format, args...) },
-		}
-		unsubs = append(unsubs, e.store.Subscribe(pushUnblockObs))
-
-		// CommentBreakerObserver resets the comment-processing circuit breaker on
-		// linked-PR state changes (#1089).
-		cbObs := &CommentBreakerObserver{Store: e.store}
-		unsubs = append(unsubs, e.store.Subscribe(cbObs))
-
-		if cacheImpl != nil {
-			// WebhookHealthObserver fires tui.WebhookStatusEvent on pause/resume transitions.
-			// SubscribePause is a CacheImpl-level signal (stream health), not a Store mutation.
-			unsubs = append(unsubs, cacheImpl.SubscribePause(func(paused bool) {
-				state := "healthy"
-				if paused {
-					state = "unhealthy"
-				}
-				e.emitStructural(tui.WebhookStatusEvent{State: state})
-			}))
-		}
-	}
+	// Register reactive observers (mayNeedWork fast-path population, TUI event
+	// emission, PushUnblockObserver's dependency-unblock propagation, the
+	// comment-breaker's PR-state reset, and — when cacheImpl is wired —
+	// webhook-health events). See RegisterObservers's own doc comment for why
+	// this is a separate exported method rather than inlined here.
+	unregisterObservers := e.RegisterObservers()
+	defer unregisterObservers()
 
 	// Start webhook manager when enabled. Failures are non-fatal: the engine
 	// continues in polling-only mode.
@@ -959,6 +906,95 @@ type pollResult struct {
 	ItemCount  int
 	Dispatched int
 	SeenRepos  map[string]bool // all repos observed on the board in this poll
+}
+
+// RegisterObservers subscribes the engine's steady-state reactive observers
+// on e.store (and, when the read client is a *boardcache.CacheImpl, on it as
+// well) and returns a function that unsubscribes all of them. It is a
+// verbatim extraction of the registration block Run() has always executed
+// immediately before starting its poll loop — same observers, same
+// construction, same order; Run() itself now calls this method instead of
+// inlining the block.
+//
+// This is a test seam (ADR-1592, mirroring PollOnce/ADR-1449): PollOnce
+// drives poll() directly and never runs any part of Run()'s preamble, so
+// without a way to call this separately, every observer registered here —
+// including PushUnblockObserver, the sole delivery mechanism for gap 1's
+// dependency-unblock propagation (#1592) — is unreachable from tests/sim,
+// exactly the same shape of gap PollWithBackoff/RunStartupCleanup close for
+// backoff.go/worker_liveness.go. tests/sim's NewEnv and RestartEnv call this
+// once, immediately after constructing the Engine, mirroring where Run()
+// calls it in production.
+//
+// Registering twice on the same Engine (e.g. a test that both calls this
+// directly AND later calls Run()) subscribes every observer twice, which is
+// never done in production and not a scenario this method guards against —
+// callers that also invoke Run() must not call this method themselves; Run()
+// already calls it internally.
+func (e *Engine) RegisterObservers() (unregister func()) {
+	// In production wiring readClient is always *CacheImpl; the cast may return
+	// (nil, false) when called from tests that use the pass-through GitHub adapter
+	// directly via NewWithDeps. Code paths that depend on cacheImpl must check nil.
+	cacheImpl, _ := e.readClient.(*boardcache.CacheImpl)
+
+	var unsubs []func()
+
+	// wakeChObserver fires on board-state changes. After store unification, the
+	// shared store receives both engine-side mutations (LockChanged) and webhook/
+	// reconcile-side mutations (Status/Labels/Comments/LinkedPR). Register once
+	// on the shared store — no cacheImpl registration needed or allowed.
+	if e.wakeCh != nil {
+		wakeObs := newWakeChObserver(e.wakeCh)
+		unsubs = append(unsubs, e.store.Subscribe(wakeObs))
+	}
+
+	// mayNeedWorkObserver populates e.mayNeedWork when items change. Register
+	// once on the shared store; all mutation types flow through it post-unification.
+	mwnObs := newMayNeedWorkObserver(&e.mayNeedWorkMu, &e.mayNeedWork)
+	unsubs = append(unsubs, e.store.Subscribe(mwnObs))
+
+	// InvocationObserver fires on InvocationRecorded mutations (engine-side).
+	invObs := &InvocationObserver{Stages: e.cfg.Stages, Emit: e.emitStructural}
+	unsubs = append(unsubs, e.store.Subscribe(invObs))
+
+	// StageChangeObserver fires on StatusChanged mutations. After store unification
+	// it registers on the shared store (not cacheImpl) so it sees all status changes.
+	stageObs := &StageChangeObserver{Emit: e.emitStructural}
+	unsubs = append(unsubs, e.store.Subscribe(stageObs))
+
+	// PushUnblockObserver fires on StateChanged (issue close) and removes
+	// fabrik:blocked from dependents whose all blockers are now resolved.
+	// StateChanged is not in wakeChFlags so this registration has no effect on
+	// poll-wake behaviour. Registered on e.store only (post store-unification).
+	pushUnblockObs := &PushUnblockObserver{
+		Store:  e.store,
+		Remove: func(owner, repo string, n int) { e.removeBlockedIfResolved(owner, repo, n) },
+		Logf:   func(format string, args ...any) { e.logf(0, "push-unblock", format, args...) },
+	}
+	unsubs = append(unsubs, e.store.Subscribe(pushUnblockObs))
+
+	// CommentBreakerObserver resets the comment-processing circuit breaker on
+	// linked-PR state changes (#1089).
+	cbObs := &CommentBreakerObserver{Store: e.store}
+	unsubs = append(unsubs, e.store.Subscribe(cbObs))
+
+	if cacheImpl != nil {
+		// WebhookHealthObserver fires tui.WebhookStatusEvent on pause/resume transitions.
+		// SubscribePause is a CacheImpl-level signal (stream health), not a Store mutation.
+		unsubs = append(unsubs, cacheImpl.SubscribePause(func(paused bool) {
+			state := "healthy"
+			if paused {
+				state = "unhealthy"
+			}
+			e.emitStructural(tui.WebhookStatusEvent{State: state})
+		}))
+	}
+
+	return func() {
+		for _, unsub := range unsubs {
+			unsub()
+		}
+	}
 }
 
 // PollOnce runs exactly one poll cycle and reports only whether it errored —

--- a/engine/worker_liveness.go
+++ b/engine/worker_liveness.go
@@ -167,6 +167,37 @@ func (e *Engine) forEachStaleUnworkedItem(label string, fn func(snap itemstate.S
 	}
 }
 
+// RunStartupCleanup runs the five one-shot startup recovery scans Run() has
+// always run, in order, immediately after the first successful poll cycle:
+// runStartupCleanup (stale fabrik:locked:<user>/fabrik:editing labels),
+// runStartupOrphanedInProgressScan, runStartupBareInProgressScan (both
+// engine/worker_liveness.go), runStartupTransientLabelScan
+// (engine/startup.go), and runStartupTerminalScan (engine/terminal.go).
+// Run() itself now calls this method instead of the five separate calls —
+// same functions, same order, same behavior.
+//
+// This is a test seam (ADR-1592, mirroring PollOnce/ADR-1449 and
+// PollWithBackoff/RegisterObservers above): all five scans are unexported
+// and called only from Run(), so gap 3 (#1592) — stale-worker-label reaping
+// N polls after the owning worker dies — is otherwise 100% unreachable from
+// tests/sim, the same shape of gap the other two seams close for their own
+// target code. A scenario calls this once after RestartEnv rebuilds the
+// Engine, mirroring where Run() calls it in production: immediately after
+// the store is first populated.
+//
+// Deliberately excludes the periodic runWorktreeJanitor/runLogJanitor/
+// runSessionJanitor calls Run() makes alongside these scans (gated
+// separately on cfg.JanitorIntervalHours > 0) — those are a distinct,
+// ongoing concern, not part of the one-shot startup recovery pass this
+// method names.
+func (e *Engine) RunStartupCleanup() {
+	e.runStartupCleanup()
+	e.runStartupOrphanedInProgressScan()
+	e.runStartupBareInProgressScan()
+	e.runStartupTransientLabelScan()
+	e.runStartupTerminalScan()
+}
+
 // runStartupCleanup scans the store for items that have a fabrik:locked:<user>
 // label but no active Worker (Worker == nil). This catches the restart case where
 // a prior Fabrik instance crashed, leaving stale lock labels behind.

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -567,6 +567,21 @@ before committing to a full live e2e run" entry point and what
 `scripts/e2e/run.sh`'s pre-gate calls — see
 `adrs/1454-sim-pre-gate-not-replacement.md` for the full layering decision.
 
+**Updated for #1592's sequence-shaped scenarios** (8 new test functions across 4 new
+files — gap 1's two dependency-unblock scenarios, gap 2's two backoff scenarios, gap
+3's stale-worker-reap scenario, gap 4's three reinvoke-cycle-counter scenarios): all
+eight, run standalone via `-run`, measure at **~5–6s** — none of them do real git work
+beyond a single `EnsureWorktree` per scenario (`preCreateWorktree`,
+`reinvokeCycleCountersEnv`), and none loop more than a handful of polls. `go test -race
+-count=1 -skip TestMergeTrainAssembly_PoisonMatrix ./tests/sim/...` (this package +
+`simgh` + `simclaude` + `simgh/ghfault`, run concurrently) measured **~80s for this
+package, ~100s for `simgh`** — both within the ranges #1454's own entry directly above
+already established as the package's current baseline, so #1592 does not move the "no
+`sim` build tag" needle further. (`TestMergeTrainAssembly_PoisonMatrix` itself is
+excluded from that figure as a pre-existing flake unrelated to this issue — confirmed
+independently reproducible on an unmodified `main` checkout, tracked separately from
+#1592's own scope.)
+
 ## Settle-scan inventory and recovery-machinery coverage (#1451)
 
 #1451 added the sim layer's first coverage of the engine's recovery

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -133,9 +133,9 @@ re-run needed.
 [`tests/e2e/harness.go`](../e2e/harness.go)'s vocabulary — see the mapping
 table below for where they diverge.
 
-### Two production seams, both additive
+### Production seams, all additive
 
-Neither changes any existing call site's behavior; both are documented test
+None changes any existing call site's behavior; all are documented test
 seams, not new capabilities:
 
 - **`Engine.PollOnce(ctx) error`** (`engine/poll.go`) — a thin delegation to
@@ -155,6 +155,42 @@ seams, not new capabilities:
   type aliases to the moved types, so every existing construction site and
   every existing `errors.As` assertion in `engine`'s own tests keeps
   compiling and behaving unchanged.
+- **`Engine.RegisterObservers() (unregister func())`** (`engine/poll.go`,
+  #1592/ADR-1592) — moves the reactive `itemstate.Store` observer
+  registration block (`mayNeedWorkObserver`, `InvocationObserver`,
+  `StageChangeObserver`, `PushUnblockObserver`, `CommentBreakerObserver`,
+  the `cacheImpl`-gated `WebhookHealthObserver` subscription) out of `Run()`
+  into its own method — `PollOnce` alone never registered any of them,
+  which nothing in this package's coverage happened to depend on until
+  #1592's dependency-unblock scenario needed `PushUnblockObserver`
+  specifically. `NewEnv`/`RestartEnv` call it once, immediately after
+  constructing the `Engine`, mirroring where `Run()` calls it.
+- **`Engine.PollWithBackoff(ctx, configuredInterval) (PollBackoffResult, error)`**
+  (`engine/poll.go`, #1592/ADR-1592) — moves `Run()`'s `doPollCycle` closure
+  body (the REST/core rate-limit hard gate, `poll()` itself, idle-timer
+  bookkeeping, GraphQL rate-limit hysteresis, the resulting effective
+  next-poll interval) into its own method, returning only the computed
+  `NextInterval` a caller needs to reset its own ticker. `backoff.go`'s five
+  pure functions had no call site outside that closure, so `PollOnce` alone
+  never reached any of them. The five backoff-state locals the closure held
+  became `Engine` fields (`backoffPrevMultiplier` etc.), mirroring
+  `idleStart`'s own precedent, since the method must now be callable
+  repeatedly across successive polls from a test.
+- **`Engine.RunStartupCleanup()`** (`engine/worker_liveness.go`,
+  #1592/ADR-1592) — delegates, in order, to the five one-shot startup
+  recovery scans `Run()` has always run once, immediately after its first
+  successful poll cycle (`runStartupCleanup` and four siblings) — all
+  unexported and `Run()`-only, so `PollOnce` alone never reached them
+  either. A scenario calls this once after `RestartEnv` rebuilds the
+  `Engine`, mirroring where `Run()` calls it in production.
+
+See `adrs/1592-sim-bed-backoff-and-startup-cleanup-seams.md` for the full
+rationale on the three newest seams, including the one behavior widening
+that rode along with `PollWithBackoff`'s extraction (the REST hard gate now
+compares against `e.now()` instead of `time.Now()` — byte-identical in
+production, since `e.now()` falls back to `time.Now()` when no `Clock` is
+injected, and necessary for the gate to be observable at all from a
+`tests/sim` scenario's injected `Clock`).
 
 Plus one **engine-local clock seam** (`Engine.Clock`/`SetClock`/`now()`,
 `engine/clock.go`), structurally identical to `simgh.Clock` so a scenario can
@@ -668,6 +704,180 @@ cover every gap the sim has — `simgh/FIDELITY.md`'s "Absent"-labeled entries a
 accepted blind spots, not violations of this rule — it covers the specific, high-signal
 case where live e2e actually caught something in production use that the pre-gate should
 have caught first.
+
+## Sequence-shaped coverage (#1592)
+
+#1451 covered settle-scan retry-and-escalation, restart recovery, and
+adversarial invoker shapes. #1592 covers a different class the sim exists
+for just as much: behavior that only manifests **across multiple polls or
+across two interacting items**, where reading a terminal label — the
+convention every earlier scenario in this package otherwise follows —
+cannot distinguish the correct sequence from a wrong one that happens to
+land in the same final state. `TestNoWorkNeeded_AwaitingDoneIsFirstMutation`
+(pre-dating #1592) is the canonical example this issue generalizes from: the
+unit suite executes the same line and cannot say it came first.
+
+The set below is defined by property, not enumeration, matching R1's own
+framing and the settle-scan table above's convention: a mechanism belongs
+here if the assertion that actually distinguishes correct from incorrect
+behavior is an ordering or sequence claim, not a state claim. Four
+mechanisms qualified when #1592 was filed — if a fifth is ever added
+without a row here, that is the gap this table exists to make visible
+instead of leaving it latent in prose.
+
+| mechanism | covering scenario | seam needed |
+|---|---|---|
+| Dependency blocking/unblocking (`PushUnblockObserver`, `engine/observers.go`) | `dependency_unblock_test.go`: `TestDependencyUnblock_OnBlockerClose`, `TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver` | `Engine.RegisterObservers` |
+| GraphQL rate-limit backoff / REST hard gate (`engine/backoff.go`) | `backoff_test.go`: `TestBackoff_GraphQLRateLimitIntervalEscalatesAndRecovers`, `TestBackoff_RESTHardGateSkipsPollUntilReset` | `Engine.PollWithBackoff` |
+| Stale-worker-label reaping (`forEachStaleUnworkedItem`, `engine/worker_liveness.go`) | `stale_worker_reap_test.go`: `TestStaleWorkerReap_OrphanedLockAndEditingLabels` | `Engine.RunStartupCleanup` + `RestartEnv` |
+| Review/no-op reinvoke-cycle counters and their interaction (`ReviewCycleDecremented`/#1045/ADR-1518, `NoOpCommentCycles`/#1555) | `reinvoke_cycle_counters_test.go`: `TestReviewCycleDecremented_NoCommitRefundsIndefinitely`, `TestNoOpCommentCycles_TripsBreakerAndResetsOnProgress`, `TestReviewCycleVsNoOpCommentCycle_Invariant` | none — reached through the existing `PollOnce`/catch-up-handler-chain path |
+
+### Gap 1 — dependency blocking and unblocking
+
+`PushUnblockObserver` fires on two distinct, asymmetric paths (R2): Path 1
+(a blocker's own `StateChanged`, scanning the store for dependents) and
+Path 2 (`BlockedByChanged` on the dependent's own snapshot, which
+deliberately declines to act when the new `BlockedBy` list is empty —
+ADR-1419's protection against a stale-empty cache falsely unblocking an
+issue). `TestDependencyUnblock_OnBlockerClose` drives the close-and-unblock
+sequence; `TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver`
+proves the empty-list guard holds and that recovery instead falls to the
+`dep-blocked` cooldown-gated pull path in `checkDependencies` — the
+behaviour #1453's chain work hit in practice.
+
+`dependency_unblock_test.go`'s own doc comment records a `tests/sim`-only
+wrinkle surfaced while writing the close-and-unblock scenario: without
+`boardcache.CacheImpl` (which `tests/sim` deliberately never wires in — see
+`NewWithDeps`'s own doc comment), the store's per-item `IsClosed` field is
+kept fresh only for items individually admitted for a deep-fetch, not for
+every board item the way production's `runProbeAndDeepFetch` keeps it. A
+blocker parked on an `Unmanaged` column that later closes can end up with a
+store entry that durably reads `IsClosed()==false` despite genuinely being
+closed — no production consequence (this exact race cannot occur once
+`CacheImpl` is in the loop), but reachable in this harness. The scenario
+routes around it by filing the blocker as a plain repo issue never added to
+any project board — never touched by any settle scan, and its real
+open/closed state is always available via the dependency edge's own
+`State` field regardless.
+
+### Gap 2 — GraphQL rate-limit backoff and the REST hard gate
+
+Driven entirely through `Engine.PollWithBackoff` (ADR-1592) — the control
+surface question (R3) resolved to `SeedRateLimits`
+(`tests/sim/simgh/seed.go`, #1457) over fault injection: `RateLimitStats` is
+documented in `simgh/FIDELITY.md` as the one interface method fault
+injection cannot fail, and `backoff.go` consumes budget *ratios*, not a
+failing call. `TestBackoff_GraphQLRateLimitIntervalEscalatesAndRecovers`
+drives the full escalation ladder (`>=10%`: 2x, `>=5%`: 4x, `>=1%`: 6x,
+`<1%`: 10x configured interval) plus the two-threshold hysteresis sticky
+zone (activates below 20%, clears only above 50%) across successive
+`PollWithBackoff` calls. `TestBackoff_RESTHardGateSkipsPollUntilReset`
+proves the hard gate skips `poll()` entirely — no `FetchProjectBoard` call
+at all — while the REST budget is exhausted, and that a fresh
+`SeedRateLimits` call (modelling GitHub's own hourly rollover) resumes it;
+simgh's `RateLimitStats` always reports `Reset` relative to the current
+injected clock instant, not a fixed timestamp a scenario could wait out.
+
+### Gap 3 — stale-worker-label reaping
+
+`forEachStaleUnworkedItem` reaps an orphaned `fabrik:locked:<user>` or
+`fabrik:editing` label left behind when a worker dies mid-dispatch.
+`TestStaleWorkerReap_OrphanedLockAndEditingLabels` reuses `RestartEnv`
+(#1451) for the genuine process-state boundary the scenario needs — the
+label is seeded directly on the pre-restart `Env` (no attempt to kill a
+real dispatched goroutine mid-flight, which would be inherently racy to
+land deterministically and isn't what `forEachStaleUnworkedItem`'s own
+precondition, `Worker() == nil` plus the label present, cares about) —
+then `Engine.RunStartupCleanup` (ADR-1592) reaps it on the restarted
+engine's first poll. Both seeded issues also carry `stage:<Name>:complete`
+from the start, isolating `RunStartupCleanup` as the only mechanism in the
+sequence that could touch either label.
+
+Deliberately scoped to the startup-cleanup shape only, not the periodic
+`runWorkerDetectorScan` sweep: that scan is real-wall-clock-bound end to
+end (`time.Since`, not the injected `Clock`) on both its heartbeat-staleness
+and its PID-unset fallback checks, and every `tests/sim`-dispatched worker
+has `PID == 0` (`simclaude` never calls `onPIDReady`), routing it
+exclusively into the also-wall-clock-bound `StartedAt` branch — reachable
+only via a genuine sleep, a narrower and more fragile addition for no real
+gain over the startup-cleanup path this issue already needed.
+
+### Gap 4 — the two reinvoke-cycle counters, and the invariant between them
+
+Two distinct, previously-uncovered mechanisms observing the same
+`processComments` funnel, plus the interaction between them (R6) — this
+issue's largest single piece, requiring no new engine seam (both
+mechanisms are reached through the ordinary `PollOnce`/catch-up-handler-
+chain path every earlier scenario in this package already exercises).
+
+- **4a — `ReviewCycleDecremented`** (#1045, ADR-1518,
+  `dispatchReviewReinvoke`'s `after` hook, `engine/reviews.go`): a
+  review-reinvoke that lands no new commit refunds its own prior
+  `ReviewCycleIncremented` — the forgive-forever guarantee that keeps a
+  chatty bot reviewer's non-actionable `COMMENTED` overviews from ever
+  accumulating toward `MaxReviewCycles`.
+  `TestReviewCycleDecremented_NoCommitRefundsIndefinitely` drives 3 rounds
+  at `MaxReviewCycles=1` and proves none of them pause. The other
+  direction — a commit-landing reinvoke does *not* refund — is not
+  duplicated here: `TestReviewAuthorityCycleLimitPauses`
+  (`review_authority_test.go`, pre-dating #1592) already commits a real
+  marker file every round via `DefaultCommentScript`, and its own
+  exact-`maxCycles`-then-pause behavior is itself the structural proof.
+- **4b — `NoOpCommentCycles`** (`checkNoOpCommentCycle`, #1555,
+  `engine/comment_noop_breaker.go`): a separate, never-refunded counter
+  over the same funnel, resetting to zero (not merely decrementing) on any
+  genuine progress. `TestNoOpCommentCycles_TripsBreakerAndResetsOnProgress`
+  drives a `[NoOp, NoOp, Commit, NoOp, NoOp, NoOp]` script sequence and
+  proves the breaker trips exactly on round 6, not round 5 — the
+  round-5-not-yet-paused check is what pins reset-to-zero specifically,
+  since a decrement-instead-of-reset regression would trip one round
+  earlier while still eventually pausing.
+- **4c — the interaction, and this gap's primary deliverable (R6):** the
+  invariant that `NoOpCommentCycles`' default (10) is deliberately higher
+  than `ReviewCycles`' default (5) *because* one refunds and the other
+  never does — stated only in `effectiveMaxNoOpCommentCycles`'s doc comment
+  before #1592, with no terminal-state test able to notice a regression
+  that collapsed the two thresholds together (the issue would still pause,
+  just for the wrong reason and at the wrong count).
+  `TestReviewCycleVsNoOpCommentCycle_Invariant` drives one sustained
+  no-op-reinvoke sequence through both halves: past `MaxReviewCycles=3`
+  without pausing (4a's refund holding), then pausing exactly at
+  `MaxNoOpCommentCycles=6` via the no-op breaker specifically — naming
+  which limit tripped via each pause comment's own literal prefix, not
+  merely that a pause occurred.
+
+Two fidelity notes surfaced while building gap 4, recorded in
+`reinvoke_cycle_counters_test.go`'s own doc comments: `simgh`'s
+`FetchPRReviews` collapses same-author `COMMENTED` follow-ups
+(`latestReviewsByAuthor`, modelling GitHub's own per-author reduction), so
+each round's seeded review needs a distinct author, not merely a distinct
+`DatabaseID`, or every round after the first is invisible to the engine;
+and `dispatchReviewReinvoke`'s `build()` hook captures `headBefore` via
+`gitHeadSHA` *before* `processComments` itself calls `EnsureWorktree` (see
+`dispatchReinvoke`, `engine/reinvoke.go`), so a zero-Claude-cost
+`seedReviewGateItem` construction needs its worktree pre-created
+(`preCreateWorktree`) or round 1's own refund is silently skipped — a
+confound specific to never having dispatched a real stage for the issue
+first, not a defect in the refund mechanism itself.
+
+### Fixture additions
+
+- **`Sim.SeedRemoveBlockedBy`** (`tests/sim/simgh/seed.go`) — removes one
+  `blockedBy` edge, modelling a human deleting the dependency link directly
+  (GitHub UI, or the REST dependencies API). No `GitHubClient` interface
+  counterpart: production only ever *adds* an edge (`AddBlockedByIssue`, at
+  spawn time), never removes one. Deliberately does not bump the
+  dependent's `updatedAt` — mirroring #977's real-API gap, and exactly the
+  staleness gap 1's companion scenario needs to exercise the empty-list
+  guard rather than the ordinary probe-driven refresh. See
+  `simgh/FIDELITY.md`'s own entry for the full rationale.
+- **`simclaude.NoOpCommentReview() CommentScript`** — touches nothing in
+  `workDir` and signals no progress (`completed=false`, no commit, no
+  `FABRIK_ISSUE_UPDATE` body) — the exact shape `processComments`'s own
+  `progressed` check treats as a no-op cycle, which both 4a and 4b's
+  mechanisms key off. Named distinctly from `DefaultCommentScript`/
+  `CommentReviewCompleted` (both of which commit), mirroring
+  `simclaude/scripts.go`'s existing naming convention.
 
 ## Running it
 

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -163,8 +163,21 @@ seams, not new capabilities:
   into its own method — `PollOnce` alone never registered any of them,
   which nothing in this package's coverage happened to depend on until
   #1592's dependency-unblock scenario needed `PushUnblockObserver`
-  specifically. `NewEnv`/`RestartEnv` call it once, immediately after
-  constructing the `Engine`, mirroring where `Run()` calls it.
+  specifically. **`NewEnv`/`RestartEnv` deliberately do NOT call it by
+  default** — see `NewEnv`'s own doc comment: registering it unconditionally
+  changes dispatch *timing* for every scenario in this package, since
+  `mayNeedWorkObserver`'s cycleSet is a fast-path that bypasses
+  `itemMayNeedWork`'s cooldown-based admission gate, and wiring it in
+  broke several pre-existing, unrelated scenarios whose own timing
+  assumptions predate this observer being reachable from `tests/sim` at
+  all. A scenario that needs it — currently `dependency_unblock_test.go`
+  (gap 1, for `PushUnblockObserver` itself) and
+  `reinvoke_cycle_counters_test.go` (gap 4, for a different reason: see
+  that file's own doc comment on `reinvokeCycleCountersEnv` — advisory-mode
+  multi-round reinvokes have no other cooldown path back to re-admission
+  once `dispatchWithCycleLimit`'s `advancedItems` marking suppresses the
+  periodic-re-eval stamp) — calls `env.Engine.RegisterObservers()` itself,
+  scoping the timing change to exactly the scenarios that require it.
 - **`Engine.PollWithBackoff(ctx, configuredInterval) (PollBackoffResult, error)`**
   (`engine/poll.go`, #1592/ADR-1592) — moves `Run()`'s `doPollCycle` closure
   body (the REST/core rate-limit hard gate, `poll()` itself, idle-timer
@@ -730,7 +743,7 @@ instead of leaving it latent in prose.
 | Dependency blocking/unblocking (`PushUnblockObserver`, `engine/observers.go`) | `dependency_unblock_test.go`: `TestDependencyUnblock_OnBlockerClose`, `TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver` | `Engine.RegisterObservers` |
 | GraphQL rate-limit backoff / REST hard gate (`engine/backoff.go`) | `backoff_test.go`: `TestBackoff_GraphQLRateLimitIntervalEscalatesAndRecovers`, `TestBackoff_RESTHardGateSkipsPollUntilReset` | `Engine.PollWithBackoff` |
 | Stale-worker-label reaping (`forEachStaleUnworkedItem`, `engine/worker_liveness.go`) | `stale_worker_reap_test.go`: `TestStaleWorkerReap_OrphanedLockAndEditingLabels` | `Engine.RunStartupCleanup` + `RestartEnv` |
-| Review/no-op reinvoke-cycle counters and their interaction (`ReviewCycleDecremented`/#1045/ADR-1518, `NoOpCommentCycles`/#1555) | `reinvoke_cycle_counters_test.go`: `TestReviewCycleDecremented_NoCommitRefundsIndefinitely`, `TestNoOpCommentCycles_TripsBreakerAndResetsOnProgress`, `TestReviewCycleVsNoOpCommentCycle_Invariant` | none — reached through the existing `PollOnce`/catch-up-handler-chain path |
+| Review/no-op reinvoke-cycle counters and their interaction (`ReviewCycleDecremented`/#1045/ADR-1518, `NoOpCommentCycles`/#1555) | `reinvoke_cycle_counters_test.go`: `TestReviewCycleDecremented_NoCommitRefundsIndefinitely`, `TestNoOpCommentCycles_TripsBreakerAndResetsOnProgress`, `TestReviewCycleVsNoOpCommentCycle_Invariant` | no new engine seam, but reuses `Engine.RegisterObservers` — see that file's own doc comment |
 
 ### Gap 1 — dependency blocking and unblocking
 
@@ -808,7 +821,11 @@ Two distinct, previously-uncovered mechanisms observing the same
 `processComments` funnel, plus the interaction between them (R6) — this
 issue's largest single piece, requiring no new engine seam (both
 mechanisms are reached through the ordinary `PollOnce`/catch-up-handler-
-chain path every earlier scenario in this package already exercises).
+chain path every earlier scenario in this package already exercises). It
+does reuse `Engine.RegisterObservers` (ADR-1592), for a reason discovered
+only once the scenario was actually driven for more than one round: see
+`reinvoke_cycle_counters_test.go`'s own doc comment on
+`reinvokeCycleCountersEnv`.
 
 - **4a — `ReviewCycleDecremented`** (#1045, ADR-1518,
   `dispatchReviewReinvoke`'s `after` hook, `engine/reviews.go`): a

--- a/tests/sim/backoff_test.go
+++ b/tests/sim/backoff_test.go
@@ -1,0 +1,189 @@
+package sim
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/handarbeit/fabrik/engine"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// Gap 2 (#1592): GraphQL rate-limit backoff and the REST hard gate
+// (engine/backoff.go) across successive polls. Both are driven exclusively
+// through Engine.PollWithBackoff (ADR-1592) — the seam this issue adds,
+// mirroring RegisterObservers above and PollOnce/ADR-1449: backoff.go's five
+// pure functions have no call site outside Run()'s own closure, so without
+// this seam gap 2 is 100% unreachable from tests/sim regardless of what a
+// scenario would want to assert.
+//
+// Control surface (R3, confirmed during Research against backoff.go's
+// actual call sites): SeedRateLimits/tests/sim/simgh's static rate-limit
+// budgets, not fault injection — RateLimitStats is documented in
+// simgh/FIDELITY.md as the one interface method fault injection cannot
+// fail, and backoff.go consumes budget *ratios*, not a failing call.
+
+// backoffStages is deliberately a single, never-dispatched stage: both
+// scenarios below never file an issue at all (an empty board), since
+// PollWithBackoff's rate-limit bookkeeping is entirely independent of board
+// content — only NewEnv's own Stages requirement needs satisfying.
+func backoffStages() []*stages.Stage {
+	return []*stages.Stage{
+		{Name: "Specify", Order: 1},
+	}
+}
+
+// runPollWithBackoff drives exactly one Engine.PollWithBackoff call — the
+// gap-2 analogue of poll.go's own RunPoll, which drives PollOnce instead.
+// Advances env.Clock by env.PollInterval first, mirroring RunPoll's own
+// reasoning (CooldownAt-based gates must not see a frozen clock), then waits
+// for worker quiescence exactly as RunPoll does — no scenario in this file
+// dispatches a worker, but a future one reusing this helper safely might.
+func runPollWithBackoff(t *testing.T, env *Env, configuredInterval time.Duration) engine.PollBackoffResult {
+	t.Helper()
+	if env.PollInterval > 0 {
+		env.Clock.Advance(env.PollInterval)
+	}
+	result, err := env.Engine.PollWithBackoff(context.Background(), configuredInterval)
+	if err != nil {
+		t.Fatalf("PollWithBackoff: %v", err)
+	}
+	if env.Engine.HasInFlightWorker() {
+		waitForWorkerQuiescence(t, env)
+	} else {
+		time.Sleep(workerYield)
+	}
+	return result
+}
+
+// TestBackoff_GraphQLRateLimitIntervalEscalatesAndRecovers is AC3's primary
+// scenario: seeded GraphQL rate-limit ratios, read fresh on each
+// PollWithBackoff call via SeedRateLimits, drive computeEffectiveInterval's
+// full escalation schedule (>=10%: 2x, >=5%: 4x, >=1%: 6x, <1%: 10x) across
+// successive polls, then the two-threshold hysteresis (nextRateLimitLow:
+// activate <20%, clear only >50% — the sticky zone in between holds the
+// backoff active) on the way back down.
+//
+// Non-vacuity (R5): the sticky-zone poll (30% remaining, asserted at exactly
+// 2x rather than 1x) is the discriminating step — an implementation that
+// dropped the hysteresis (cleared backoff the instant ratio rose above the
+// 20% activation threshold, rather than requiring 50%) would compute 1x
+// there instead of 2x, and every other step in this sequence would still
+// pass. Confirmed by temporarily neutralizing nextRateLimitLow's hysteresis
+// (forcing it to clear whenever ratio >= rateLimitBackoffThreshold instead
+// of requiring rateLimitHealthyThreshold) and observing this assertion fail
+// while the rest of the sequence kept passing.
+func TestBackoff_GraphQLRateLimitIntervalEscalatesAndRecovers(t *testing.T) {
+	t.Parallel()
+	env := NewEnv(t, EnvOptions{Stages: backoffStages()})
+	configuredInterval := env.PollInterval
+
+	// Baseline: full budget, no backoff.
+	env.Sim.Sim().SeedRateLimits(5000, 5000, 5000, 5000)
+	if r := runPollWithBackoff(t, env, configuredInterval); r.NextInterval != configuredInterval {
+		t.Fatalf("baseline: NextInterval = %v, want configuredInterval %v", r.NextInterval, configuredInterval)
+	}
+
+	// Activate: 18% remaining (< 20% threshold), falls in the >=10% bracket (2x).
+	env.Sim.Sim().SeedRateLimits(5000, 5000, 5000, 900)
+	if r := runPollWithBackoff(t, env, configuredInterval); r.NextInterval != 2*configuredInterval {
+		t.Fatalf("18%% remaining: NextInterval = %v, want 2x configuredInterval (%v)", r.NextInterval, 2*configuredInterval)
+	}
+
+	// 8% remaining: >=5% and <10% bracket (4x).
+	env.Sim.Sim().SeedRateLimits(5000, 5000, 5000, 400)
+	if r := runPollWithBackoff(t, env, configuredInterval); r.NextInterval != 4*configuredInterval {
+		t.Fatalf("8%% remaining: NextInterval = %v, want 4x configuredInterval (%v)", r.NextInterval, 4*configuredInterval)
+	}
+
+	// 4% remaining: >=1% and <5% bracket (6x).
+	env.Sim.Sim().SeedRateLimits(5000, 5000, 5000, 200)
+	if r := runPollWithBackoff(t, env, configuredInterval); r.NextInterval != 6*configuredInterval {
+		t.Fatalf("4%% remaining: NextInterval = %v, want 6x configuredInterval (%v)", r.NextInterval, 6*configuredInterval)
+	}
+
+	// 0.8% remaining: <1% bracket, the max multiplier (10x).
+	env.Sim.Sim().SeedRateLimits(5000, 5000, 5000, 40)
+	if r := runPollWithBackoff(t, env, configuredInterval); r.NextInterval != 10*configuredInterval {
+		t.Fatalf("0.8%% remaining: NextInterval = %v, want 10x configuredInterval (%v)", r.NextInterval, 10*configuredInterval)
+	}
+
+	// 30% remaining: ABOVE the 20% activation threshold, but backoff is
+	// already active and 30% is still below the 50% healthy threshold — the
+	// hysteresis's sticky zone. Must stay active (2x, the >=10% bracket for
+	// the current 30% ratio), not clear to 1x. This is the discriminating
+	// assertion (see the doc comment above).
+	env.Sim.Sim().SeedRateLimits(5000, 5000, 5000, 1500)
+	if r := runPollWithBackoff(t, env, configuredInterval); r.NextInterval != 2*configuredInterval {
+		t.Fatalf("30%% remaining (sticky zone): NextInterval = %v, want 2x configuredInterval (%v) — hysteresis should still hold backoff active", r.NextInterval, 2*configuredInterval)
+	}
+
+	// 60% remaining: above the 50% healthy threshold — clears.
+	env.Sim.Sim().SeedRateLimits(5000, 5000, 5000, 3000)
+	if r := runPollWithBackoff(t, env, configuredInterval); r.NextInterval != configuredInterval {
+		t.Fatalf("60%% remaining: NextInterval = %v, want configuredInterval %v (fully recovered)", r.NextInterval, configuredInterval)
+	}
+}
+
+// TestBackoff_RESTHardGateSkipsPollUntilReset is AC3's second scenario:
+// when the REST/core budget is exhausted, PollWithBackoff must skip the
+// entire poll work phase (no FetchProjectBoard call at all) until the
+// budget is reported healthy again — modelling GitHub's hourly reset, since
+// simgh's RateLimitStats always reports Reset relative to the current
+// (injected) clock (see tests/sim/simgh/misc.go), not a fixed instant a
+// scenario could simply wait out.
+//
+// Non-vacuity (R5): the discriminating assertion is the FetchProjectBoard
+// call count staying flat across the paused poll and only increasing on the
+// resumed one — a broken hard gate that let poll() run anyway would still
+// leave NextInterval computable (masking a terminal-state-only check) but
+// would fail this call-count assertion. Confirmed by temporarily
+// neutralizing shouldPauseForRESTRateLimit (forcing it to always return
+// false) and observing the "paused poll makes no FetchProjectBoard call"
+// assertion fail.
+func TestBackoff_RESTHardGateSkipsPollUntilReset(t *testing.T) {
+	t.Parallel()
+	env := NewEnv(t, EnvOptions{Stages: backoffStages()})
+	configuredInterval := env.PollInterval
+
+	boardFetches := func() int {
+		return len(env.Sim.Log().ByMethod("FetchProjectBoard"))
+	}
+
+	// Establish a baseline poll so the board-fetch counter has a known
+	// starting point.
+	env.Sim.Sim().SeedRateLimits(5000, 5000, 5000, 5000)
+	runPollWithBackoff(t, env, configuredInterval)
+	before := boardFetches()
+	if before == 0 {
+		t.Fatal("baseline poll made no FetchProjectBoard call — seeding/assumption broken")
+	}
+
+	// REST budget exhausted (remaining at 0, well within the near-zero
+	// threshold) — the hard gate must skip poll() entirely this cycle.
+	env.Sim.Sim().SeedRateLimits(5000, 0, 5000, 5000)
+	r := runPollWithBackoff(t, env, configuredInterval)
+	if got := boardFetches(); got != before {
+		t.Fatalf("FetchProjectBoard call count changed (%d -> %d) while REST-paused — the hard gate should have skipped poll() entirely", before, got)
+	}
+	// NextInterval must point at (approximately) the REST reset, not the
+	// configured interval — SeedRateLimits fixes Reset one hour out from the
+	// simulated clock's current instant (see simgh's RateLimitStats).
+	if r.NextInterval < 55*time.Minute || r.NextInterval > time.Hour+time.Minute {
+		t.Fatalf("NextInterval = %v while REST-paused, want ~1h (time until Reset + rateLimitResetBuffer)", r.NextInterval)
+	}
+
+	// The budget "resets" (a fresh SeedRateLimits call, modelling GitHub's
+	// hourly rollover — see this test's own doc comment for why the
+	// scenario cannot simply wait out simgh's Reset timestamp). Work must
+	// resume: poll() runs again, and NextInterval returns to the configured
+	// baseline (GraphQL is healthy too, so no rate-limit backoff applies).
+	env.Sim.Sim().SeedRateLimits(5000, 5000, 5000, 5000)
+	r = runPollWithBackoff(t, env, configuredInterval)
+	if got := boardFetches(); got <= before {
+		t.Fatalf("FetchProjectBoard call count did not increase (%d -> %d) after the REST budget reset — work should have resumed", before, got)
+	}
+	if r.NextInterval != configuredInterval {
+		t.Fatalf("NextInterval after REST reset = %v, want configuredInterval %v", r.NextInterval, configuredInterval)
+	}
+}

--- a/tests/sim/dependency_unblock_test.go
+++ b/tests/sim/dependency_unblock_test.go
@@ -1,0 +1,198 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/handarbeit/fabrik/stages"
+	"github.com/handarbeit/fabrik/tests/sim/simgh"
+)
+
+// Gap 1 (#1592): dependency blocking and unblocking (engine/observers.go,
+// engine/dependencies.go). Two issues interacting across polls — exactly
+// what this package exists to drive, and untouched by any existing scenario
+// before this file.
+//
+// PushUnblockObserver (engine/observers.go) fires on two distinct paths, and
+// this file's two tests pin the asymmetry between them (R2):
+//
+//   - Path 1 (StateChanged): a blocker closes; the observer scans the store
+//     for dependents listing it and removes fabrik:blocked once every
+//     blocker is resolved. TestDependencyUnblock_OnBlockerClose (AC1).
+//   - Path 2 (BlockedByChanged): the dependent's own BlockedBy is
+//     re-populated by a deep-fetch; the observer inspects only that item.
+//     It returns early when the new list is EMPTY (observers.go:299) —
+//     deliberate, per ADR-1419: a stale-empty cache must never be trusted
+//     as "no blockers" on its own. TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver
+//     (AC2) proves this guard holds, and that recovery instead falls to the
+//     "dep-blocked" cooldown-gated pull path in checkDependencies
+//     (engine/dependencies.go) — the behaviour #1453's chain work hit in
+//     practice.
+//
+// dependencyUnblockStages places the blocker on an Unmanaged column
+// (Backlog): a real board item the store does track (BootstrapFromProbe
+// seeds every board item, including Unmanaged ones — see
+// engine/terminal.go's runProbeAndDeepFetch, which keeps applying
+// ProbeBoardItemUpdated to an already-known Unmanaged item on every later
+// poll too), but one dispatch never touches, so the blocker's own pipeline
+// progress cannot interfere with either assertion below.
+func dependencyUnblockStages() []*stages.Stage {
+	return []*stages.Stage{
+		{Name: "Backlog", Order: 1, Unmanaged: true},
+		{Name: "Specify", Order: 2},
+		{Name: "Done", Order: 3, CleanupWorktree: true},
+	}
+}
+
+// TestDependencyUnblock_OnBlockerClose is gap 1's first direction (AC1,
+// R2's Path 1): a blocker issue closes, PushUnblockObserver removes
+// fabrik:blocked from the dependent, and the dependent proceeds — actually
+// dispatches to Specify, not merely loses the label.
+//
+// Non-vacuity (R5): hasLabel(..., "stage:Specify:complete") is checked
+// false immediately after the first poll (still blocked) and the
+// Precedes assertion below requires the label removal to genuinely precede
+// the dispatch, not merely both eventually being true — an implementation
+// that dispatched Specify regardless of fabrik:blocked (dropping the gate
+// entirely, engine/item.go:542) would still pass a terminal-state-only
+// check but fails Precedes here, and fails the "still blocked" check above
+// even sooner.
+func TestDependencyUnblock_OnBlockerClose(t *testing.T) {
+	t.Parallel()
+	env := NewEnv(t, EnvOptions{Stages: dependencyUnblockStages()})
+
+	blocker := FileIssue(t, env, "blocker",
+		"This issue must close before the dependent below is allowed to proceed.",
+		"Backlog")
+	dependent := FileIssue(t, env, "dependent",
+		"Blocked on the blocker issue; must not dispatch to Specify until it closes.",
+		"Specify", "fabrik:blocked")
+	env.Sim.Sim().SeedBlockedBy(env.OwnerRepo, dependent, env.OwnerRepo, blocker)
+	if err := env.Sim.Sim().Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	// First poll: checkDependencies's alreadyBlocked live re-read
+	// (engine/dependencies.go) finds the blocker still open — the label
+	// survives and Specify is never dispatched. Confirms the scenario
+	// actually starts blocked, not merely labelled so.
+	RunPoll(t, env)
+	if !hasLabel(IssueLabels(t, env, dependent), "fabrik:blocked") {
+		t.Fatal("dependent lost fabrik:blocked before the blocker even closed")
+	}
+	if hasLabel(IssueLabels(t, env, dependent), "stage:Specify:complete") {
+		t.Fatal("dependent's Specify stage completed while still blocked")
+	}
+
+	if err := env.Sim.CloseIssue(env.Owner, env.Repo, blocker); err != nil {
+		t.Fatalf("CloseIssue: %v", err)
+	}
+
+	// Path 1: the blocker's own StateChanged fires PushUnblockObserver,
+	// which scans the store for dependents and asynchronously removes
+	// fabrik:blocked (o.Remove runs in its own goroutine — see
+	// observers.go) once allBlockersClosed holds.
+	WaitForLabelAbsent(t, env, dependent, "fabrik:blocked", 10)
+
+	// "…and it proceeds": the dependent actually dispatches once unblocked.
+	WaitForIssueLabel(t, env, dependent, "stage:Specify:complete", 10)
+
+	// R1: a sequence-shaped claim — the unblock must genuinely precede the
+	// dispatch it enables, not merely both end up true. Only the mutation
+	// log (not a terminal-label read) can distinguish "unblocked, then
+	// dispatched" from "dispatched regardless, unblocked separately".
+	log := env.Sim.Log()
+	unblock := simgh.LabelRemoved(dependent, "fabrik:blocked")
+	dispatched := simgh.LabelAdded(dependent, "stage:Specify:complete")
+	if before, err := log.Precedes(unblock, dispatched); err != nil {
+		t.Fatalf("Precedes(fabrik:blocked removed, stage:Specify:complete added): %v", err)
+	} else if !before {
+		t.Error("fabrik:blocked must clear before Specify dispatches — the dependent proceeded before (or without) actually being unblocked")
+	}
+}
+
+// TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver is gap 1's
+// companion direction (AC2, R2's Path 2): removing the LAST blockedBy edge
+// by hand must NOT unblock via PushUnblockObserver's BlockedByChanged path
+// — the empty-list guard at observers.go:299 is a deliberate ADR-1419
+// protection against a stale-empty cache falsely unblocking an issue, and a
+// test asserting only TestDependencyUnblock_OnBlockerClose's direction
+// would pass against an implementation that dropped this guard entirely.
+//
+// The claim this test can actually make, traced against the real admission
+// gate (engine/item.go's itemMayNeedWork "dep-blocked" cooldown): while the
+// cooldown set by the item's first checkDependencies call is active, the
+// item is not even admitted to deep-fetch, so no BlockedByChanged event can
+// fire for it at all — the observer's guard and the admission gate are two
+// independent layers protecting the same invariant, and this test proves
+// the outer one (no premature re-check) holds across every poll in the
+// window, then proves recovery happens only once the window closes and
+// checkDependencies's own live re-read (the pull path, not the observer)
+// finds the list empty and removes the label directly. See engine/
+// dependencies.go's checkDependencies for the pull path and #1453 for where
+// exactly this survival-for-minutes-with-no-log-line behaviour was hit in
+// practice.
+//
+// Non-vacuity (R5): the assertion loop below fails immediately (before the
+// cooldown boundary) if the guard were dropped and Path 2 fired on any
+// intervening poll — the discriminating condition is "still blocked
+// throughout the cooldown window", not merely "eventually unblocked", which
+// a broken always-unblock-on-empty-list implementation would satisfy
+// trivially and too early.
+func TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver(t *testing.T) {
+	t.Parallel()
+	env := NewEnv(t, EnvOptions{Stages: dependencyUnblockStages()})
+
+	blocker := FileIssue(t, env, "blocker",
+		"Blocker issue — deliberately never closed in this scenario; the edge is removed by hand instead.",
+		"Backlog")
+	dependent := FileIssue(t, env, "dependent",
+		"Blocked on the blocker issue via a blockedBy edge that will be removed directly, not resolved by a close.",
+		"Specify", "fabrik:blocked")
+	env.Sim.Sim().SeedBlockedBy(env.OwnerRepo, dependent, env.OwnerRepo, blocker)
+	if err := env.Sim.Sim().Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	// First poll: alreadyBlocked live re-read confirms the blocker is still
+	// open and re-stamps the "dep-blocked" cooldown
+	// (CooldownAt, PollSeconds*10 — engine/item.go:547).
+	RunPoll(t, env)
+	if !hasLabel(IssueLabels(t, env, dependent), "fabrik:blocked") {
+		t.Fatal("dependent lost fabrik:blocked on the very first poll — seeding bug, this scenario needs it to start genuinely blocked")
+	}
+
+	// A human deletes the dependency link directly (SeedRemoveBlockedBy —
+	// no GitHubClient interface counterpart; production never removes an
+	// edge itself). Per #977 this does NOT bump the dependent's updatedAt,
+	// so the probe-driven cache refresh has nothing to notice.
+	env.Sim.Sim().SeedRemoveBlockedBy(env.OwnerRepo, dependent, env.OwnerRepo, blocker)
+	if err := env.Sim.Sim().Err(); err != nil {
+		t.Fatalf("SeedRemoveBlockedBy: %v", err)
+	}
+
+	// While the dep-blocked cooldown is active the item is not admitted to
+	// deep-fetch at all, so no BlockedByChanged can fire — confirm
+	// fabrik:blocked survives every poll in this window.
+	for i := 0; i < 3; i++ {
+		RunPoll(t, env)
+		if !hasLabel(IssueLabels(t, env, dependent), "fabrik:blocked") {
+			t.Fatalf("fabrik:blocked cleared during the dep-blocked cooldown window (poll %d) — either the empty-list guard was bypassed, or the cooldown admission gate no longer holds", i+1)
+		}
+	}
+
+	// Advance past the cooldown boundary (PollSeconds*10) plus a one-second
+	// margin so the next poll is admitted for exactly one live re-check.
+	env.Clock.Advance(10*env.PollInterval + time.Second)
+
+	// This is the pull path: checkDependencies's own live re-read
+	// (engine/dependencies.go) finds an empty blockedBy list and removes
+	// the label directly. The very same deep-fetch that feeds it also
+	// fires BlockedByChanged with an empty list — PushUnblockObserver's
+	// Path 2 sees that event too and, per its own guard, declines to act.
+	// Both routes converge on the same underlying RemoveLabelFromIssue
+	// call, so the mutation log cannot distinguish which one won; the
+	// timing window proven above is what pins the pull path as the actual
+	// mechanism.
+	WaitForLabelAbsent(t, env, dependent, "fabrik:blocked", 5)
+}

--- a/tests/sim/dependency_unblock_test.go
+++ b/tests/sim/dependency_unblock_test.go
@@ -108,7 +108,7 @@ func TestDependencyUnblock_OnBlockerClose(t *testing.T) {
 	env := NewEnv(t, EnvOptions{Stages: dependencyUnblockStages()})
 	// PushUnblockObserver is not registered by default — see NewEnv's own
 	// doc comment (ADR-1592). Both scenarios in this file specifically need it.
-	env.Engine.RegisterObservers()
+	t.Cleanup(env.Engine.RegisterObservers())
 
 	const blocker = 1000
 	env.Sim.Sim().SeedIssue(env.OwnerRepo, simgh.IssueSeed{
@@ -199,7 +199,7 @@ func TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver(t *testing.T) 
 	env := NewEnv(t, EnvOptions{Stages: dependencyUnblockStages()})
 	// PushUnblockObserver is not registered by default — see NewEnv's own
 	// doc comment (ADR-1592). Both scenarios in this file specifically need it.
-	env.Engine.RegisterObservers()
+	t.Cleanup(env.Engine.RegisterObservers())
 
 	blocker := FileIssue(t, env, "blocker",
 		"Blocker issue — deliberately never closed in this scenario; the edge is removed by hand instead.",

--- a/tests/sim/dependency_unblock_test.go
+++ b/tests/sim/dependency_unblock_test.go
@@ -106,6 +106,9 @@ func dependencyUnblockStages() []*stages.Stage {
 func TestDependencyUnblock_OnBlockerClose(t *testing.T) {
 	t.Parallel()
 	env := NewEnv(t, EnvOptions{Stages: dependencyUnblockStages()})
+	// PushUnblockObserver is not registered by default — see NewEnv's own
+	// doc comment (ADR-1592). Both scenarios in this file specifically need it.
+	env.Engine.RegisterObservers()
 
 	const blocker = 1000
 	env.Sim.Sim().SeedIssue(env.OwnerRepo, simgh.IssueSeed{
@@ -194,6 +197,9 @@ func TestDependencyUnblock_OnBlockerClose(t *testing.T) {
 func TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver(t *testing.T) {
 	t.Parallel()
 	env := NewEnv(t, EnvOptions{Stages: dependencyUnblockStages()})
+	// PushUnblockObserver is not registered by default — see NewEnv's own
+	// doc comment (ADR-1592). Both scenarios in this file specifically need it.
+	env.Engine.RegisterObservers()
 
 	blocker := FileIssue(t, env, "blocker",
 		"Blocker issue — deliberately never closed in this scenario; the edge is removed by hand instead.",

--- a/tests/sim/dependency_unblock_test.go
+++ b/tests/sim/dependency_unblock_test.go
@@ -18,24 +18,67 @@ import (
 //
 //   - Path 1 (StateChanged): a blocker closes; the observer scans the store
 //     for dependents listing it and removes fabrik:blocked once every
-//     blocker is resolved. TestDependencyUnblock_OnBlockerClose (AC1).
+//     blocker is resolved.
 //   - Path 2 (BlockedByChanged): the dependent's own BlockedBy is
 //     re-populated by a deep-fetch; the observer inspects only that item.
 //     It returns early when the new list is EMPTY (observers.go:299) —
 //     deliberate, per ADR-1419: a stale-empty cache must never be trusted
-//     as "no blockers" on its own. TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver
-//     (AC2) proves this guard holds, and that recovery instead falls to the
-//     "dep-blocked" cooldown-gated pull path in checkDependencies
-//     (engine/dependencies.go) — the behaviour #1453's chain work hit in
-//     practice.
+//     as "no blockers" on its own.
 //
-// dependencyUnblockStages places the blocker on an Unmanaged column
-// (Backlog): a real board item the store does track (BootstrapFromProbe
-// seeds every board item, including Unmanaged ones — see
-// engine/terminal.go's runProbeAndDeepFetch, which keeps applying
-// ProbeBoardItemUpdated to an already-known Unmanaged item on every later
-// poll too), but one dispatch never touches, so the blocker's own pipeline
-// progress cannot interfere with either assertion below.
+// TestDependencyUnblock_OnBlockerClose (AC1) drives the close-and-unblock
+// sequence. TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver
+// (AC2) proves the empty-list guard holds, and that recovery instead falls
+// to the "dep-blocked" cooldown-gated pull path in checkDependencies
+// (engine/dependencies.go) — the behaviour #1453's chain work hit in
+// practice.
+//
+// # Why AC1's blocker is never placed on the project board
+//
+// tests/sim's Engine is built via NewWithDeps, which wires the bare
+// GitHubAdapter as readClient (deliberately — see NewWithDeps's own doc
+// comment), never boardcache.CacheImpl. Production's per-poll store refresh
+// for EVERY board item, including ones outside normal dispatch admission
+// (runProbeAndDeepFetch, engine/terminal.go), is CacheImpl-only machinery
+// tests/sim never runs. Without it, e.store's per-item IsClosed field is
+// written ONLY by itemstate.ItemDeepFetched, and ONLY for items
+// itemMayNeedWork actually admits — which excludes a closed item outright
+// unless it is either at a cleanup stage (which itself skips
+// FetchItemDetails — see selectDeepFetchCandidates) or already carries
+// stage:<itsStage>:complete for a non-cleanup stage it hasn't yet advanced
+// away from. In practice a completed, yolo-advanced item leaves that window
+// within the very same dispatch goroutine that completed it (confirmed by
+// running the scenario both ways), so there is no poll at which a
+// board-resident blocker is simultaneously closed, admitted, and freshly
+// deep-fetched.
+//
+// Anything short of that leaves the blocker's store entry either absent
+// (harmless — checkDependencies and PushUnblockObserver.allBlockersClosed
+// both fall back to the dependency edge's own State field, which
+// resolveDependenciesLocked always resolves correctly straight from the
+// repo's issue record, independent of project-board membership — see
+// tests/sim/simgh/board.go) or, worse, MATERIALIZED WRONG: the very first
+// mutation any settle scan or cleanup dispatch applies to a
+// previously-untracked item (e.g. SelfWriteObserved from
+// settleClosedItemsToDone, or a plain LabelAdded from handleCleanupStage)
+// creates a zero-value store entry via Store.getOrCreate whose IsClosed
+// defaults to false — durably wrong, since nothing later corrects a field
+// neither mutation type touches. checkDependencies's Store-preferred check
+// then trusts that wrong entry over the correct dep.State fallback,
+// re-blocking the dependent on its very next dispatch attempt. This has no
+// production consequence — CacheImpl's probe refresh always keeps every
+// board item's IsClosed current before any settle scan runs, so the race
+// this harness exposes cannot occur there — but it is very much reachable
+// here, and was hit and traced while writing this scenario.
+//
+// The clean way to route around it, matching how a blocker frequently is
+// NOT itself a Fabrik-managed item in practice (an upstream issue, a
+// human-owned issue, an issue in an unmanaged repo): file the blocker as a
+// plain repo issue via Sim.SeedIssue with no Status, so it is never added
+// to any project board at all. It never enters e.store, is never touched by
+// any settle scan, and its true open/closed state is always available to
+// the dependent's own BlockedBy resolution regardless. See
+// TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver's own doc
+// comment for why its blocker does not need this treatment.
 func dependencyUnblockStages() []*stages.Stage {
 	return []*stages.Stage{
 		{Name: "Backlog", Order: 1, Unmanaged: true},
@@ -44,26 +87,32 @@ func dependencyUnblockStages() []*stages.Stage {
 	}
 }
 
-// TestDependencyUnblock_OnBlockerClose is gap 1's first direction (AC1,
-// R2's Path 1): a blocker issue closes, PushUnblockObserver removes
-// fabrik:blocked from the dependent, and the dependent proceeds — actually
-// dispatches to Specify, not merely loses the label.
+// TestDependencyUnblock_OnBlockerClose is gap 1's first direction (AC1): a
+// blocker issue closes, PushUnblockObserver clears fabrik:blocked from the
+// dependent, and the dependent proceeds — actually dispatches to Specify,
+// not merely loses the label.
+//
+// See dependencyUnblockStages's doc comment for why the blocker is filed as
+// a board-less repo issue rather than a project item.
 //
 // Non-vacuity (R5): hasLabel(..., "stage:Specify:complete") is checked
-// false immediately after the first poll (still blocked) and the
-// Precedes assertion below requires the label removal to genuinely precede
-// the dispatch, not merely both eventually being true — an implementation
-// that dispatched Specify regardless of fabrik:blocked (dropping the gate
-// entirely, engine/item.go:542) would still pass a terminal-state-only
-// check but fails Precedes here, and fails the "still blocked" check above
-// even sooner.
+// false on the dependent immediately after the first poll (still blocked),
+// and the Precedes assertion below requires the label removal to genuinely
+// precede the dependent's own dispatch, not merely both eventually being
+// true — an implementation that dispatched Specify regardless of
+// fabrik:blocked (dropping the gate entirely, engine/item.go:542) would
+// still pass a terminal-state-only check but fails Precedes here, and fails
+// the "still blocked" check above even sooner.
 func TestDependencyUnblock_OnBlockerClose(t *testing.T) {
 	t.Parallel()
 	env := NewEnv(t, EnvOptions{Stages: dependencyUnblockStages()})
 
-	blocker := FileIssue(t, env, "blocker",
-		"This issue must close before the dependent below is allowed to proceed.",
-		"Backlog")
+	const blocker = 1000
+	env.Sim.Sim().SeedIssue(env.OwnerRepo, simgh.IssueSeed{
+		Number: blocker,
+		Title:  "blocker",
+		Body:   "This issue must close before the dependent below is allowed to proceed. Deliberately not placed on any project board — see dependencyUnblockStages's doc comment.",
+	})
 	dependent := FileIssue(t, env, "dependent",
 		"Blocked on the blocker issue; must not dispatch to Specify until it closes.",
 		"Specify", "fabrik:blocked")
@@ -72,8 +121,8 @@ func TestDependencyUnblock_OnBlockerClose(t *testing.T) {
 		t.Fatalf("seeding: %v", err)
 	}
 
-	// First poll: checkDependencies's alreadyBlocked live re-read
-	// (engine/dependencies.go) finds the blocker still open — the label
+	// First poll: the dependent's alreadyBlocked live re-read
+	// (engine/dependencies.go) finds the blocker still open — its label
 	// survives and Specify is never dispatched. Confirms the scenario
 	// actually starts blocked, not merely labelled so.
 	RunPoll(t, env)
@@ -88,10 +137,8 @@ func TestDependencyUnblock_OnBlockerClose(t *testing.T) {
 		t.Fatalf("CloseIssue: %v", err)
 	}
 
-	// Path 1: the blocker's own StateChanged fires PushUnblockObserver,
-	// which scans the store for dependents and asynchronously removes
-	// fabrik:blocked (o.Remove runs in its own goroutine — see
-	// observers.go) once allBlockersClosed holds.
+	// PushUnblockObserver removes fabrik:blocked (o.Remove runs in its own
+	// goroutine — see observers.go) once allBlockersClosed holds.
 	WaitForLabelAbsent(t, env, dependent, "fabrik:blocked", 10)
 
 	// "…and it proceeds": the dependent actually dispatches once unblocked.
@@ -112,12 +159,17 @@ func TestDependencyUnblock_OnBlockerClose(t *testing.T) {
 }
 
 // TestDependencyUnblock_EmptyEdgeListDoesNotUnblockViaObserver is gap 1's
-// companion direction (AC2, R2's Path 2): removing the LAST blockedBy edge
-// by hand must NOT unblock via PushUnblockObserver's BlockedByChanged path
-// — the empty-list guard at observers.go:299 is a deliberate ADR-1419
-// protection against a stale-empty cache falsely unblocking an issue, and a
-// test asserting only TestDependencyUnblock_OnBlockerClose's direction
-// would pass against an implementation that dropped this guard entirely.
+// companion direction (AC2, R2): removing the LAST blockedBy edge by hand
+// must NOT unblock via PushUnblockObserver's BlockedByChanged path — the
+// empty-list guard at observers.go:299 is a deliberate ADR-1419 protection
+// against a stale-empty cache falsely unblocking an issue, and a test
+// asserting only TestDependencyUnblock_OnBlockerClose's direction would
+// pass against an implementation that dropped this guard entirely.
+//
+// Unlike the companion test above, this blocker is never closed, so
+// dependencyUnblockStages's board-less-blocker concern never applies here:
+// it stays on Unmanaged Backlog for the scenario's whole lifetime, purely
+// as a real board item SeedBlockedBy/SeedRemoveBlockedBy can reference.
 //
 // The claim this test can actually make, traced against the real admission
 // gate (engine/item.go's itemMayNeedWork "dep-blocked" cooldown): while the

--- a/tests/sim/env.go
+++ b/tests/sim/env.go
@@ -191,6 +191,25 @@ func stageColumns(stgs []*stages.Stage) []string {
 // — see ADR-1449), reproduces production's git topology by cloning simgh's
 // backing repo as a local "origin" (R6), and boots a real engine.Engine via
 // NewWithDeps with the shared Clock wired to both simgh and the engine.
+//
+// Deliberately does NOT call Engine.RegisterObservers (ADR-1592/#1592). It
+// is tempting to register it unconditionally here, mirroring where Run()
+// calls it in production — and an earlier revision of this function did
+// exactly that — but it changes dispatch *timing* for every scenario in
+// this package, not just the ones that need it: mayNeedWorkObserver
+// populates the cycleSet fast-path that bypasses itemMayNeedWork's
+// cooldown-based admission gate, so once active, previously-cooldown-paced
+// items are re-admitted for deep-fetch immediately on any relevant Store
+// change instead of waiting out the cooldown. Wiring it in here made four
+// pre-existing, unrelated scenarios fail — some by racing an item through
+// multiple stages before an intermediate WaitForProjectStatus checkpoint
+// could observe it, one by hanging the whole package past its 10-minute
+// timeout — none of which is a mayNeedWorkObserver defect; those scenarios'
+// own timing assumptions simply predate this observer ever being reachable
+// from tests/sim at all. A scenario that specifically needs a reactive
+// itemstate.Store observer (currently only PushUnblockObserver, gap 1 —
+// dependency_unblock_test.go) calls env.Engine.RegisterObservers() itself,
+// scoping the timing change to exactly the scenario that requires it.
 func NewEnv(t *testing.T, opts EnvOptions) *Env {
 	t.Helper()
 	skipIfNoGit(t)
@@ -303,11 +322,6 @@ func NewEnv(t *testing.T, opts EnvOptions) *Env {
 		eng = engine.NewWithDeps(cfg, inst, claude, wm)
 	}
 	eng.SetClock(clk)
-	// Mirrors what Run() does immediately after construction, in production —
-	// see Engine.RegisterObservers's own doc comment (ADR-1592). Without this,
-	// PushUnblockObserver (and every other reactive observer Run() registers)
-	// is unreachable from a scenario driven through PollOnce alone.
-	eng.RegisterObservers()
 
 	return &Env{
 		T:             t,

--- a/tests/sim/env.go
+++ b/tests/sim/env.go
@@ -303,6 +303,11 @@ func NewEnv(t *testing.T, opts EnvOptions) *Env {
 		eng = engine.NewWithDeps(cfg, inst, claude, wm)
 	}
 	eng.SetClock(clk)
+	// Mirrors what Run() does immediately after construction, in production —
+	// see Engine.RegisterObservers's own doc comment (ADR-1592). Without this,
+	// PushUnblockObserver (and every other reactive observer Run() registers)
+	// is unreachable from a scenario driven through PollOnce alone.
+	eng.RegisterObservers()
 
 	return &Env{
 		T:             t,

--- a/tests/sim/reinvoke_cycle_counters_test.go
+++ b/tests/sim/reinvoke_cycle_counters_test.go
@@ -1,0 +1,297 @@
+package sim
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/handarbeit/fabrik/engine"
+	"github.com/handarbeit/fabrik/tests/sim/simclaude"
+)
+
+// Gap 4 (#1592): the two reinvoke-cycle counters, and the invariant between
+// them — the largest single piece of this issue.
+//
+//   - 4a — ReviewCycleDecremented (#1045, ADR-1518): a review-reinvoke that
+//     lands no new commit refunds its own prior ReviewCycleIncremented.
+//     TestReviewCycleDecremented_NoCommitRefundsIndefinitely (AC5).
+//   - 4b — NoOpCommentCycles (engine/comment_noop_breaker.go, #1555): a
+//     separate, never-refunded counter over the same processComments
+//     funnel. TestNoOpCommentCycles_TripsBreakerAndResetsOnProgress (AC6).
+//   - 4c — the interaction, and this gap's primary deliverable: the
+//     invariant (maxNoOpCommentCycles > maxReviewCycles, "one refunds and
+//     the other does not") stated only in effectiveMaxNoOpCommentCycles's
+//     doc comment. TestReviewCycleVsNoOpCommentCycle_Invariant (AC7).
+//
+// All three use advisory review mode (no review-authority label): traced
+// through checkReviewGate, advisory clears blocked=false immediately on any
+// submitted review regardless of verdict — the "chatty bot reviewer" shape
+// #1045/ADR-1518 exists for — which keeps ReviewBlockedCycles (the
+// never-refunded ADR-1518 counterpart, folded into the same dispatch-and-
+// limit-check via max(ReviewCycles, ReviewBlockedCycles)) from climbing and
+// confounding the assertions below. Authoritative mode would leave
+// blocked=true on an unresolved verdict, defeating that isolation.
+//
+// 4a's other direction — a commit-landing reinvoke does NOT refund — is
+// already covered by TestReviewAuthorityCycleLimitPauses
+// (review_authority_test.go): its CHANGES_REQUESTED reinvokes run
+// DefaultCommentScript, which commits a real marker file every round, so
+// headBefore != headAfter and ReviewCycleDecremented never fires — that
+// test's exact-maxCycles-then-pause behavior is itself a structural proof
+// that increments are never refunded when a commit lands. Not duplicated
+// here.
+//
+// The exact round counts and script sequences below were derived by tracing
+// handleReviewGate/dispatchWithCycleLimit/checkNoOpCommentCycle's actual
+// order (Plan stage), not assumed.
+
+// reinvokeCycleCountersEnv builds the shared Env for all three scenarios:
+// reviewAuthorityStages() (review_authority_test.go) with a real,
+// wait_for_reviews-gated Review stage, StartTime near time.Now() (the
+// real-wall-clock-anchored checkAwaitingReviewTimeout gate needs this, same
+// reasoning as newReviewAuthorityEnv/ci_fix_reinvoke_test.go), and both
+// cycle limits configured explicitly — engine.Config has no built-in
+// fallback for either when NewEnv's Config literal bypasses cmd/root.go's
+// flag-resolution defaults.
+func reinvokeCycleCountersEnv(t *testing.T, maxReviewCycles, maxNoOpCommentCycles int) *Env {
+	t.Helper()
+	return NewEnv(t, EnvOptions{
+		Stages:    reviewAuthorityStages(),
+		StartTime: time.Now(),
+		ConfigureCfg: func(cfg *engine.Config) {
+			cfg.ReviewWaitTimeout = time.Hour // generous — never times out mid-test
+			cfg.MaxReviewCycles = maxReviewCycles
+			cfg.MaxNoOpCommentCycles = maxNoOpCommentCycles
+		},
+	})
+}
+
+// preCreateWorktree creates issueNum's worktree on disk (checking out the
+// fabrik/issue-<N> branch seedReviewGateItem already created on the model)
+// before any reinvoke round runs.
+//
+// This matters specifically for 4a: dispatchReviewReinvoke's build() hook
+// captures headBefore via gitHeadSHA(workDir) BEFORE processComments itself
+// calls EnsureWorktree — dispatchReinvoke only computes the worktree path
+// (wm.WorktreeDir), it does not create it. Without a worktree already on
+// disk, round 1's headBefore is "" (gitHeadSHA errors on a missing
+// directory), and dispatchReviewReinvoke's after hook requires headBefore
+// != "" before ever comparing SHAs — so round 1's own ReviewCycleIncremented
+// would never get refunded regardless of whether a commit landed, purely as
+// an artifact of seedReviewGateItem's zero-Claude-cost construction never
+// having touched a real worktree. Pre-creating it here removes that
+// confound so every round's refund behavior is judged on its own merits.
+func preCreateWorktree(t *testing.T, env *Env, issueNum int) {
+	t.Helper()
+	base, err := env.WM.DefaultBaseBranch()
+	if err != nil {
+		t.Fatalf("DefaultBaseBranch: %v", err)
+	}
+	if _, err := env.WM.EnsureWorktree(issueNum, base, false); err != nil {
+		t.Fatalf("EnsureWorktree: %v", err)
+	}
+}
+
+// driveReinvokeRound seeds a fresh actionable review — a unique DatabaseID
+// each round (buildReviewFeedbackCommentsFromReviews would otherwise dedup
+// an already-processed one, engine/reviews.go) AND a unique author each
+// round. The author must vary too: simgh's FetchPRReviews models GitHub's
+// own latest-review-per-author reduction, and a COMMENTED follow-up never
+// supersedes that same author's existing entry (tests/sim/simgh/reviews.go's
+// latestReviewsByAuthor) — reusing one author across rounds would make every
+// round after the first invisible to the engine, since the reduction
+// collapses them all down to round 1's review before checkReviewGate ever
+// sees them. Distinct authors also mirror the "chatty bot reviewer" shape
+// #1045/ADR-1518 exist for more directly than one author resubmitting would.
+//
+// Drives polls until the Review stage's comment-invocation count advances
+// past its pre-round value, proving a reinvoke was genuinely dispatched
+// this round rather than merely that time passed.
+func driveReinvokeRound(t *testing.T, env *Env, prNum, round int, maxPolls int) {
+	t.Helper()
+	before := env.Claude.CommentCallCount("Review")
+	seedActionableReview(t, env, prNum, fmt.Sprintf("chatty-review-bot-%d", round), "COMMENTED",
+		fmt.Sprintf("round %d: a non-actionable status overview.", round))
+	AdvanceUntil(t, env, func(env *Env) bool {
+		return env.Claude.CommentCallCount("Review") > before
+	}, maxPolls)
+}
+
+// TestReviewCycleDecremented_NoCommitRefundsIndefinitely is 4a (AC5): a
+// no-commit review-reinvoke refunds its own prior ReviewCycleIncremented
+// (#1045, ADR-1518), so a chatty bot reviewer's non-actionable overviews
+// never accumulate toward MaxReviewCycles.
+//
+// MaxReviewCycles=1 makes this the discriminating configuration: with the
+// refund working, every round's pre-dispatch cycleCount reads back 0 (the
+// prior round's increment having been refunded), so dispatchWithCycleLimit
+// (0 >= 1 is false) always takes the dispatch branch, never the pause
+// branch, however many rounds run. NoOpCommentReview (tests/sim/simclaude)
+// supplies the no-commit shape every round.
+//
+// Non-vacuity (R5): with the limit at 1, any implementation that
+// incremented ReviewCycles without ever refunding it would compute
+// cycleCount=1 on round 2 (1 >= 1) and pause — round 2's check is what an
+// unrefunded implementation would fail first. Confirmed by temporarily
+// neutralizing dispatchReviewReinvoke's after hook (removing the
+// ReviewCycleDecremented Apply call) and observing round 2 pause.
+func TestReviewCycleDecremented_NoCommitRefundsIndefinitely(t *testing.T) {
+	t.Parallel()
+	env := reinvokeCycleCountersEnv(t, 1, 20) // MaxNoOpCommentCycles kept well out of the way
+	env.Claude.ForStageComments("Review", simclaude.NoOpCommentReview())
+
+	issueNum, prNum := seedReviewGateItem(t, env, "Review", "4a")
+	preCreateWorktree(t, env, issueNum)
+
+	for round := 1; round <= 3; round++ {
+		driveReinvokeRound(t, env, prNum, round, 20)
+		if hasLabel(IssueLabels(t, env, issueNum), "fabrik:paused") {
+			t.Fatalf("round %d: issue paused despite MaxReviewCycles=1 — the no-commit refund (ReviewCycleDecremented) must be keeping the pre-dispatch cycle count at 0 every round", round)
+		}
+	}
+}
+
+// noOpCommentBreakerCommentPrefix is the literal prefix of
+// tripNoOpCommentCycleBreaker's own comment (engine/comment_noop_breaker.go)
+// — copied here the same way reviewCycleLimitCommentPrefix
+// (review_authority_test.go) copies pauseForReviewCycleLimit's, since the
+// engine's own const is unexported. Used to confirm which breaker actually
+// tripped, not merely that a pause occurred (AC6/AC7).
+const noOpCommentBreakerCommentPrefix = "🏭 **Fabrik — no-op comment-processing circuit breaker tripped**"
+
+// TestNoOpCommentCycles_TripsBreakerAndResetsOnProgress is 4b (AC6): a
+// sustained sequence of no-progress comment-processing cycles increments
+// NoOpCommentCycles and trips the breaker at effectiveMaxNoOpCommentCycles;
+// a progressing cycle resets the counter to zero rather than merely
+// decrementing it.
+//
+// MaxNoOpCommentCycles=3, MaxReviewCycles=20 (kept out of the way). Six
+// rounds, scripted [NoOp, NoOp, Commits, NoOp, NoOp, NoOp]: rounds 1-2
+// increment to 2; round 3 commits and resets to 0 (checkNoOpCommentCycle's
+// progressed branch); rounds 4-6 increment 1, 2, 3 — tripping exactly on
+// round 6.
+//
+// Non-vacuity (R5): round 5 (count would-be 2, not yet at the limit) is the
+// discriminating assertion. A regression that decremented on progress
+// instead of resetting to zero would have left the counter at 2 after round
+// 3's commit (3 no-ops, minus 1) rather than 0, reaching the limit of 3 on
+// round 5 instead of round 6 — this test's round-5-not-paused check catches
+// that even though round 6 alone (a bare "eventually pauses" check) would
+// not. Confirmed by temporarily changing checkNoOpCommentCycle's progressed
+// branch from NoOpCommentCycleReset to a decrement-by-one mutation and
+// observing round 5 pause instead of round 6.
+func TestNoOpCommentCycles_TripsBreakerAndResetsOnProgress(t *testing.T) {
+	t.Parallel()
+	env := reinvokeCycleCountersEnv(t, 20, 3)
+	env.Claude.ForStageComments("Review",
+		simclaude.NoOpCommentReview(),
+		simclaude.NoOpCommentReview(),
+		simclaude.CommentReviewCompleted(), // commits — resets the no-op counter
+		simclaude.NoOpCommentReview(),
+		simclaude.NoOpCommentReview(),
+		simclaude.NoOpCommentReview(),
+	)
+
+	issueNum, prNum := seedReviewGateItem(t, env, "Review", "4b")
+	preCreateWorktree(t, env, issueNum)
+
+	for round := 1; round <= 6; round++ {
+		driveReinvokeRound(t, env, prNum, round, 20)
+		paused := hasLabel(IssueLabels(t, env, issueNum), "fabrik:paused")
+		switch {
+		case round < 6 && paused:
+			t.Fatalf("round %d: issue paused prematurely — NoOpCommentCycles should not reach the limit of 3 until round 6 (rounds 1-2 increment, round 3 resets on commit, rounds 4-6 increment again)", round)
+		case round == 6 && !paused:
+			t.Fatal("round 6: issue not paused — expected the no-op comment-processing breaker to trip")
+		}
+	}
+
+	item := projectItem(t, env, issueNum)
+	if !hasCommentWithPrefix(item.Comments, noOpCommentBreakerCommentPrefix) {
+		t.Error("round 6: no-op comment-processing breaker comment not found")
+	}
+	if hasCommentWithPrefix(item.Comments, reviewCycleLimitCommentPrefix) {
+		t.Error("round 6: review-cycle-limit comment present — the wrong breaker tripped (MaxReviewCycles=20 should never be reached)")
+	}
+}
+
+// TestReviewCycleVsNoOpCommentCycle_Invariant is 4c (AC7) — gap 4's primary
+// deliverable: the interaction invariant between the two counters, stated
+// only in effectiveMaxNoOpCommentCycles's doc comment
+// (engine/comment_noop_breaker.go): NoOpCommentCycles' default (10) is
+// deliberately higher than ReviewCycles' default (5) specifically because
+// ReviewCycles is refunded to ~0 on every no-op reinvoke (4a) while
+// NoOpCommentCycles never refunds — collapsing the two thresholds to the
+// same value would silently nullify 4a's forgive-forever guarantee at
+// whatever count they shared, with no terminal-state test noticing (the
+// issue would still pause, just for the wrong reason and at the wrong
+// count — #1555 review discussion cites a healthy, mergeable PR that
+// accumulated 4 consecutive no-op cycles under ordinary duplicate-bot
+// delivery, one shy of tripping at the old MaxReviewCycles default of 5).
+//
+// MaxReviewCycles=3, MaxNoOpCommentCycles=6 — mirrors the real default
+// ratio (5:10) at a scale this test can drive quickly. A single sustained
+// no-op reinvoke sequence (NoOpCommentReview registered once — the
+// package's "last script repeats" rule covers every further round)
+// exercises both counters together each round, exactly as production does
+// (dispatchReviewReinvoke is built on dispatchReinvoke -> processComments,
+// so one review-reinvoke cycle increments ReviewCycles pre-dispatch and
+// NoOpCommentCycles inside processComments in the same pass).
+//
+// Assertions, both against the SAME six-round sequence:
+//   - after round 4 (> MaxReviewCycles=3): NOT paused, and no
+//     reviewCycleLimitCommentPrefix comment exists — 4a's refund is holding
+//     ReviewCycles at 0 every round, so the review-cycle limit is never
+//     reached despite 4 rounds exceeding its raw threshold.
+//   - after round 6 (== MaxNoOpCommentCycles=6): paused, with the no-op
+//     breaker's comment prefix present and the review-cycle-limit prefix
+//     absent — naming which limit tripped (AC7's own requirement), not
+//     merely that a pause occurred.
+//
+// Non-vacuity (R5): this is the assertion the doc comment's own warning is
+// about. Confirmed by temporarily setting effectiveMaxNoOpCommentCycles to
+// return e.cfg.MaxReviewCycles's value instead of its own (collapsing the
+// two thresholds to the same value, mirroring "someone tidying two
+// similar-looking cycle constants into one shared default") and observing
+// the no-op breaker trip on round 3 instead of round 6, with the round-4
+// "not yet paused" assertion failing as a direct consequence.
+func TestReviewCycleVsNoOpCommentCycle_Invariant(t *testing.T) {
+	t.Parallel()
+	env := reinvokeCycleCountersEnv(t, 3, 6)
+	env.Claude.ForStageComments("Review", simclaude.NoOpCommentReview())
+
+	issueNum, prNum := seedReviewGateItem(t, env, "Review", "4c")
+	preCreateWorktree(t, env, issueNum)
+
+	for round := 1; round <= 6; round++ {
+		driveReinvokeRound(t, env, prNum, round, 20)
+
+		switch round {
+		case 4:
+			// Past MaxReviewCycles (3), but 4a's refund keeps ReviewCycles
+			// at 0 every round — must NOT have paused via the review-cycle
+			// limit.
+			if hasLabel(IssueLabels(t, env, issueNum), "fabrik:paused") {
+				t.Fatal("round 4 (> MaxReviewCycles=3): issue paused — the review-cycle limit tripped despite every reinvoke being a no-commit no-op; 4a's forgive-forever refund is not holding")
+			}
+			item := projectItem(t, env, issueNum)
+			if hasCommentWithPrefix(item.Comments, reviewCycleLimitCommentPrefix) {
+				t.Fatal("round 4: a review-cycle-limit comment exists despite no pause — inconsistent state")
+			}
+		case 6:
+			// At MaxNoOpCommentCycles (6): the no-op breaker must trip,
+			// and it must be nameable as the no-op breaker specifically,
+			// not the review-cycle limit.
+			if !hasLabel(IssueLabels(t, env, issueNum), "fabrik:paused") {
+				t.Fatal("round 6 (== MaxNoOpCommentCycles=6): issue not paused — expected the no-op comment-processing breaker to trip")
+			}
+			item := projectItem(t, env, issueNum)
+			if !hasCommentWithPrefix(item.Comments, noOpCommentBreakerCommentPrefix) {
+				t.Error("round 6: no-op comment-processing breaker comment not found")
+			}
+			if hasCommentWithPrefix(item.Comments, reviewCycleLimitCommentPrefix) {
+				t.Error("round 6: review-cycle-limit comment also present — naming the wrong limit (or both) as having tripped")
+			}
+		}
+	}
+}

--- a/tests/sim/reinvoke_cycle_counters_test.go
+++ b/tests/sim/reinvoke_cycle_counters_test.go
@@ -53,9 +53,27 @@ import (
 // cycle limits configured explicitly — engine.Config has no built-in
 // fallback for either when NewEnv's Config literal bypasses cmd/root.go's
 // flag-resolution defaults.
+//
+// Also calls Engine.RegisterObservers (ADR-1592), which NewEnv deliberately
+// leaves uncalled by default (see NewEnv's own doc comment) — required here
+// for a reason specific to this file's advisory-mode, multi-round shape,
+// not merely a speed-up: dispatchWithCycleLimit (engine/catch_up_handlers.go)
+// marks every dispatched item as "advanced" (pctx.advancedItems[iKey] =
+// true) whether or not it genuinely left its stage, which suppresses
+// poll()'s own periodic-re-eval CooldownAt stamp for that item on the very
+// poll that dispatched it. In advisory mode the review gate clears
+// (blocked=false) every round, so handleReviewGate never takes the
+// alternate blocked-only branch that stamps a real, expiring
+// "review-blocked" cooldown instead (the branch TestReviewAuthorityCycle-
+// LimitPauses's authoritative-mode CHANGES_REQUESTED rounds always take,
+// which is why that pre-existing test never needed this). Without any
+// cooldown at all, and without mayNeedWorkObserver's cycleSet fast-path to
+// notice the dispatch's own fabrik:editing add/remove churn, the item is
+// never re-admitted for a second round's deep-fetch — confirmed empirically
+// by tracing round 2 hanging indefinitely with RegisterObservers uncalled.
 func reinvokeCycleCountersEnv(t *testing.T, maxReviewCycles, maxNoOpCommentCycles int) *Env {
 	t.Helper()
-	return NewEnv(t, EnvOptions{
+	env := NewEnv(t, EnvOptions{
 		Stages:    reviewAuthorityStages(),
 		StartTime: time.Now(),
 		ConfigureCfg: func(cfg *engine.Config) {
@@ -64,6 +82,8 @@ func reinvokeCycleCountersEnv(t *testing.T, maxReviewCycles, maxNoOpCommentCycle
 			cfg.MaxNoOpCommentCycles = maxNoOpCommentCycles
 		},
 	})
+	env.Engine.RegisterObservers()
+	return env
 }
 
 // preCreateWorktree creates issueNum's worktree on disk (checking out the

--- a/tests/sim/reinvoke_cycle_counters_test.go
+++ b/tests/sim/reinvoke_cycle_counters_test.go
@@ -82,7 +82,7 @@ func reinvokeCycleCountersEnv(t *testing.T, maxReviewCycles, maxNoOpCommentCycle
 			cfg.MaxNoOpCommentCycles = maxNoOpCommentCycles
 		},
 	})
-	env.Engine.RegisterObservers()
+	t.Cleanup(env.Engine.RegisterObservers())
 	return env
 }
 

--- a/tests/sim/restart.go
+++ b/tests/sim/restart.go
@@ -102,6 +102,10 @@ func RestartEnv(t *testing.T, env *Env) *Env {
 
 	eng := engine.NewWithDeps(env.cfg, restored, env.Claude, env.WM)
 	eng.SetClock(env.Clock)
+	// Mirrors production: a real restart re-registers observers immediately
+	// (Run() does this every time it starts) — see Engine.RegisterObservers's
+	// own doc comment (ADR-1592) and NewEnv's identical call.
+	eng.RegisterObservers()
 
 	env.issueSeqMu.Lock()
 	nextIssue := env.issueSeqNext

--- a/tests/sim/restart.go
+++ b/tests/sim/restart.go
@@ -102,10 +102,10 @@ func RestartEnv(t *testing.T, env *Env) *Env {
 
 	eng := engine.NewWithDeps(env.cfg, restored, env.Claude, env.WM)
 	eng.SetClock(env.Clock)
-	// Mirrors production: a real restart re-registers observers immediately
-	// (Run() does this every time it starts) — see Engine.RegisterObservers's
-	// own doc comment (ADR-1592) and NewEnv's identical call.
-	eng.RegisterObservers()
+	// Deliberately does NOT call Engine.RegisterObservers (ADR-1592) — see
+	// NewEnv's own doc comment for why this package leaves it uncalled by
+	// default. A scenario needing reactive-observer behavior on a restarted
+	// Engine (none currently do) must call it explicitly on the returned Env.
 
 	env.issueSeqMu.Lock()
 	nextIssue := env.issueSeqNext

--- a/tests/sim/simclaude/scripts.go
+++ b/tests/sim/simclaude/scripts.go
@@ -92,3 +92,22 @@ func PartialOutputThenKilled() Script {
 func CommentReviewCompleted() CommentScript {
 	return DefaultCommentScript
 }
+
+// NoOpCommentReview returns a CommentScript that touches nothing in workDir
+// and signals no progress: no commit (so headChanged stays false), no
+// FABRIK_ISSUE_UPDATE_BEGIN/END body update, and completed=false — the
+// exact shape processComments's own progress check (engine/comments.go:
+// `progressed := headChanged || extractUpdatedBody(output) != "" ||
+// completed`) treats as a no-op cycle, which is what both
+// checkNoOpCommentCycle (engine/comment_noop_breaker.go, #1592 gap 4b) and
+// dispatchReviewReinvoke's own no-commit refund path (engine/reviews.go,
+// #1592 gap 4a) key off. Named distinctly from DefaultCommentScript/
+// CommentReviewCompleted (both of which commit), mirroring this file's
+// existing naming convention.
+func NoOpCommentReview() CommentScript {
+	return func(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts engine.InvokeOptions) (string, bool, engine.TokenUsage, error) {
+		output := fmt.Sprintf("Reviewed the latest feedback on %s — nothing actionable, no changes made.\n", stage.Name)
+		usage := engine.TokenUsage{TurnsUsed: 2, MaxTurns: 50, CostUSD: 0.03}
+		return output, false, usage, nil
+	}
+}

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -1067,6 +1067,24 @@ graph traversal the model does not perform, and GitHub does reject them.
 rather than a refusal, which is visible as a stuck scenario rather than a green
 one; but do not use this layer to test cycle *rejection*.
 
+### `SeedRemoveBlockedBy` — **Fixture-only, no production analogue**
+
+Unlike every other Seed\* method that mirrors a real `GitHubClient` mutation
+(`SeedBlockedBy` mirrors `AddBlockedByIssue`), `SeedRemoveBlockedBy` has no
+counterpart on the interface at all: production only ever *adds* a blockedBy
+edge (`AddBlockedByIssue`, called from `spawnChildren` at spawn time); nothing
+in `engine/` ever removes one. `SeedRemoveBlockedBy` exists to model a human
+deleting the dependency link directly (GitHub UI, or the REST dependencies
+API) — the only way that edge disappears in practice.
+
+It deliberately does **not** bump the dependent issue's `updatedAt`, matching
+`#977`: real GitHub's REST dependencies API doesn't bump it either, so a
+scenario driving gap 1's companion case (the empty-`blockedBy`-list observer
+guard, ADR-1419, `engine/observers.go:299`) needs that exact staleness — the
+removal must be invisible to the probe-driven cache refresh until
+`checkDependencies`'s own cooldown-gated live re-read picks it up. See
+`tests/sim/dependency_unblock_test.go`.
+
 ### Check run IDs — **Modelled, unique across the sim**
 
 GitHub's check run IDs are unique and monotonically increasing, and production

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -523,6 +523,14 @@ mutate "SeedBlockedBy does not stamp the issue" \
   'TestSeedBlockedByDedupesAndStamps' \
   'seed.go::s{iss\.blockedBy = append\(iss\.blockedBy, gh\.Dependency\{Number: blockerNumber, Repo: repoField\}\)\n\tiss\.updatedAt = s\.now\(\)}{iss.blockedBy = append(iss.blockedBy, gh.Dependency\{Number: blockerNumber, Repo: repoField\})}'
 
+mutate "SeedRemoveBlockedBy does not actually remove the edge" \
+  'TestSeedRemoveBlockedByRemovesEdgeWithoutBumpingUpdatedAt' \
+  'seed.go::s{iss\.blockedBy = append\(iss\.blockedBy\[:idx\], iss\.blockedBy\[idx\+1:\]\.\.\.\)}{}'
+
+mutate "SeedRemoveBlockedBy does not fail on an unknown edge" \
+  'TestSeedRemoveBlockedByFailsOnUnknownEdge' \
+  'seed.go::s{if idx == -1 \{\n\t\ts\.fail\("simgh: %s#%d has no blockedBy edge to %s#%d", ownerRepo, issueNumber, blockerOwnerRepo, blockerNumber\)\n\t\treturn s\n\t\}}{}'
+
 # --- R2: clock-driven schedules (#1457) -------------------------------------
 #
 # The drain accessors are the whole sequencing mechanism, and each read path

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -965,6 +965,50 @@ func (s *Sim) SeedBlockedBy(ownerRepo string, issueNumber int, blockerOwnerRepo 
 	return s
 }
 
+// SeedRemoveBlockedBy removes one blockedBy edge, modelling a human deleting
+// the dependency link directly (e.g. via the GitHub UI or the REST
+// dependencies API) rather than anything Fabrik itself does. There is no
+// GitHubClient interface counterpart — production only ever adds a blockedBy
+// edge (AddBlockedByIssue, called from spawnChildren); it never removes one.
+// See FIDELITY.md for why this is a fixture-only mutator with no production
+// analogue, and #977 for why removal does NOT bump the dependent's
+// updatedAt — real GitHub's REST dependencies API doesn't either, and a
+// scenario relying on gap 1's empty-list guard (ADR-1419,
+// engine/observers.go:299) needs that exact staleness: the removal must be
+// invisible to the probe-driven refresh until checkDependencies's own
+// cooldown-gated live re-read (engine/dependencies.go) picks it up.
+func (s *Sim) SeedRemoveBlockedBy(ownerRepo string, issueNumber int, blockerOwnerRepo string, blockerNumber int) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, ok := r.issues[issueNumber]
+	if !ok {
+		s.fail("simgh: issue %s#%d not found", ownerRepo, issueNumber)
+		return s
+	}
+	idx := -1
+	for i, dep := range iss.blockedBy {
+		depRepo := dep.Repo
+		if depRepo == "" {
+			depRepo = ownerRepo
+		}
+		if dep.Number == blockerNumber && depRepo == blockerOwnerRepo {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		s.fail("simgh: %s#%d has no blockedBy edge to %s#%d", ownerRepo, issueNumber, blockerOwnerRepo, blockerNumber)
+		return s
+	}
+	iss.blockedBy = append(iss.blockedBy[:idx], iss.blockedBy[idx+1:]...)
+	// Deliberately does NOT stamp iss.updatedAt — see the doc comment above.
+	return s
+}
+
 // SeedRepoAccess overrides the repo's reported access flags.
 func (s *Sim) SeedRepoAccess(ownerRepo string, access gh.RepoAccess) *Sim {
 	r, ok := s.repoForSeed(ownerRepo)

--- a/tests/sim/simgh/state_test.go
+++ b/tests/sim/simgh/state_test.go
@@ -1484,6 +1484,58 @@ func TestSeedBlockedByDedupesAndStamps(t *testing.T) {
 	}
 }
 
+// TestSeedRemoveBlockedByRemovesEdgeWithoutBumpingUpdatedAt pins
+// SeedRemoveBlockedBy's two load-bearing properties for gap 1's companion
+// scenario (#1592): the edge is actually gone from the next read, and —
+// unlike SeedBlockedBy's own add path — updated-at does NOT move, mirroring
+// #977's real-API staleness gap that the empty-blockedBy-list observer guard
+// (ADR-1419, engine/observers.go:299) exists to protect against.
+func TestSeedRemoveBlockedByRemovesEdgeWithoutBumpingUpdatedAt(t *testing.T) {
+	s, clk := seedBasicBoard(t)
+	s.SeedIssue("acme/widgets", IssueSeed{Number: 8, Title: "blocker", Status: "Implement"})
+	s.SeedBlockedBy("acme/widgets", 7, "acme/widgets", 8)
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	before := issueUpdatedAt(t, s, 7)
+	clk.Advance(time.Hour)
+
+	s.SeedRemoveBlockedBy("acme/widgets", 7, "acme/widgets", 8)
+	if err := s.Err(); err != nil {
+		t.Fatalf("SeedRemoveBlockedBy: %v", err)
+	}
+
+	item, err := s.FetchProjectItem("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchProjectItem: %v", err)
+	}
+	if len(item.BlockedBy) != 0 {
+		t.Fatalf("blockedBy = %+v, want empty after SeedRemoveBlockedBy", item.BlockedBy)
+	}
+	if got := issueUpdatedAt(t, s, 7); !got.Equal(before) {
+		t.Fatalf("SeedRemoveBlockedBy bumped updated-at from %v to %v; it must not, mirroring #977", before, got)
+	}
+}
+
+// TestSeedRemoveBlockedByFailsOnUnknownEdge pins that removing an edge that
+// was never added is reported as a sticky error (a scenario bug), not a
+// silent no-op — asymmetric with SeedBlockedBy's own duplicate-add no-op,
+// since there is no real "GitHub already agrees" case a removal could be
+// idempotent about here.
+func TestSeedRemoveBlockedByFailsOnUnknownEdge(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	s.SeedIssue("acme/widgets", IssueSeed{Number: 8, Title: "blocker", Status: "Implement"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	s.SeedRemoveBlockedBy("acme/widgets", 7, "acme/widgets", 8)
+	if err := s.Err(); err == nil {
+		t.Fatal("SeedRemoveBlockedBy: expected an error removing a never-added edge, got nil")
+	}
+}
+
 // issueUpdatedAt reads an issue's updated-at from the model.
 func issueUpdatedAt(t *testing.T, s *Sim, issueNumber int) time.Time {
 	t.Helper()

--- a/tests/sim/stale_worker_reap_test.go
+++ b/tests/sim/stale_worker_reap_test.go
@@ -1,0 +1,97 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// Gap 3 (#1592): stale-worker-label reaping (engine/worker_liveness.go).
+// forEachStaleUnworkedItem reaps orphaned fabrik:editing/fabrik:locked:<user>
+// labels left behind when a worker dies mid-dispatch and the label survives
+// on GitHub with no in-memory Worker record to match it. Sequence-shaped:
+// the worker dies, a fresh process discovers the label N polls later —
+// directly adjacent to the restart-recovery scenarios #1451 already built
+// (tests/sim/restart.go's RestartEnv), reused here for exactly the genuine
+// process-state boundary it exists to provide.
+//
+// Driven through Engine.RunStartupCleanup (ADR-1592) — the seam this issue
+// adds, mirroring RegisterObservers/PollWithBackoff above: the five startup
+// scans it wraps are unexported and called only from Run(), so gap 3 is
+// otherwise 100% unreachable from tests/sim.
+func staleWorkerReapStages() []*stages.Stage {
+	return []*stages.Stage{
+		{Name: "Specify", Order: 1},
+		{Name: "Done", Order: 2, CleanupWorktree: true},
+	}
+}
+
+// TestStaleWorkerReap_OrphanedLockAndEditingLabels is AC4: an orphaned
+// fabrik:locked:<user> and a separate orphaned fabrik:editing label are each
+// left on an issue, as if the worker holding it died before releasing it;
+// RunStartupCleanup, run once a fresh process's store has been populated,
+// reaps both.
+//
+// Both issues also carry stage:Specify:complete from the moment they're
+// seeded — itemNeedsWork treats a stage-complete item as having no
+// dispatchable work left (fabrik:editing is separately excluded from
+// dispatch outright), so neither label can be touched by any ordinary
+// dispatch path on the restarted env's own first poll. This isolates
+// RunStartupCleanup as the only mechanism in the sequence that could
+// possibly remove either label — the discriminating property a
+// terminal-state check on its own could not establish.
+//
+// The lock label uses NewEnv's own hardcoded cfg.User ("fabrik-sim-bot" —
+// see env.go's Config literal), matching what a real fabrik:locked:<user>
+// label would read for this Env's configured identity.
+//
+// Non-vacuity (R5): both post-cleanup checks fail if RunStartupCleanup no
+// longer reaps its target label. Confirmed by temporarily neutralizing
+// forEachStaleUnworkedItem (returning immediately without ever calling fn)
+// and observing both assertions fail together — and, run separately,
+// confirmed each label's own removal call
+// (removeLockLabel/removeEditingLabel) is what RunStartupCleanup actually
+// depends on by tracing runStartupCleanup's two forEachStaleUnworkedItem
+// passes directly.
+func TestStaleWorkerReap_OrphanedLockAndEditingLabels(t *testing.T) {
+	t.Parallel()
+	env := NewEnv(t, EnvOptions{Stages: staleWorkerReapStages()})
+
+	lockedNum := FileIssue(t, env, "orphaned lock",
+		"Simulates a worker that died holding fabrik:locked:<user> — no active Worker record survives a restart.",
+		"Specify", "fabrik:locked:fabrik-sim-bot", "stage:Specify:complete")
+	editingNum := FileIssue(t, env, "orphaned editing",
+		"Simulates a comment-processing worker that died holding fabrik:editing.",
+		"Specify", "fabrik:editing", "stage:Specify:complete")
+	if err := env.Sim.Sim().Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	// Restart: a genuine process-state boundary. RestartEnv discards the
+	// engine and its store — Worker() becomes nil for everything — while
+	// simgh's model, and both labels with it, survives unchanged. No poll
+	// runs on the pre-restart env at all: gap 3's story begins with a fresh
+	// process discovering labels a dead predecessor left behind, not with
+	// this process's own dispatch history.
+	restarted := RestartEnv(t, env)
+
+	// One poll populates the restarted engine's store — RunStartupCleanup's
+	// own documented precondition ("must be called after the store is
+	// populated by the first poll cycle").
+	RunPoll(t, restarted)
+	if !hasLabel(IssueLabels(t, restarted, lockedNum), "fabrik:locked:fabrik-sim-bot") {
+		t.Fatal("orphaned lock label vanished before RunStartupCleanup ran — seeding/timing assumption broken")
+	}
+	if !hasLabel(IssueLabels(t, restarted, editingNum), "fabrik:editing") {
+		t.Fatal("orphaned editing label vanished before RunStartupCleanup ran — seeding/timing assumption broken")
+	}
+
+	restarted.Engine.RunStartupCleanup()
+
+	if hasLabel(IssueLabels(t, restarted, lockedNum), "fabrik:locked:fabrik-sim-bot") {
+		t.Error("RunStartupCleanup did not reap the orphaned fabrik:locked:<user> label")
+	}
+	if hasLabel(IssueLabels(t, restarted, editingNum), "fabrik:editing") {
+		t.Error("RunStartupCleanup did not reap the orphaned fabrik:editing label")
+	}
+}


### PR DESCRIPTION
Closes #1592

## Summary

Adds `tests/sim/` scenarios for four sequence-shaped engine behaviors (multi-poll or two-item interactions) the existing sim bed didn't reach:

1. **Gap 1 — dependency blocking/unblocking** (`tests/sim/dependency_unblock_test.go`): blocker close → dependent unblocks via `PushUnblockObserver` (AC1); removing the last `blockedBy` edge does *not* unblock via the observer, only via the `dep-blocked` cooldown's pull-path recheck (AC2).
2. **Gap 2 — GraphQL/REST rate-limit backoff** (`tests/sim/backoff_test.go`): interval escalation/recovery hysteresis across successive polls, and the REST hard gate.
3. **Gap 3 — stale-worker label reaping** (`tests/sim/stale_worker_reap_test.go`, AC4): orphaned lock/editing labels reaped on restart.
4. **Gap 4 — review/no-op-comment reinvoke cycle counters** (`tests/sim/reinvoke_cycle_counters_test.go`): the no-commit `ReviewCycleDecremented` refund (AC5), the `NoOpCommentCycles` breaker trip-and-reset-on-progress (AC6), and the invariant between the two limits (AC7).

## New engine seams (additive, no behavior change)

- `Engine.PollWithBackoff(ctx, configuredInterval) (PollBackoffResult, error)` — verbatim extraction of `doPollCycle`'s body from `Run()`; 5 new `backoff*` `Engine` fields replace what were closure locals.
- `Engine.RunStartupCleanup()` — delegates, in order, to the 5 one-shot startup scans `Run()` already called.
- `Engine.RegisterObservers() (unregister func())` — extraction of the observer-registration block (`mayNeedWorkObserver`, `PushUnblockObserver`, etc.), discovered necessary while writing gap 1. Deliberately **not** called by default from `tests/sim`'s `NewEnv`/`RestartEnv` — wiring it in unconditionally changed dispatch timing package-wide and broke four unrelated pre-existing scenarios. Only the two scenario files that need it call it explicitly; see `tests/sim/env.go`'s `NewEnv` doc comment and ADR-1592 for the full incident writeup.

One minor, documented widening: `shouldPauseForRESTRateLimit`'s two `time.Now()` call sites now use `e.now()`, so the REST hard gate can be driven by an injected `Clock` in tests. Byte-identical in production (`e.now()` falls back to `time.Now()` when no `Clock` is set).

## Verification

Fixed the malformed `FABRIK_PR_CREATE` marker (was using lowercase `title:` instead of the required `TITLE:` prefix) and re-emitted it correctly. No other changes needed — all implementation work, tests, ADR, README updates, and the Plan checklist were already complete, committed, and pushed.

## Docs

- New `adrs/1592-sim-bed-backoff-and-startup-cleanup-seams.md`.
- `tests/sim/README.md` updated: new coverage-inventory section for the four gaps, seam descriptions, fixture additions, runtime figure.