### PR TITLE
Add an optional marketplace plugin for non-technical spec authoring

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,6 +22,22 @@
         "name": "Tenacious Ventures",
         "url": "https://github.com/handarbeit/fabrik"
       }
+    },
+    {
+      "name": "fabrik-project-onboarding",
+      "description": "Onboard a software project and write its feature specifications, for product managers and business owners rather than engineers. Interviews you about project goals, scope, constraints, and vocabulary, then turns feature ideas into Spec Kit specifications ready to hand to Fabrik for build.",
+      "category": "productivity",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/handarbeit/fabrik.git",
+        "path": "plugin/fabrik-project-onboarding",
+        "ref": "main"
+      },
+      "homepage": "https://fabrik.handarbeit.io",
+      "author": {
+        "name": "handarbeit.io",
+        "url": "https://handarbeit.io"
+      }
     }
   ]
 }

--- a/plugin/fabrik-project-onboarding/.claude-plugin/plugin.json
+++ b/plugin/fabrik-project-onboarding/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "fabrik-project-onboarding",
+  "displayName": "Fabrik Project Onboarding",
+  "version": "0.1.0",
+  "description": "Onboard a software project and write its feature specifications, for product managers and business owners rather than engineers. Interviews you about project goals, scope, constraints, and vocabulary, then turns feature ideas into GitHub Spec Kit specifications ready to hand to Fabrik for build. No terminal, git, or technical background needed.",
+  "author": {
+    "name": "handarbeit.io",
+    "url": "https://handarbeit.io"
+  },
+  "homepage": "https://fabrik.handarbeit.io",
+  "repository": "https://github.com/handarbeit/fabrik",
+  "keywords": ["fabrik", "spec-kit", "specification", "requirements", "product-management", "onboarding"]
+}

--- a/plugin/fabrik-project-onboarding/GETTING-STARTED.md
+++ b/plugin/fabrik-project-onboarding/GETTING-STARTED.md
@@ -1,0 +1,96 @@
+# Getting started
+
+You don't need to install anything technical, use a terminal, or know git. You need the **Claude desktop app**, on a computer, and about five minutes of setup. The phone app won't work for this — it can't connect to a folder, and your specs need somewhere to be saved.
+
+A **spec** is a written description of what a piece of software should do and why, detailed enough that someone can build it without guessing. That's what you're going to produce here.
+
+## 1. Install the plugin
+
+In the Claude desktop app, click **Cowork**, then **Customize** in the sidebar and open **Plugins**.
+
+1. Select **Add marketplace** and enter: `handarbeit/fabrik`
+2. Find **Fabrik Project Onboarding** in the list and click **Install**.
+
+You don't need a GitHub account for this — it's a public repository, so it just loads.
+
+When a new version ships you'll see an **Update** button in the same place.
+
+## 2. Make a project and connect a folder
+
+Your specs are written to a real folder on your computer, so Claude needs access to one.
+
+If someone's already building the software, ask them which folder to use — often a shared
+one that syncs to them automatically, so there's no separate step to send anything. If it's
+just you for now, make a new folder anywhere you like (Documents is fine) and use that. It
+can be shared with a developer later without moving anything.
+
+A **project** in Cowork is just a saved setup: which folders Claude can use, plus any
+standing instructions. Making one means you don't reconnect the folder every time.
+
+1. Click **Projects** in the left sidebar, then the **+** button.
+2. Choose a starting point:
+   - **Use an existing folder** if the folder is already on your computer — this is
+     the usual case.
+   - **Start from scratch** if nothing has been set up yet; it creates a new folder
+     for you.
+3. Give it a name and a short description.
+4. Confirm the folder is attached. You can add more folders later from the project's
+   settings.
+
+From then on, click the project in the sidebar to start a session with that folder
+already connected. Projects live only on your computer.
+
+## 3. Onboard the project (once)
+
+Start here, before writing any individual feature:
+
+> Let's set up the project.
+
+You'll be asked about seven things, one at a time — what the project is and what's broken without it, who it serves, what success looks like, what's explicitly out of scope, the hard constraints, the words your business uses, and the rules every feature has to respect. Expect thirty to forty-five minutes, and it's fine to do it in two sittings.
+
+Most of it is you correcting drafts rather than answering from a blank page. If a proposal is wrong, say so — that's faster than being asked open questions, and it's what the format is designed around.
+
+You'll get a short document at the end. **Read it properly.** Every feature spec inherits it, including its mistakes, and you're the only person who can spot what's wrong.
+
+## 4. Write a spec, one feature at a time
+
+Describe the feature in your own words, with however much detail you have:
+
+> I want to spec out a feature for tracking food waste — spoiled deliveries, prep offcuts, plate returns — across all our sites, so we can see where the money is going.
+
+You'll get back a written specification, plus at most three questions about things that genuinely couldn't be guessed. Everything else gets a reasonable default, written down under **Assumptions** so you can correct anything wrong.
+
+The spec lands in the folder you connected, as `specs/001-your-feature/spec.md`.
+
+You'll notice folders called `specs` and `.specify`. Those are just the standard names for where specifications and project settings live — nothing you need to press or remember. The one starting with a dot is hidden by your computer by default, so don't be alarmed when you can't see it; ask Claude to open it for you.
+
+## 5. Sharpen it
+
+When you're happy with the shape:
+
+> Clarify this spec.
+
+Up to five questions, one at a time, each with a recommended answer. If the recommendation looks right, just say "yes". Each answer gets written into the spec as you go, so decisions live in the document rather than the chat.
+
+Then go back to step 4 for the next feature.
+
+## What you're being asked for (and what you're not)
+
+**You're being asked for:** what the software should do, who it's for, why it matters, and how anyone would know it's working. That's the whole job, and you're the person who knows it.
+
+**You're not being asked for:** how it gets built. No databases, frameworks, or architecture — that's deferred to the build stage. If you have a strong technical opinion, say it anyway; it gets recorded for the build team rather than thrown away.
+
+Two things are worth knowing, because they're where specs usually go wrong:
+
+**Say what "good" looks like in numbers.** "The system should be fast" can't be checked by anyone. "A manager can log a waste entry in under 30 seconds" can. Every vague adjective — robust, intuitive, seamless — is a decision someone downstream will end up making on your behalf. If you can put a number on it, you've made that decision yourself.
+
+**Rank the user stories honestly.** A *user story* is one thing someone needs to be able to do, written so it could ship on its own. P1 means "must be in the first version"; P2 and P3 can follow later. If everything is P1, nothing is, and the build order gets chosen by someone with less context than you.
+
+## If something goes wrong
+
+- **You can't find your spec** — it's in the `specs` folder, which is *not* hidden: look for `specs/001-your-feature/spec.md` in the folder you connected. If the whole folder looks empty, see the next entry.
+- **You can't find the project setup** — that one *is* hidden. The constitution written during setup lives in a folder whose name starts with a dot (`.specify`), and your computer hides those by default. It's almost certainly there. Ask Claude to show you the project setup rather than hunting for it in Finder or File Explorer.
+- **It genuinely didn't write anything** — this happens when no folder was connected to the session, so there was nowhere to save to. Claude should tell you and offer the files as a download instead. Connect a folder (step 2) and ask again, and it'll save automatically from then on.
+- **You want to change something after the fact** — just say so. "Add a user story about ordering" or "the waste one should be P1, not P2" works fine, and it doesn't have to be the same conversation or even the same day; the existing spec gets edited rather than a new one started.
+- **The project's goals have shifted** — ask to update the project setup. It'll show you what's recorded and only reopen what's changed.
+- **You want to start a new feature** — just describe it. Each gets its own numbered folder; nothing overwrites.

--- a/plugin/fabrik-project-onboarding/NOTICE.md
+++ b/plugin/fabrik-project-onboarding/NOTICE.md
@@ -1,0 +1,106 @@
+# Notices
+
+The `write-spec` and `clarify` skills in this plugin are adapted from
+[GitHub Spec Kit](https://github.com/github/spec-kit), specifically
+`templates/commands/specify.md`, `templates/commands/clarify.md`, and
+`templates/spec-template.md`.
+
+Spec Kit is MIT licensed:
+
+```
+MIT License
+
+Copyright GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## What was changed
+
+Spec Kit's commands assume a Claude Code / CLI environment and cover the whole
+lifecycle from idea to implementation. This plugin covers **spec authoring
+only** — everything downstream of the specification is Fabrik's scope — and is
+written for a product manager or business owner rather than an engineer.
+
+**Kept:** the spec template and section structure, sequential `specs/NNN-name/`
+numbering, `.specify/feature.json`, `.specify/memory/constitution.md`, the
+requirements quality checklist (all sixteen items verbatim, in upstream's order)
+and its re-validation pass, the three-marker `[NEEDS CLARIFICATION]` cap, and
+clarify's full coverage taxonomy with its five-question ceiling and incremental
+write-back.
+
+**Removed:** the `plan`, `tasks`, `analyze`, `implement`, and `checklist`
+commands and everything that supports them; the `.specify/extensions.yml` hook
+system; git branch creation; the `check-prerequisites` shell/PowerShell/Python
+scripts; and the preset/template resolution stack.
+
+**Renamed:** the `specify` command became **write-spec**. Fabrik's own pipeline
+ships a separate, unrelated `fabrik-specify` skill that operates on an already-
+filed GitHub issue; the two never load into the same session, but the distinct
+name keeps "the skill a human uses to author a spec" from reading as a variant
+of it. The output format is unchanged from upstream `specify`; the behavioural
+differences are listed below.
+
+**Adapted for a non-technical author.** Beyond the audience rewrite, these
+behavioural changes were made deliberately and depart from upstream:
+
+- **Questions take a position.** Upstream `specify` presents a neutral A/B/C
+  menu; both skills here lead with a recommendation, a one-line "why it
+  matters", and an explicit "say yes to accept" — a neutral menu handed to
+  someone who came here precisely because they don't know the options just
+  returns the decision to them. "You pick" is handled explicitly, and the
+  result is recorded as an assumption rather than as the person's decision.
+- **No invented facts.** Neither skill may propose a specific number, name, or
+  threshold the person hasn't implied. Where upstream would fill a measurable
+  success criterion with a plausible figure, this writes the shape and marks
+  the figure `[NEEDS BASELINE]`. `[NEEDS BASELINE]` is local to this plugin and
+  does not count against upstream's three-marker cap.
+- **No temporary-directory fallback.** Upstream assumes a repo checkout. These
+  skills write only to a folder the person has connected, and hand the files
+  back for download when there isn't one, rather than saving to a scratch
+  directory that disappears when a cloud session ends.
+- **Assumptions are surfaced in conversation**, not only written to the file —
+  the correctability that justifies guessing doesn't work if it lives only in a
+  document nobody opens.
+- **The physical environment of use** is never silently defaulted.
+- **The checklist `## Notes` section stays a single bullet**, as upstream has
+  it. The repair log lives in the reply instead, because downstream tooling
+  reads that file as a gate rather than a scratchpad. Two things inside the
+  checklist file differ from upstream deliberately, both outside the sixteen
+  graded items: the `**Feature**` header links to the spec rather than carrying
+  upstream's bare placeholder, and the `## Notes` bullet says "before
+  clarification or planning" where upstream names its `/speckit.*` slash
+  commands — a Cowork reader has no way to run those.
+- **No plan-stage handoffs in user-facing text.** Upstream closes by pointing at
+  `/speckit.plan`; these skills never tell the reader to run a command, skill,
+  or stage, since a Cowork user has no way to start one.
+
+**Changed:** the `constitution` command became **onboard**, a guided interview
+rather than a principles-authoring command. Its output keeps Spec Kit's
+constitution shape and location, but the content is narrowed to what a
+non-technical author can legitimately own and what actually constrains a
+specification — project goals, users, scope boundaries, hard constraints,
+domain glossary, and product principles. Engineering governance (testing
+strategy, delivery process, architecture, tech stack) is deliberately excluded
+and deferred to the build stage; technical preferences raised during the
+interview are recorded in a clearly non-binding section instead.
+
+Spec output remains compatible with upstream Spec Kit, so anything that
+consumes a Spec Kit `specs/NNN-name/` folder — including `/speckit.plan` and
+`/speckit.tasks` in Claude Code — works against these specs unchanged.

--- a/plugin/fabrik-project-onboarding/README.md
+++ b/plugin/fabrik-project-onboarding/README.md
@@ -1,0 +1,69 @@
+# Fabrik Project Onboarding
+
+Onboard a software project and write its feature specifications — aimed at the product manager or business owner, not the engineer. No terminal, no git, no technical background needed.
+
+A **specification** — a spec — is a written description of what a piece of software should do and why, in enough detail that someone can build it without guessing. This plugin writes them with you, by asking questions.
+
+Three skills, meant to be used in that order:
+
+- **onboard** — a 30–45 minute interview about the project as a whole: the problem, who it serves, what's in and out of scope, the hard constraints, and the words the business uses. Writes a short document — the project *constitution* — recording the ground rules every later spec has to respect, so you only answer these questions once.
+- **write-spec** — turns a feature described in plain language into a structured spec: the things people need to do with it (*user stories*), what it must do (*requirements*), how you'd know it worked (*success criteria*), and a checklist that grades the result.
+- **clarify** — reads a spec, finds what's vague or missing, asks up to five targeted questions one at a time, and writes each answer back into the document.
+
+The files it writes follow a widely-used open format called [Spec Kit](https://github.com/github/spec-kit), so any development team can pick them up without translation — as can Fabrik, the tool that builds software from specs like these automatically.
+
+## Install
+
+In the Claude desktop app: **Cowork** → **Customize** → **Plugins** → **Add marketplace**, enter `handarbeit/fabrik`, then install **Fabrik Project Onboarding**. Updates appear as an **Update** button in the same place.
+
+You'll need the desktop app on a computer. The phone app can't connect to a folder, and these skills need somewhere to save your specs.
+
+**[GETTING-STARTED.md](GETTING-STARTED.md) is the full walkthrough**, including creating a Cowork project so your folder stays connected between sessions. Start there if this is your first time.
+
+## Using it
+
+Connect the folder where specs should live — in practice, by making a Cowork project with that folder attached, so you don't reconnect it every session. Any folder works; Documents is fine. If someone's already building the software, ask which folder they'd like you to use; a folder that syncs automatically to them, like a shared Dropbox, Google Drive, or OneDrive folder, saves you emailing anything to anyone. If it's just you for now, make a new folder anywhere and share it later.
+
+**Start the project.** "Let's set up the project" or "onboard me". You'll be interviewed about goals, users, scope, constraints, and vocabulary, then shown a short constitution to check. This happens once.
+
+**Write a spec.** Describe a feature in your own words, with as much or as little detail as you have. You'll get a spec plus a quality checklist, and at most three questions about things that genuinely couldn't be guessed. Everything else gets a sensible default, recorded under Assumptions where you can correct it.
+
+**Sharpen it.** Ask to clarify the spec. Up to five questions, one at a time, each with a recommended answer you can accept by saying "yes". Answers are written straight into the spec — the decision lives in the document, not the chat.
+
+Repeat the last two per feature. The constitution keeps them consistent.
+
+## What you're asked for, and what you aren't
+
+**You're asked for:** what the software should do, who it's for, why it matters, and how anyone would know it's working. That's the whole job, and you're the person who knows it.
+
+**You aren't asked for:** how it gets built. No architecture, databases, or frameworks — that's deferred to the build stage. If you have a technical opinion, say it anyway; it gets recorded for the build team rather than thrown away, and it won't distort the spec.
+
+Two things are worth knowing, because they're where specs usually go wrong:
+
+**Say what "good" looks like in numbers.** "The system should be fast" can't be checked by anyone. "A manager can log an entry in under 30 seconds" can. Every vague adjective — robust, intuitive, seamless — is a decision someone downstream ends up making on your behalf.
+
+**Rank the features honestly.** Each user story is written so it could ship on its own. P1 means "must be in the first version"; P2 and P3 can come later. If everything is P1, nothing is, and build order gets chosen by someone with less context than you.
+
+## What it produces
+
+```
+.specify/memory/constitution.md      project goals, scope, constraints, glossary
+specs/001-feature-name/
+├── spec.md                          the specification
+└── checklists/requirements.md       quality checks, with pass/fail state
+```
+
+`.md` files are plain text documents — they open in anything, including Notepad or TextEdit. The folder starting with a dot (`.specify`) is hidden by your computer by default; that's normal, and Claude can open it for you any time.
+
+Not sure where to start? Install the plugin, connect a folder, and say "let's set up the project".
+
+## For developers
+
+Install into Claude Code instead:
+
+```
+/plugin marketplace add handarbeit/fabrik
+/plugin install fabrik-project-onboarding@fabrik
+```
+
+`NOTICE.md`, alongside this file in the plugin source, records what was adapted from upstream Spec Kit and what was deliberately left out.

--- a/plugin/fabrik-project-onboarding/skills/clarify/SKILL.md
+++ b/plugin/fabrik-project-onboarding/skills/clarify/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: clarify
+description: Finds the vague and missing parts of an existing feature specification and fixes them by asking up to five targeted questions, one at a time, writing each answer back into the spec as it is answered. Follows GitHub Spec Kit's clarify workflow. Use this when someone wants to review, tighten, sharpen, sanity-check, poke holes in, or fill the gaps in a spec or requirements document, when they ask "what's missing from this spec", "is this ready to hand to engineering", or "what did I forget" — and as the natural follow-up after a spec has been written.
+---
+
+# Clarify a Specification
+
+Find where a specification is ambiguous or silent, ask the smallest number of questions that resolve the highest-impact gaps, and write every answer back into the spec so the document — not the chat transcript — carries the decision.
+
+This runs after a spec exists and before anyone builds against it. Ambiguity caught here costs one question; ambiguity caught during the build costs a rebuild.
+
+The person answering is a product manager, business owner, or domain expert — expert in the business, not in software construction. Every question must be answerable from what they know about their own operation. A question they'd need an engineer to answer is a question you shouldn't be asking.
+
+**Never invent a specific number, threshold, name, or percentage they haven't given you.** Turning a vague adjective into a number is the single most valuable thing this skill does — but the number has to come from them. Proposing "under two seconds" to someone with no target in mind produces agreement, not information, and a figure you made up is then indistinguishable in the spec from one the business actually committed to. Ask what they'd expect, or what they measure today; if they genuinely don't know, record the shape and leave the figure as `[NEEDS BASELINE]`.
+
+`[NEEDS BASELINE]` is a sanctioned marker meaning "not currently measured", written by this skill and by write-spec. Resolve it only with a figure the person supplies. Never fill one in yourself, and never treat one as a lingering vague placeholder to be cleaned up.
+
+## Find the spec
+
+Locate the specification in this order:
+
+0. **If the person attached a spec to the conversation**, work from that and hand back an updated copy when you're done. Everything below about reading and writing files applies to that working copy instead. Check this first — it costs nothing and saves hunting for a file that was handed to you.
+1. Otherwise establish which folder holds the spec: use the connected folder if there's exactly one, and ask which if several are connected. If **no** folder is connected, don't go looking in a temporary or scratch directory — ask them to attach the spec to the conversation instead, and tell them how to connect a folder so it's found automatically next time.
+2. Settle the **project root**: if a `.specify/` folder exists at that folder or anywhere above it, the folder containing it is the root; otherwise the connected folder is. Everything below is relative to that root, and `feature_directory` is read relative to it — someone may have connected a sub-folder of a larger project whose `.specify/` sits higher up.
+3. `.specify/feature.json` at the root — read `feature_directory`, and use `<feature_directory>/spec.md`. If the file can't be read, or the folder it names no longer exists, ignore it and fall through to the next step. Don't report that as an error — someone renaming a folder in Finder is a perfectly ordinary thing to do, and they have no idea a file was tracking it.
+4. If that's missing or stale, list the `specs/NNN-*` folders under the root and use the highest-numbered one, confirming with the person which spec they mean if there's any doubt. Once resolved, quietly update `.specify/feature.json`'s `feature_directory` to point at the folder you settled on, preserving any other keys — leaving a stale pointer in place means every later run repeats this search, and it silently breaks write-spec's ability to revise a spec rather than starting a new one.
+5. If no spec file exists at all, don't create one — say plainly that there's no spec here yet and offer to write one with them first.
+
+Read `.specify/memory/constitution.md` too, if it exists. It settles project-wide vocabulary, constraints, and scope — so anything it already answers is not an ambiguity, and asking about it wastes one of five questions and makes the project look like it isn't listening to itself. It also gives you the canonical terms to normalize toward when you find the spec using two words for one thing.
+
+## Steps
+
+### 1. Scan for ambiguity
+
+Read the whole spec and assess it against the coverage taxonomy in `references/taxonomy.md`. Mark every category **Clear**, **Partial**, or **Missing**. Keep this map to yourself while questioning — leading with a wall of categories buries the questions — but keep it, because the final report presents it back as the coverage summary, translated into plain language (see Reporting). The taxonomy's category names are working vocabulary for you, never text to show the person.
+
+For each Partial or Missing category, consider a question — but drop candidates where the answer wouldn't change what gets built, tested, or accepted, and drop ones better answered during technical planning. Note the latter internally so they can be reported as deferred rather than silently dropped.
+
+### 2. Build the question queue
+
+Assemble a prioritized queue of at most **five** questions. Each must:
+
+- be answerable either by picking from 2–5 mutually exclusive options, or in five words or fewer
+- materially affect architecture, data modeling, task breakdown, test design, user-facing behavior, operational readiness, or compliance
+- be answerable from what this person actually knows. A question whose real answer depends on facts they don't hold — whether some data is already collected, whether a system can supply a field — isn't a clarification, it's a research task. Either frame it as a preference they can express from their own experience, or note it as deferred to planning
+
+Rank by impact × uncertainty and cover the highest-impact unresolved categories first. Don't spend two of five questions on low-impact details while something like security posture stays unresolved. Skip anything already answered elsewhere in the spec, anything purely stylistic, and plan-level execution detail unless it blocks correctness.
+
+If nothing meets the bar, say "No critical ambiguities detected worth formal clarification", show a compact coverage summary, and suggest moving on. That's a real outcome, not a failure.
+
+### 3. Ask, one question at a time
+
+Present exactly one question, wait for the answer, then move on. Don't reveal what's queued next — seeing five questions at once invites skimming, and each answer can change what's worth asking afterward. Saying where you are ("question 2 of up to 5") is fine and worth doing; it costs nothing and tells the person the end is in sight.
+
+**Write questions a non-technical stakeholder can answer unaided:**
+
+- Lead with `**Question:**` followed by a full sentence that ends in `?` and stands on its own. A topic label like `Acceptance device/runtime matrix (FR-023)` is not a question — it's a heading, and it puts the work of guessing the question on the reader.
+- The only thing allowed after the `?` is a parenthesized requirement id: `**Question:** <question>? (FR-023)`. Never lead with the id. The first time you use one in a session, gloss it once — "FR-023 is just the numbered line in the spec this would change" — then use it bare after that.
+- Immediately after the question, add one plain-language **Why it matters** sentence naming the stake — what goes wrong at acceptance or at ship time if this stays undecided.
+- Use everyday words. Introduce jargon only if you define it in the same sentence. Self-check: could someone who has never heard of Spec Kit answer from the question line alone?
+
+**Multiple-choice format** — analyze the options first and take a position, based on best practice for the project type, common patterns in similar work, risk reduction, and any goals or constraints already visible in the spec. Lead with the recommendation, because an expert opinion is more useful than a neutral menu:
+
+```markdown
+**Recommended:** Option B — <one or two sentences of reasoning>
+
+| Option | Description |
+|--------|-------------|
+| A | <description> |
+| B | <description> |
+| C | <description> |
+```
+
+Then: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or give your own short answer.`
+
+**Short-answer format** — when there are no meaningful discrete options:
+
+```markdown
+**Suggested:** <proposed answer> — <brief reasoning>
+```
+
+Then: `Format: Short answer (≤5 words). Accept the suggestion by saying "yes", or give your own answer.`
+
+**Handling the reply:** "yes", "recommended", or "suggested" means take your stated recommendation. Otherwise check the answer maps to an option or fits the five-word limit. If it's ambiguous, ask for quick disambiguation — that stays part of the same question and doesn't advance the count.
+
+The five-word limit governs what the person has to *type*, not what gets recorded. A terse reply plus your stated recommendation resolves into a full decision, and it's that decision — precise enough to build and test against — that goes into the spec. "B" is a fine answer; "B" is not a fine requirement.
+
+**Stop early** when the remaining queued questions have become unnecessary, when the person signals they're done ("done", "good", "no more", "stop", "proceed"), or when five questions have been asked. Retries on a single question don't count as new questions.
+
+### 4. Integrate each answer immediately
+
+After each accepted answer, update the spec — on disk, or in the working copy you'll hand back if the spec was attached to the conversation — before asking the next question. Saving incrementally means an interrupted session still leaves the spec better than it was.
+
+On the first integration of the session, ensure a `## Clarifications` section exists — placed after the title block and immediately before the first `##` section, whatever that section happens to be — with a `### Session YYYY-MM-DD` subheading for today. Append the exchange:
+
+```markdown
+- Q: <question> → A: <final answer>
+```
+
+One bullet per question, carrying the resolved decision. A question that needed a disambiguation round still produces one bullet, with the final answer rather than the exchange that got there.
+
+Then apply the answer where it actually belongs:
+
+| Kind of answer | Where it goes |
+|---|---|
+| Functional ambiguity | Update or add a Functional Requirement |
+| Role or actor distinction | Update User Scenarios / the relevant actor description |
+| Data shape, entity, relationship | Update Key Entities, preserving existing order |
+| Non-functional constraint | Add or sharpen a measurable item under Success Criteria — turn the vague adjective into a number *the person gave you* |
+| Edge case or failure mode | Add a bullet under Edge Cases |
+| Terminology conflict | Normalize the term throughout; keep the old one only as `(formerly referred to as "X")`, once |
+
+When a clarification invalidates an earlier statement, **replace** that statement rather than adding a contradicting one. A spec that says two things is worse than a spec that said nothing. Before moving on, search the whole document for the vague term the answer just retired — "normalised basis", "appropriate", "as needed" — because the phrase you resolved in a requirement usually also appears in an acceptance scenario or an entity description, and a spec that's precise in one place and vague in another is still vague.
+
+If an answer requires a **new** functional requirement, give it the next unused FR number and place it with the requirements it relates to rather than appending it to the end — grouping survives longer than numeric order. Add at least one acceptance scenario covering it in the same edit. New requirements are the main way a clarify pass makes the quality checklist worse than it found it, and the fix costs one sentence at the time you already have the context.
+
+Preserve heading hierarchy, don't reorder unrelated sections, and keep each insertion minimal and testable rather than narrative.
+
+### 5. Validate
+
+On each write, check the two things that write could have broken: one bullet per accepted answer with no duplicates, and no statement left contradicting the answer just integrated.
+
+Once at the end, confirm the rest: no more than five accepted questions; no lingering vague placeholder that an answer was meant to resolve; valid markdown with no new headings beyond `## Clarifications` and `### Session YYYY-MM-DD`; and consistent terminology across every section touched.
+
+### 6. Re-validate the quality checklist
+
+If `<feature_directory>/checklists/requirements.md` exists, re-evaluate it against the updated spec. If it doesn't, skip this silently.
+
+Read the file and find the checkbox lines — `- [ ]`, `- [x]`, `- [X]`, tolerating leading whitespace, ignoring anything inside code fences. Record the before state, re-evaluate each item against the spec as it now stands, and flip only the markers whose state actually changed: unchecked → `[x]` when an item now passes, checked → `[ ]` when it now fails. Leave unchanged markers exactly as they were, including their case, and don't touch headings, notes, ordering, or whitespace — a clean diff is what makes the change reviewable.
+
+Track three lists for the report: newly passing, regressions, and still unchecked. Record before/after counts as checked-over-total.
+
+## Reporting
+
+**Nothing in this report uses the taxonomy's internal category names — deferrals included.** Use the plain-language gloss from `references/taxonomy.md` everywhere, not just in the coverage summary. "Deferred: Protocol and versioning assumptions" is exactly the leak this rule exists to prevent.
+
+Close with:
+
+- how many questions were asked and answered
+- the path to the updated spec
+- which sections were touched
+- checklist status if re-validated, as before → after counts (e.g. "12/16 → 15/16 items passing"), naming anything newly passing, any regression, and anything still unchecked
+- a short coverage summary **in plain language**. "Observability", "Protocol and versioning assumptions", "Rate limiting and throttling" are engineering vocabulary and mean nothing to the person reading. Group what you assessed into these seven business-readable headings, and mark each **Resolved**, **Deferred**, **Already clear**, or **Still open**:
+  - what it does
+  - who uses it
+  - the information it keeps
+  - who's allowed to see and do what, and any rules you have to follow
+  - how it behaves when things go wrong
+  - how fast and reliable it has to be
+  - the words it uses
+- a recommendation in plain terms: either "this is ready to hand to whoever's building it", or "worth another look once you've decided X", naming what would need to be true. Describe it as something they can ask for, never as a command, a skill, or a stage to run — they have no way to start one.
+
+Name anything deferred explicitly with the reason. A gap that's been consciously deferred is a managed risk; a gap that quietly vanished from the report is not.
+
+If the person says they're skipping clarification entirely — an exploratory spike, say — that's their call. Proceed, but note once that unresolved ambiguity tends to resurface as rework.

--- a/plugin/fabrik-project-onboarding/skills/clarify/references/taxonomy.md
+++ b/plugin/fabrik-project-onboarding/skills/clarify/references/taxonomy.md
@@ -1,0 +1,67 @@
+# Coverage Taxonomy
+
+Assess the specification against every category below and mark each **Clear**, **Partial**, or **Missing**. The categories are ordered roughly by how expensive the gap is to discover late — a wrong scope boundary is more costly than a missing log line — but weigh impact against the specific feature rather than following the order mechanically.
+
+**These category names are working vocabulary for you, not text to show the person.** They're engineering terms, and a business owner handed a table of twenty of them marked "Outstanding" learns nothing except that something is wrong. Each entry below carries a plain-language gloss in italics — use that phrasing when you need to raise the topic in conversation or in the coverage summary, and group the categories into the six business-readable headings named in the skill's Reporting section.
+
+## Functional Scope & Behavior
+
+- Core user goals and success criteria — *what it's for, and how you'd know it worked*
+- Explicit out-of-scope declarations — *what this deliberately doesn't do*
+- User roles / personas and how they differ — *who uses it, and who's allowed to do what*
+
+## Domain & Data Model
+
+- Entities, attributes, relationships — *the things it keeps track of, and what it records about each*
+- Identity and uniqueness rules — *what makes two records the same thing or different things*
+- Lifecycle and state transitions — *the stages something moves through, from created to finished*
+- Data volume and scale assumptions — *how much of it there'll be*
+
+## Interaction & UX Flow
+
+- Critical user journeys and their sequence — *the steps someone actually takes, in order*
+- Error, empty, and loading states — *what they see when something's wrong, missing, or still working*
+- Accessibility and localization needs — *whether it has to work for people with disabilities, or in another language*
+
+## Non-Functional Quality Attributes
+
+- Performance (latency, throughput targets) — *how fast it has to be*
+- Scalability (limits, growth expectations) — *how much busier it might get*
+- Reliability and availability (uptime, recovery expectations) — *how often it can be down, and how quickly it must come back*
+- Observability (what needs logging, measuring, tracing) — *what the business needs to be able to see and report on*
+- Security and privacy (authentication, authorization, data protection, threat assumptions) — *who can get in, who can see what, and what must be kept private*
+- Compliance and regulatory constraints — *rules you have to follow by law or contract*
+
+## Integration & External Dependencies
+
+- External services and APIs, and what happens when they fail — *other systems this relies on, and what happens when one is unavailable*
+- Data import/export formats — *getting information in and out, including to a spreadsheet*
+- Protocol and versioning assumptions — *how it keeps working when a connected system changes*
+
+## Edge Cases & Failure Handling
+
+- Negative scenarios — *what happens when someone does the wrong thing*
+- Rate limiting and throttling — *what happens when too many people use it at once*
+- Conflict resolution (for example, concurrent edits to the same record) — *what happens when two people change the same thing at the same time*
+
+## Constraints & Tradeoffs
+
+- Technical constraints already fixed (language, storage, hosting) — *decisions already made that can't be revisited*
+- Explicit tradeoffs made, and alternatives already rejected — *what was chosen over what, and why*
+
+## Terminology & Consistency
+
+- Canonical glossary terms — *the agreed word for each thing*
+- Synonyms and deprecated terms to avoid — *words that mean the same thing and shouldn't be mixed*
+
+## Completion Signals
+
+- Whether acceptance criteria are actually testable — *whether you could genuinely check each promise was met*
+- Measurable definition-of-done indicators — *what "finished" means, in terms you could verify*
+
+## Placeholders & Unresolved Decisions
+
+- TODO markers and open questions left in the text — *notes-to-self nobody came back to*
+- Ambiguous adjectives — "robust", "intuitive", "fast", "seamless" — used without a number attached — *promises that sound firm but can't be checked*
+
+Vague adjectives are the highest-yield thing to scan for. They read as requirements but can't be tested, so they survive review and then get interpreted differently by everyone downstream. Turning one into a number is usually the single most valuable question available — but the number must come from the person, never from you. Ask what they'd expect or what they measure today; if they don't know, record the shape and leave the figure as `[NEEDS BASELINE]` rather than proposing a plausible one for them to agree to.

--- a/plugin/fabrik-project-onboarding/skills/onboard/SKILL.md
+++ b/plugin/fabrik-project-onboarding/skills/onboard/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: onboard
+description: Interviews someone about a software project as a whole — the problem it solves, who it serves, what is in and out of scope, the hard constraints, and the domain vocabulary — and writes it up as a project constitution that every later feature specification inherits. Use this at the start of a project, before any individual feature is specified, whenever someone says they want to onboard a project, kick off or start a new project, capture project goals or context, define scope, agree terminology, or record the ground rules and non-negotiables that all specs must respect. Also use it when an existing constitution needs revisiting because the project's goals or boundaries have shifted. This is about the software being built — not about configuring folders, instructions, or settings for a Cowork project, which is a different thing that happens to share the word "project".
+---
+
+# Project Onboarding
+
+Interview the person about the project as a whole and write the result to `.specify/memory/constitution.md`. Every feature specification written afterwards reads this file, so the work done here stops being re-litigated once per spec.
+
+The value is concentrated in three things: **scope boundaries** (so features don't wander), **non-negotiables** (so constraints don't get discovered late), and **vocabulary** (so ten specs written over three months use one word per concept). Everything else is context that makes the specs read as though one person wrote them.
+
+Run this once at the start of a project. Re-run it when goals or boundaries genuinely shift.
+
+## Who this is for, and what's out of bounds
+
+The person you're interviewing is a product manager, business owner, or domain expert. Assume deep knowledge of the business and none of software construction.
+
+Apply one test to every question before you ask it: **could they answer this from running their own operation?** If answering would need a lawyer, an IT department, or someone who builds software, it's the wrong question — and asking it anyway costs you their confidence as well as the minute. Rewrite it as something they've lived:
+
+| Don't ask | Ask |
+|---|---|
+| "Are there accessibility standards you must meet?" | "Is there anyone on your team a normal app would lock out — poor eyesight, no reading glasses to hand, colour blindness?" |
+| "What are your data residency requirements?" | "Is there anything here you'd be uncomfortable with being stored abroad?" |
+| "What systems must this integrate with?" | "Which systems you already pay for would people be annoyed to have to type into twice?" |
+| "What's the connectivity like?" | "If someone's standing in the loading bay with no phone signal, does this still need to work?" |
+| "What's your data retention policy?" | "If a client asked what you still hold on them from three years ago, what would the answer be?" |
+
+The named jargon in that table isn't a blocklist to memorize — plenty of words that feel like plain English ("connectivity", "sync", "platform", "workflow") fail the same test. Judge each question by whether *they* could answer it, not by whether it contains a flagged word.
+
+This document describes what the software should achieve and what bounds it. It does not describe how it gets built — no architecture, no tech stack, no data design, no testing or delivery process. All of that is deferred to the build stage, and stating it here creates a second source of truth that will drift.
+
+The test for whether something belongs: **would it change what a feature spec says?** A rule that every price is shown inclusive of tax changes specs. A rule about code review does not.
+
+### Separating the need from the solution
+
+Technical opinions will come up, because people who've been burned have views — and those views usually arrive welded to a real constraint. *"Last time the app needed wifi and the kitchen has none, so it has to be a native app, not a website"* is one sentence containing both a hard environmental constraint and a build decision.
+
+Split it. The constraint ("must work with no network in the kitchen") is exactly what topic 5 exists to capture and goes in **Constraints** or a principle; the conclusion ("native app, not a website") goes under **Technical notes**. Filing the whole sentence as an opinion loses the requirement, which is the most damaging thing this interview can do.
+
+Say the split out loud, and say it in a way that keeps their point intact: *"So the hard rule is it has to work with no signal in the kitchen — I'm writing that down as non-negotiable. Your hunch about how to achieve that, I'll pass to the build team as a note rather than a rule, so they can find the best way to meet it."* People accept this readily when they can see the requirement survived; they resent it when it looks like their experience was filed away.
+
+## Before starting
+
+Establish where the finished document goes: the connected folder if there's exactly one, or the one they name if several are connected.
+
+Then settle the **project root**, which every path below is relative to. If a `.specify/` folder already exists at that folder or anywhere above it, the folder containing it is the root — someone may have connected a sub-folder of a project that is already set up, and a second `.specify/` alongside the first would split the project in two. Otherwise the connected folder is the root, and `.specify/` gets created there.
+
+If **no** folder is connected, do not write to a temporary or scratch directory. Say so before you start — "I don't have access to a folder I can save this in, so I'll hand the finished document back to you to download" — and tell them how to connect one so it saves automatically next time. A temporary working directory almost always exists, especially when this runs in the cloud, and writing a 45-minute interview there looks like success while quietly throwing it away. Connected folders are the only durable destination.
+
+If `.specify/memory/constitution.md` already exists, read it and treat this as an amendment rather than a fresh start: show what's currently recorded, ask what's changed, and only reopen the parts that have moved. Bump the version and the amendment date rather than rewriting from scratch. People are far more willing to correct a wrong statement than to answer a blank question.
+
+## The interview
+
+Work through the seven topics below **one at a time**, in order. Each builds on the last — you can't bound scope before you know what the thing is, and you can't write a useful glossary before you've heard them talk.
+
+Two rules that matter more than the questions themselves:
+
+**Propose, don't interrogate.** Once you know enough to draft, lead each topic with a concrete proposal drawn from what they've already said and ask them to correct it. "Here's what I think your user types are — what have I got wrong?" gets better answers in less time than "who are your users?", because reacting is easier than generating.
+
+This technique has one failure mode, and it's serious enough to manage deliberately: **a proposal manufactures an opinion where none existed.** Propose "waste down from 4% to 3%" to someone with no target in mind and you'll get "yeah, call it 3" — and a number you invented is now in a document every spec inherits, indistinguishable from one they cared about. Three habits contain it:
+
+- **Never propose a specific number, name, or threshold they haven't implied.** Propose the *shape* and let them fill it: "you'd want waste down by some percentage over the year — what would make this worth doing?"
+- **Seed a deliberate error in list-shaped proposals.** Include one item you suspect is wrong. A proposal that comes back "yeah, that's right" wholesale returned nothing; the correction is the information.
+- **Track what they accepted without changing.** If a whole proposal came back unamended, it's yours, not theirs — say so at the end and ask them to confirm it specifically. Mark anything still shaky as uncertain in the file rather than letting it read as settled.
+
+**Play back what you heard in their words.** This document is only useful if they recognize it as theirs. Use their vocabulary, not a normalized version of it — that's the entire point of topic 6.
+
+Expect 30–45 minutes for a first run; topics 5, 6, and 7 carry most of it. Don't rush those three — they're where the value is. If time is short, it's better to stop after topic 6 and schedule the rest than to skim all seven, and it's fine to split this across two sittings. If they're giving short answers throughout, take the hint and draft harder from less: a thin constitution that's correct beats a thorough one they stopped reading.
+
+### 1. What is this and what's broken without it
+
+What the project is, and the problem it exists to solve. Push past the solution to the problem underneath — "we need an app for shift managers" is a solution; "managers can't see waste until the monthly P&L, by which point the money's gone" is a problem, and it's the one that tells a spec author which features matter.
+
+Ask what happens if nothing gets built. The answer usually reveals the real priority.
+
+### 2. Who it serves
+
+The distinct kinds of people who'll use it, what each needs from it, and roughly how many there are. Watch for roles that sound like one group but split under pressure — a "manager" who logs data during service and a "manager" who reviews it on Monday morning want different software, and finding that out here saves an argument in every spec.
+
+Note anyone affected who never touches the software. Their needs show up as requirements regardless.
+
+### 3. What success looks like
+
+Project-level outcomes, not feature-level ones. What has to be true in a year for this to have been worth doing? Push for something countable — a number, a percentage, a time. "Better visibility" isn't checkable; "site managers see yesterday's waste before today's service" is.
+
+Ask what they'd measure to know it's working, and whether that measurement exists today. **"We don't measure that at all" is a better answer than a number they've just made up**, and it belongs in the file — record it alongside the criterion as *(not currently measured)*. It tells the build team that establishing the baseline is part of the job, and it stops a fabricated target being treated as a commitment.
+
+Resist inventing precision here. A criterion the business already tracks is worth three that sound rigorous and rest on nothing.
+
+### 4. What's explicitly not in scope
+
+The highest-value question in the interview and the one people skip. Every project has adjacent things it could grow into; naming them now is what stops a spec quietly annexing one.
+
+Prompt with the obvious neighbours of what they've described, and ask directly: "should this ever do X?" A firm no is worth writing down. A "not in version one" is worth writing down differently — as deferred, with what would bring it back.
+
+Close the topic by stating the boundary from the inside as well: "so this project is about *X*, and everything else stays where it is today — right?" That confirms the **In scope** line rather than leaving you to infer it from what they excluded, and the boundary gets sharper when they hear it drawn in both directions.
+
+### 5. Hard constraints and non-negotiables
+
+Things no feature may violate. Cover each area below, since people rarely volunteer them — but ask in the operator's language, not the category's. The headings are for you; the questions beside them are roughly what to say.
+
+- **Rules they get audited on** — "what would an inspector or auditor pull you up on?" Food safety, allergens, employment law, tax. They'll know these cold; it's their job.
+- **Information that's sensitive** — "is there anything here you'd be uncomfortable with the wrong person seeing, or with being stored abroad?" Also: "how far back do you need to be able to look, and is anything you're required to keep?"
+- **Where it gets used** — "walk me through where someone actually stands when they'd use this." Kitchens, warehouses, and vans have no signal, wet hands, gloves, noise, and one shared device between six people. An office has none of that, and it's the environment software gets designed for by default.
+- **Systems already in place** — "which systems you already pay for would people be annoyed to have to type into twice?"
+- **People a default build would lock out** — "is there anyone who'd struggle with this — reading English, eyesight, anything?"
+- **Commercial commitments** — "is anything here fixed by a contract, a franchise agreement, or a supplier deal?"
+
+If an answer is genuinely beyond them — data residency and formal accessibility standards often are — don't press. Record what they did say and mark it as needing confirmation from whoever does own it. "Dana assumed UK-only; unconfirmed" is useful; a fabricated requirement is not.
+
+These become the constraints every spec inherits, and they're the ones most expensive to discover late — a constraint found during a build usually invalidates work already done.
+
+### 6. The words the project uses
+
+Capture the domain vocabulary in their words, with a definition for each. This is the single most useful artifact for whoever builds the software, and the person you're interviewing is the only one who can produce it.
+
+You'll have been collecting candidates through the whole conversation — the terms they used without explaining, because to them they're obvious. Play them back and ask for definitions. Chase three things specifically:
+
+- **Terms used interchangeably.** If "site", "store", "restaurant", and "location" have all appeared, ask which one is right. Pick one, record the others as "don't use".
+- **Terms that look ordinary but aren't.** Words like "cover", "shift", "waste", or "return" carry precise local meaning that an outsider will silently get wrong.
+- **Distinctions that matter.** If two things sound alike but must never be conflated, say so explicitly — that's a bug prevented.
+
+### 7. Principles
+
+Three to seven rules that every feature must honour. Derive them from what's already been said rather than asking cold — people struggle to state principles in the abstract but recognize them instantly.
+
+A good principle is falsifiable and constrains real decisions: "any action a manager takes during service must work with one hand and no network" rules things out. "We value quality" doesn't rule anything out and shouldn't be written down.
+
+When one smells like a slogan — "we're a people business", "quality first" — test it by asking what it would forbid. Put it concretely, since stating a rule's negative space is an abstract task: *"if the build team came back with X, would you send it back?"* If nothing gets sent back, it's a sentiment, and it dilutes the principles that mean something. Don't run this test on principles that already obviously constrain something; you'll just get the principle restated.
+
+Mark any that are genuinely absolute as **NON-NEGOTIABLE**.
+
+## Writing the file
+
+Write `.specify/memory/constitution.md`, creating `.specify/memory/` if needed.
+
+Keep the top-level headings exactly as below — `## Purpose`, `## Core Principles`, `## Product Context`, `## Scope & Constraints`, `## Technical notes`, `## Governance` — even where a section is thin, because that's the shape anything downstream looks for. Sub-headings within them are yours to drop: a project with no glossary worth recording is better off without a `### Glossary` heading than with one holding invented terms.
+
+```markdown
+# [PROJECT NAME] Constitution
+
+## Purpose
+
+[Two or three sentences: what the project is, the problem it solves, what happens if it isn't built.]
+
+## Core Principles
+
+### I. [Principle Name]
+
+[What it requires, and what it forbids. Mark NON-NEGOTIABLE where it genuinely is.]
+
+### II. [Principle Name]
+
+[...]
+
+## Product Context
+
+### Who this serves
+
+- **[User type]**: [what they need from it, roughly how many, where and how they use it]
+
+### Success looks like
+
+- [Countable project-level outcome] [*(not currently measured)* where no baseline exists today]
+
+### Glossary
+
+- **[Term]**: [Definition]. [Where relevant: "Not to be confused with X" or "Use this rather than Y, Z".]
+
+## Scope & Constraints
+
+### In scope
+
+- [What this project covers]
+
+### Out of scope
+
+- [What it does not cover] — [firm exclusion, or deferred with what would bring it back]
+
+### Constraints
+
+- **[Category]**: [The constraint, and where it comes from.]
+
+## Technical notes (deferred to build)
+
+*Not binding on specifications. Preferences and prior experience raised during onboarding,
+recorded for the build team to weigh.*
+
+- [Whatever was raised, attributed to why they raised it.]
+
+## Governance
+
+This constitution constrains every feature specification in this project. A specification that
+conflicts with it is wrong by default — if the constitution is what's wrong, amend it here first
+rather than making an exception in a spec.
+
+Amendments are made by the project owner, and this document should be revisited whenever the
+project's goals or boundaries shift.
+
+**Version**: [VERSION] | **Ratified**: [YYYY-MM-DD] | **Last Amended**: [YYYY-MM-DD]
+```
+
+A first run is version `1.0.0`, ratified and amended on today's date. On a later amendment, bump the version — patch for wording, minor for a new principle or constraint, major for a change that invalidates specs already written — update the amendment date, and keep the original ratification date.
+
+The version scheme is for the document's own bookkeeping. Don't explain it to them unless they ask — say "version 1.0, dated today" and move on. "Ratified" likewise: it means the date they agreed it, nothing more.
+
+## Finishing
+
+Show the finished constitution and ask them to read it once, properly. It's short, they're the only person who can catch what's wrong in it, and everything downstream inherits its mistakes.
+
+Three things to call out by name rather than leaving them to notice:
+
+- **Anything you drafted that they accepted without changing.** Name those items specifically and ask them to confirm each one — they carry your judgement, not theirs, and this is the last cheap moment to catch it.
+- **Anything recorded as uncertain**, including answers that need confirming from someone else.
+- **Anything deferred**, and what would bring it back.
+
+**Say where it was saved, in words they can act on.** They will go looking for this file, and by default they won't find it:
+
+> "I've saved this in your project folder, inside a folder called `.specify`. The dot at the front means your computer hides it in Finder and File Explorer — that's normal, and nothing's gone wrong. Just ask me to show you the project setup any time and I'll open it for you."
+
+Then point at what's next, as something they can say rather than something they must run: features get written up one at a time — they describe a feature in their own words and ask for it to be turned into a spec — and each one inherits this document automatically, so none of this has to be repeated.

--- a/plugin/fabrik-project-onboarding/skills/write-spec/SKILL.md
+++ b/plugin/fabrik-project-onboarding/skills/write-spec/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: write-spec
+description: Creates a new feature specification from a plain-language feature description, written for a product manager or business owner rather than an engineer, following GitHub Spec Kit's specify workflow. Writes a numbered specs/NNN-short-name/spec.md plus a requirements quality checklist, validates the spec against it, and asks up to three high-impact clarifying questions. Use this whenever someone wants to write, draft, start, or create a spec, specification, feature spec, PRD, or requirements document — and also when they describe a feature they want built and ask to "spec this out", "spec out a feature", "write this up properly", or "turn this into a spec". Trigger it even if they never say the words "spec kit" or "speckit".
+---
+
+# Create a Feature Specification
+
+Produce a feature specification a development team can build from, using GitHub Spec Kit's structure and quality bar. The specification describes **what** users need and **why** it matters — never how to implement it.
+
+The person using this is a product manager, business owner, or domain expert — deep knowledge of the business, none of software construction assumed. Write the spec for business stakeholders and keep the conversation in plain language. Never ask them a question only an engineer could answer, and don't use a technical term without defining it in the same sentence. Don't narrate file paths or internal steps as you go — but do say where the spec ended up when you're finished, so they can find it.
+
+## How to ask anything, anywhere in this skill
+
+This governs **every** question below, not just the clarifying questions in step 6:
+
+- **Always lead with a recommendation.** A neutral menu hands the decision back to someone who came here precisely because they don't know the options. Say what you'd do and why, in a sentence, and make agreeing cheap: "say yes and I'll take it."
+- **"You pick" / "I don't know" / "which is normal?" is an answer.** Take your recommendation and carry on — never stall waiting for a preference they don't have. Record the result under **Assumptions** as *your* guess, not as their decision.
+- **Never invent a specific number, threshold, name, or percentage they haven't given you or clearly implied.** Filling in structure is the job; manufacturing facts is not. See "Writing success criteria" for what to do when a figure is genuinely missing.
+- **Batch what you can.** Every separate round-trip costs the person patience they'd rather spend on the spec.
+
+## Where the work goes
+
+Specs live in a folder the engineering team can read. Before writing anything, establish the working folder:
+
+- If exactly one folder is connected to this session, use it.
+- If several are connected, ask which one to use — don't say "which one holds the specs", since on a first run none of them does.
+- If **no** folder is connected, say so plainly — "I don't have access to a folder I can save this in, so I'll hand these back to you to download" — and hand the files back instead. Everything below still applies: produce all three deliverables, at these relative paths, so they can be dropped into a project intact:
+  - `specs/NNN-short-name/spec.md`
+  - `specs/NNN-short-name/checklists/requirements.md`
+  - `.specify/feature.json` — note this is a *sibling* of `specs/`, not inside the feature folder, so handing back only the feature folder leaves it out
+
+A temporary working directory almost always exists, especially when this runs in the cloud, and treating one as the **destination** looks like success while quietly throwing the work away. That's the prohibition — staging files somewhere in order to hand them back is fine and necessary. What's forbidden is finishing, reporting success, and leaving the only copy somewhere that disappears when the session ends. Also tell the person how to connect a folder, so the next spec saves automatically.
+
+Then settle the **project root**, which is what every path below is relative to. There is exactly one, and it is never two:
+
+- If a `.specify/` folder already exists at the working folder, or anywhere above it, the folder containing that `.specify/` is the project root. Use it. Someone connecting a sub-folder of a bigger project — a single package inside a larger repository — must not get a second `.specify/` alongside the first, and must not get their specs filed somewhere the existing project can't see.
+- Otherwise the working folder is the project root, and `.specify/` gets created there.
+
+Paths, relative to the project root:
+
+- `specs/NNN-short-name/spec.md` — the specification
+- `specs/NNN-short-name/checklists/requirements.md` — the quality checklist
+- `.specify/feature.json` — pointer to the active feature, so the clarify skill and downstream engineering tooling can find it
+
+Because there is one root and everything hangs off it, `feature_directory` is always a plain `specs/NNN-short-name` with no prefix to compute. If you ever find yourself working out an offset between two folders, the root was resolved wrongly — go back and resolve it once, properly.
+
+`.specify/` and `specs/` are GitHub Spec Kit's own directory names. They are fixed by that format and have nothing to do with what this skill is called — never rename them to match the skill, and never invent variants.
+
+## Read the project constitution first
+
+If `.specify/memory/constitution.md` exists, read it before writing anything. It carries the project's scope boundaries, non-negotiable constraints, and agreed vocabulary, and this spec inherits all three:
+
+- **Use its glossary terms exactly.** If it says "site", write "site" throughout — never "store" or "location". Consistent vocabulary across a set of specs is most of what makes them usable together.
+- **Treat its constraints as settled.** Don't re-ask them, and never spend one of your three clarification markers on something it already answers.
+- **Check the feature against its scope boundaries.** If the description asks for something the constitution lists as out of scope, raise it before writing rather than after — that's a conversation about the project, not about this spec.
+
+If no constitution exists, say so **before** writing, not after — by the time the spec is written the vocabulary and scope boundaries have already been invented, and this first spec is usually the one that matters most. Offer the choice plainly and in one breath: setting the project up first takes about half an hour and every later spec inherits it, or you can write this spec now and set the project up afterwards.
+
+If they'd rather press on, carry on without a constitution — but at the end, tell them this spec was written before the project's shared vocabulary and boundaries existed, and that once the project is set up they can ask for this spec to be gone over again to reconcile the two.
+
+## Steps
+
+### First gate: is this a new feature, or a change to one that exists?
+
+Before anything else — before naming, numbering, or creating a folder — decide which of the two you're being asked for.
+
+If the request **modifies a spec that already exists** — a different priority, an extra user story, a term used wrongly, a requirement that isn't right — go straight to "Revising a spec you already wrote" below and **do not allocate a number**. "Add a user story about ordering", "make the ordering one P1, not P2", "that's not what I meant by site" are all revisions, and they arrive far more often in a later session than in the one that wrote the spec.
+
+Only continue into step 0 when they're describing a genuinely different feature.
+
+### 0. Pre-flight: one feature, and the two things worth knowing first
+
+Ask these together, in one message, each with a recommendation — not as three sequential round-trips. If the answer to all of them is obvious from the description, ask nothing and carry on.
+
+**Is this one feature?** Create exactly one feature per invocation. Before generating a name or creating any folder, check whether the description actually describes one feature or several.
+
+The test is **not** whether the parts are related — three things can all concern food waste and still be three features. The test is whether they could ship separately and be prioritized against each other. If each part could go live on its own and someone might reasonably want one before another, they're separate features.
+
+If it's several, say so in the person's own words and ask which comes first — "that's really three things: recording what gets binned, advising on over-ordering, and comparing sites against each other. Which matters most right now?" — then spec that one and offer to do the others afterwards.
+
+Do this before creating anything on disk. A folder created for the wrong feature burns its number permanently (numbers never get reused, see step 2) and leaves `.specify/feature.json` pointing at a directory nobody wanted.
+
+**Where is this used, and on what?** Never silently default the physical environment. Where is the person standing, and on what device, when they use this? A kitchen at the end of service means no signal, wet or gloved hands, noise, and one shared screen on a wall — and a spec that quietly assumes an office desk and a personal phone will be wrong in ways no checklist item catches. Recommend the reading you'd draw from their description and let them correct it. Skip this only when a constitution already answers it.
+
+**Is there a project set up?** If no constitution exists, this is where you say so — see "Read the project constitution first" above for what to offer. Fold it into the same message.
+
+If the feature description is empty, ask for it rather than inventing one.
+
+### 1. Generate a short name
+
+Extract a 2–4 word kebab-case name from the description. Prefer action-noun form; preserve technical terms and acronyms.
+
+- "I want to add user authentication" → `user-auth`
+- "Track waste from prep through service across all sites" → `waste-tracking`
+- "Let head office compare waste across all sites" → `cross-site-comparison`
+
+### 2. Create the feature folder
+
+Scan `specs/` for existing `NNN-*` folders and take **one higher than the highest number present**, zero-padded to three digits — not the lowest unused one. Gaps left by deleted or renamed features stay as gaps, so the numbers keep telling you the order features were specified. If `specs/` doesn't exist, or exists with no `NNN-*` folders in it, start at `001`.
+
+Create `specs/NNN-short-name/` and `specs/NNN-short-name/checklists/`, then write `.specify/feature.json` pointing at the folder you just made:
+
+```json
+{ "feature_directory": "specs/001-waste-tracking" }
+```
+
+This file names the *active* feature, so overwrite `feature_directory` if it already exists — but preserve any other keys in the file rather than replacing the whole thing, since other tooling may keep state there.
+
+`feature_directory` is always relative to the project root settled in "Where the work goes" — a plain `specs/NNN-short-name`, exactly as the example shows, with nothing prefixed to it. Downstream tooling resolves this path from the project root, and since `.specify/` sits at that root by construction, the two cannot disagree.
+
+### 3. Write the specification
+
+Read `references/spec-template.md` and use it as the structure. Preserve section order and headings, and replace every bracketed placeholder with concrete content. Optional sections that genuinely don't apply get removed entirely rather than left as "N/A"; the sections marked `*(mandatory)*` are always kept and always filled.
+
+`## Assumptions` is never removed, however detailed the description was, and even though the template carries no `*(mandatory)*` marker on it. It's the section that makes informed guessing safe, and the checklist item *"Dependencies and assumptions identified"* depends on it. Leave the template's markers exactly as they are — don't add a `*(mandatory)*` marker to Assumptions, since that would diverge from upstream.
+
+The template is scaffolding, and none of its instructions to *you* should survive into the finished spec. Remove all of these:
+
+- `<!-- ... -->` guidance comments
+- the `*Example of marking unclear requirements:*` line and the two illustrative FRs beneath it — they're samples, and leaving them in collides with your real requirement numbering
+- bracketed authoring notes like `[Add more user stories as needed, each with an assigned priority]`
+- any `---` rule left stranded by content you removed. The rules separate user stories, so keep one between each pair of stories you actually write and drop the rest
+
+Keep `*(mandatory)*` on the headings that carry it — the quality checklist checks that those sections are complete, so the marker has to survive. Drop conditional annotations like `*(include if feature involves data)*`: they're instructions about whether to include the section, and once you've decided to include it, they've done their job.
+
+Two title-block lines have a shape downstream tooling reads, so keep it exactly even though the content changes. The template has:
+
+```
+**Feature Branch**: `[###-feature-name]`
+**Input**: User description: "$ARGUMENTS"
+```
+
+Written out, with a real name and the person's own words, those become:
+
+```
+**Feature Branch**: `001-waste-tracking`
+**Input**: User description: "Track waste from prep through service across all sites"
+```
+
+The backticks around the branch name stay, and so do the `User description:` prefix and the quotes around it.
+
+Fill the header fields: feature name, `**Feature Branch**` set to `NNN-short-name`, today's date as `YYYY-MM-DD`, status `Draft`, and the person's original words in `**Input**`. Use `YYYY-MM-DD` for every date this skill writes, so the spec and the clarify skill's session headings agree.
+
+Then work in this order. This is the order to *author* in, not the order sections appear in the document — the template's own section order is authoritative, and Key Entities belongs under Requirements, above Success Criteria:
+
+1. Extract key concepts — actors, actions, data, constraints.
+2. Write **User Scenarios**, prioritized P1, P2, P3. Each story must be independently testable: if only that one story shipped, it would still deliver real value. This is what lets engineering slice the work into something shippable.
+3. Write **Edge Cases**. Ask yourself, in the person's own domain, what happens when someone forgets, does it twice, does it out of order, or stops halfway — and what happens when the thing being recorded doesn't fit the categories on offer. The checklist scores this section, so it has to be written deliberately rather than back-filled when a check fails.
+4. Write **Functional Requirements** — each testable and unambiguous.
+5. Write **Success Criteria** — measurable and technology-agnostic (see below).
+6. Identify **Key Entities** if the feature involves data.
+7. Record every default chosen under **Assumptions**. This is where informed guesses become visible and correctable, which is what makes guessing safe.
+
+**Never invent a specific number, threshold, name, or percentage the person hasn't given you or clearly implied.** Filling in structure is the job; manufacturing facts is not. A target like "cuts waste by 15% within six months" put into someone's mouth reads as their commitment and gets quoted back at them later — and if they never said they measure waste at all, it's fiction with a number attached.
+
+When a success criterion needs a figure nobody has supplied, write the *shape* of the measure and mark the figure as missing — or pick a criterion the business already tracks. One criterion resting on a number they actually know beats three that sound rigorous and rest on nothing. Written into the spec, without backticks, it reads:
+
+> Reduces food waste across sites by [NEEDS BASELINE]% within [NEEDS BASELINE] months *(not currently measured)*
+
+`[NEEDS BASELINE]` is not a `[NEEDS CLARIFICATION]` marker: it doesn't count against the cap of three, it doesn't block the *"No [NEEDS CLARIFICATION] markers remain"* item, and a criterion carrying one still satisfies *"Success criteria are measurable"* as long as the shape is measurable.
+
+### 4. Handle genuine unknowns
+
+Fill gaps with informed guesses from context and industry standards, and document them under Assumptions. Reserve `[NEEDS CLARIFICATION: specific question]` markers for decisions that truly can't be defaulted:
+
+- the choice significantly changes scope or user experience, **or**
+- multiple reasonable readings exist with materially different implications, **and**
+- no sensible default exists.
+
+Cap this at **three markers**. More than three usually means guesses are being avoided rather than real gaps surfaced — prioritize by scope > security/privacy > user experience > technical detail, and default the rest. Every question spent on something guessable is a question not spent on something that matters.
+
+Things with obvious defaults, which shouldn't be asked about, stated as business needs rather than technical choices: data retention ("records kept for the current financial year" — the industry norm for the domain), responsiveness ("fast enough not to slow someone down mid-task"), and error handling ("a plain message explaining what went wrong and what to do next").
+
+Don't default anything that names a technology. Authentication *methods*, integration *patterns*, storage and hosting choices are implementation, and an assumption recording one will fail the checklist item *"No implementation details (languages, frameworks, APIs)"* in step 5 and have to be deleted again. Record the need — "only staff on shift at that site can enter waste for it" — never the mechanism.
+
+**The physical environment of use is never silently defaulted** — but it's asked in step 0's pre-flight, before the spec is written, not here. If you reach this point without knowing it, that's a step 0 you skipped.
+
+### 5. Create and run the quality checklist
+
+Write `specs/NNN-short-name/checklists/requirements.md` from the block below, replacing `[FEATURE NAME]` and `[DATE]` with the real values. Every other bracketed string in the block — notably `[ ]`, `[x]`, and the literal `[NEEDS CLARIFICATION]` inside a checklist item — is part of the checklist's own text and stays exactly as written.
+
+```markdown
+# Specification Quality Checklist: [FEATURE NAME]
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: [DATE]
+**Feature**: [../spec.md](../spec.md)
+
+## Content Quality
+
+- [ ] No implementation details (languages, frameworks, APIs)
+- [ ] Focused on user value and business needs
+- [ ] Written for non-technical stakeholders
+- [ ] All mandatory sections completed
+
+## Requirement Completeness
+
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [ ] Requirements are testable and unambiguous
+- [ ] Success criteria are measurable
+- [ ] Success criteria are technology-agnostic (no implementation details)
+- [ ] All acceptance scenarios are defined
+- [ ] Edge cases are identified
+- [ ] Scope is clearly bounded
+- [ ] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [ ] All functional requirements have clear acceptance criteria
+- [ ] User scenarios cover primary flows
+- [ ] Feature meets measurable outcomes defined in Success Criteria
+- [ ] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before clarification or planning
+```
+
+The sixteen checklist items are kept word-for-word identical to upstream Spec Kit, in the same order, so the file means the same thing to anyone downstream. Don't add, remove, reword, or reorder them. Two things outside the graded items differ from upstream deliberately: the `**Feature**` line links to the spec rather than carrying upstream's bare placeholder, and the `## Notes` bullet says "before clarification or planning" where upstream names its slash commands — this reader has no way to run those. Four items need a consistent reading:
+
+- *"No implementation details leak into specification"* (Feature Readiness) and *"No implementation details (languages, frameworks, APIs)"* (Content Quality) are differently worded but test the same thing. Evaluate once, tick both the same way. The denominator stays 16 — it counts checkboxes, not independent judgments.
+- *"Feature meets measurable outcomes defined in Success Criteria"* can't mean the built feature at this stage, since nothing is built. Read it as: every success criterion is attributable to a user story in this spec — no criterion measures something the spec doesn't deliver, and no story ships with nothing measuring it.
+- *"All functional requirements have clear acceptance criteria"* — the template attaches acceptance scenarios to user stories, not to individual requirements. Read it as: every functional requirement is exercised by at least one acceptance scenario somewhere in the spec. A requirement no scenario touches is one nobody can sign off.
+- *"Success criteria are measurable"* is satisfied when the **shape** of the measure is measurable, even where the figure itself is still `[NEEDS BASELINE]`. Tick it, and name the outstanding baselines in the Finishing report instead. The alternative — treating it as a failure — has exactly one available repair, which is inventing the number you're forbidden to invent, so it would burn all three repair passes and still fail.
+
+Evaluate each item against what was actually written, quoting the relevant spec text to yourself as evidence rather than trusting intent. A checklist ticked from memory of having meant to do the thing is worth nothing.
+
+**Write the result into the file.** Save `requirements.md` with `[x]` against every item that passes and `[ ]` against every item that doesn't. The checkbox state is durable state, not a note to yourself: the clarify skill compares the marks before and after its own run, and downstream tooling reads them as a gate. A checklist left entirely unticked reads as a spec that failed every check.
+
+Work the results in this order:
+
+1. **Fix what's fixable first.** For every failing item other than the clarification-marker one, correct the spec and re-check. Allow up to three passes. Doing this before asking questions matters — the questions in step 6 should be about the spec as it now stands, not a draft you already know is wrong.
+
+   Keep the running record of what failed and what you changed in your **reply to the person**, not in the file. Upstream's `## Notes` section is a single fixed bullet that downstream tooling reads as part of the gate; appending a repair log to it changes a machine-read file into a scratchpad. Leave the `## Notes` section exactly as the block above has it.
+2. **Then handle the markers.** Leave *"No [NEEDS CLARIFICATION] markers remain"* unticked and go to step 6. This item is expected to fail on the first pass — leaving up to three markers is the design, not a defect — and it gets ticked once the answers are written in. Report the count honestly (e.g. "15 of 16, pending your answers below") rather than pre-ticking it.
+3. **If everything passes and no markers remain**, skip step 6 entirely and go straight to Finishing.
+
+### 6. Ask the clarifying questions
+
+Present all outstanding questions together (maximum three, numbered Q1–Q3), then wait for answers to all of them. Batching them respects the person's time and lets them see the whole decision surface at once.
+
+Every question must be answerable from the person's own knowledge of how their business runs. If answering it would require knowing how software gets built, it isn't a question for them — default it and record the default under Assumptions instead.
+
+Take a position. A neutral menu hands the decision back to someone who came here precisely because they don't know the options, and "you pick" is the most likely reply. Recommend one, say why in a sentence, and make agreeing the cheapest possible action:
+
+```markdown
+**Q1: [Topic]**
+
+In the spec right now: "[quote the relevant line]"
+
+**[The specific question, in plain language]?**
+
+**Why it matters**: [one sentence on what changes depending on the answer]
+
+| Option | Answer | What it means |
+|--------|--------|---------------|
+| A      | [First suggested answer] | [What this means for the feature] |
+| B      | [Second suggested answer] | [What this means for the feature] |
+| C      | [Third suggested answer] | [What this means for the feature] |
+| Custom | Something else | Tell me in your own words |
+
+**Recommended: [X] — [why, in one line].** Say "yes" and I'll take it.
+```
+
+Keep the tables well-formed — spaces around cell content, at least three dashes in the separator row — so they render.
+
+Number the questions `Q1`, `Q2`, `Q3` and use that form in the heading too, so what you call them matches what they're labelled.
+
+Handle the three realistic replies:
+
+- **An answer, or "yes" / "the recommended one"** — take it, and record it as the person's decision.
+- **"You pick" / "I don't know" / "which is normal?"** — take your recommendation, and record it under **Assumptions** as your guess, not under Clarifications as their answer. The distinction matters: the next person to read the spec needs to know which decisions the business actually made.
+- **"Not yet"** — leave the markers in place and say plainly which decisions are still open and that they can be settled later without redoing anything.
+
+When answers come back, replace each marker with the chosen answer, save the spec, and re-run the checklist — including the marker item, which should now pass.
+
+A `[NEEDS BASELINE]` figure the business plausibly knows is a good candidate for one of your three questions — ask what they currently measure. If they don't track it at all, leave the marker, record it under Assumptions, and say so at the end; that's a real answer, not a gap.
+
+Record the exchange in the spec under `## Clarifications`, placed after the title block and immediately before the first `##` section, with a `### Session YYYY-MM-DD` subheading — the same placement the clarify skill uses, so the two maintain one consistent section rather than two competing ones. One bullet per question **the person actually answered**, in the form `- Q: <question> → A: <answer>`. A question they handed back to you produces an Assumptions entry and no Clarifications bullet — that distinction is the whole point, and without it a decision the business actually made is indistinguishable from a guess.
+
+## Revising a spec you already wrote
+
+"Add a user story about ordering", "make the waste one P1, not P2", "that's not what I meant by site" — these are edits to the spec that already exists, not requests for a new one.
+
+Find the spec the change belongs to — `.specify/feature.json`'s `feature_directory` if it covers the feature being changed, otherwise the `specs/NNN-*` folder that does, asking which they mean if it's genuinely unclear. Session and conversation are irrelevant: a revision the next morning is still a revision.
+
+Edit that spec in place: make the change, re-run the checklist, and report what moved. Do **not** allocate a new `NNN` number, create a second folder, or repoint `feature.json` — that burns a number, splits one feature across two specs, and leaves the person's earlier answers behind in the first one.
+
+Only start a new spec when the person is describing a genuinely different feature.
+
+## Writing success criteria
+
+Success criteria are the part most specs get wrong. They must be verifiable by someone who knows nothing about the implementation.
+
+Good — measurable, user-facing, technology-agnostic:
+
+- "Users can complete checkout in under 3 minutes"
+- "95% of searches return results in under 1 second"
+- "Cuts end-of-shift reconciliation time by 40%"
+
+Bad — leaks implementation:
+
+- "API response time under 200ms" → say "users see results instantly"
+- "Database handles 1000 TPS" → state the user-facing volume instead
+- "Redis cache hit rate above 80%" → not a user outcome at all
+
+## Staying out of implementation
+
+The spec answers what and why. It doesn't name languages, frameworks, databases, APIs, or code structure. When the description already contains technical choices, capture the *need* behind them in the spec and note the stated preference under Assumptions — the constraint survives without the spec turning into a design document.
+
+Don't embed extra checklists inside the spec. `checklists/requirements.md` is the only one this creates.
+
+## Finishing
+
+Report back in plain language:
+
+- **A one-line summary** of what the spec covers.
+- **Checklist status**, as a count of what genuinely passes right now — "16 of 16 quality checks passing", or "15 of 16 — the last one clears once you've answered the questions above".
+- **Where it was saved**, in words they can act on. Name the folder, and warn them about the hidden one: "it's in your project folder under `specs/001-waste-tracking`. There's also a folder called `.specify` holding the project's settings — the dot at the front means your computer hides it in Finder and File Explorer, so don't worry if you can't see it. Ask me any time and I'll open either for you." If there was no folder to save into, say that instead — what you're handing back, and how to connect a folder so next time it saves by itself.
+- **The assumptions, in the chat, not just in the file.** List every default you chose, flagged as yours: *"These are my guesses, not your words — tell me any that are wrong."* Call out separately any figure left as `[NEEDS BASELINE]`, and say plainly that it's waiting on a number they'd have to know. This is the whole reason guessing is safe rather than reckless, and it doesn't work if it lives in a file nobody opens. Keep it short — a handful of bullets, not the full section pasted back.
+- **What happens next**, described as something they can say rather than something they must run: "if you want, I can go back over this and tighten anything vague — just ask", or "this is ready to hand to whoever's building it." Never tell them to run a command, a skill, or a stage; they have no way to start one.
+
+Say plainly that the spec is a draft meant to be argued with, and that changing it later costs nothing.

--- a/plugin/fabrik-project-onboarding/skills/write-spec/references/spec-template.md
+++ b/plugin/fabrik-project-onboarding/skills/write-spec/references/spec-template.md
@@ -1,0 +1,131 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`
+
+**Created**: [DATE]
+
+**Status**: Draft
+
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Assumptions
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right assumptions based on reasonable defaults
+  chosen when the feature description did not specify certain details.
+-->
+
+- [Assumption about target users, e.g., "Users have stable internet connectivity"]
+- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
+- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
+- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]


### PR DESCRIPTION
Adds **the spec-authoring plugin** to the handarbeit plugin marketplace. It is **not installed with Fabrik** and is not part of the engine — it's an optional tool people can install on its own.

Three skills that let a product manager or business owner write GitHub Spec Kit specifications in Claude Cowork or the desktop app, with no terminal, git, or engineering background. Output is a standard `specs/NNN-feature/` folder plus `.specify/memory/constitution.md`, which can be handed to Fabrik — or to any development team — to build from.

Adapted from [github/spec-kit](https://github.com/github/spec-kit) (MIT). Attribution and a full account of what was kept, removed, renamed and changed is in `NOTICE.md`.

## The three skills

| Skill | What it does |
|---|---|
| `onboard` | A 30–45 minute interview about the project as a whole, written up as a constitution every later spec inherits |
| `write-spec` | Turns a plain-language feature description into a structured spec plus a quality checklist |
| `clarify` | Finds what's vague, asks up to five targeted questions one at a time, writes each answer back into the spec |

## Scope

Ten files: the plugin directory, and one added entry in `marketplace.json` so it can be installed. Nothing else in the repo is touched — no engine code, no release tooling, no existing plugin.

## Design constraints held throughout

- **Spec authoring only.** `plan`, `tasks`, `analyze` and `implement` are out of scope and were deliberately not ported.
- **Never an engineer-only question**, and no technical term used without defining it in the same sentence.
- **Byte-compatible with upstream.** The sixteen checklist items are verbatim and in upstream order, `spec-template.md` is byte-identical to upstream `main`, and `.specify/` and `specs/NNN-name/` paths are unchanged — so anything consuming a Spec Kit folder works unchanged.
- **No developer tooling at runtime.** The skills invoke no shell, `gh`, `jq`, or CLI of any kind; they only read and write files in a folder the user connected.

## Naming

Upstream's `specify` became **write-spec**, so it doesn't read as a variant of the unrelated `fabrik-specify` pipeline skill (which operates on an already-filed issue). The two never load into the same context — `fabrik-workflows` is embedded and loaded into engine-spawned workers, this plugin is marketplace-installed into a human's session — but the distinct name removes the ambiguity for anyone reading the repo.

## How this was validated

Each skill was run through adversarial dry-run subagents playing both interviewer and stakeholder, then fixed, then re-verified the same way. Among what that found:

- **Silent data loss.** Both `onboard` and `write-spec` resolved the output folder as "…use an ordinary working directory if none is connected" *before* the download fallback. A temp directory essentially always exists in a cloud session, so the fallback was unreachable and a 45-minute interview was written somewhere ephemeral and lost.
- **A step instructing what a later step must delete.** `write-spec` told you to default the authentication method while its own checklist forbids implementation details — a guaranteed wasted repair pass every run.
- **A graded section nothing wrote.** The checklist scores "Edge cases are identified"; no step authored them.
- **Manufactured agreement.** A dry-run produced "reduces food waste by 15% within six months" from a stakeholder who never said they measure waste. Now guarded, with a `[NEEDS BASELINE]` convention.
- **The plugin's own rule broken in its own output.** `clarify`'s coverage summary printed raw taxonomy categories at a non-technical reader.
- **Control flow that never reached its own fixes.** The re-verification pass found new material appended below the step flow that decided whether it ran — most seriously a revise path that allocated a new feature number before it was ever read.

Review feedback from this PR also fixed a `feature_directory` path bug (two divergent base directories when someone connects a sub-folder of a project that already has `.specify/` at its root — now resolved by settling a single project root in all three skills) and a troubleshooting entry that sent users hunting for their spec in the hidden `.specify` folder rather than the visible `specs/`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass
- [x] `marketplace.json` and the plugin manifest parse; every skill directory name matches its frontmatter `name`
- [x] Sixteen checklist items verbatim; `spec-template.md` md5-identical to upstream `github/spec-kit@main`
- [ ] First real-user run — the intended next step, and the best source of remaining fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEECnu53jBenQA7yxu3jS8