### PR TITLE
Attribute plugins to handarbeit.io

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,8 +3,8 @@
   "name": "fabrik",
   "description": "The Fabrik plugin marketplace — ambient awareness of Fabrik (a GitHub-Project-driven SDLC pipeline orchestrator) for your interactive Claude Code session.",
   "owner": {
-    "name": "Tenacious Ventures",
-    "url": "https://github.com/handarbeit/fabrik"
+    "name": "handarbeit.io",
+    "url": "https://handarbeit.io"
   },
   "plugins": [
     {
@@ -19,8 +19,8 @@
       },
       "homepage": "https://fabrik.handarbeit.io",
       "author": {
-        "name": "Tenacious Ventures",
-        "url": "https://github.com/handarbeit/fabrik"
+        "name": "handarbeit.io",
+        "url": "https://handarbeit.io"
       }
     },
     {

--- a/plugin/fabrik-workflows/.claude-plugin/plugin.json
+++ b/plugin/fabrik-workflows/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "description": "SDLC stage workflow skills for the Fabrik pipeline orchestrator. Provides expertise for each pipeline stage: Specify, Research, Plan, Implement, Review, and Validate.",
   "author": {
-    "name": "Tenacious Ventures",
-    "url": "https://github.com/handarbeit/fabrik"
+    "name": "handarbeit.io",
+    "url": "https://handarbeit.io"
   },
   "homepage": "https://github.com/handarbeit/fabrik",
   "repository": "https://github.com/handarbeit/fabrik"

--- a/plugin/fabrik/.claude-plugin/plugin.json
+++ b/plugin/fabrik/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "version": "0.2.2",
   "description": "Ambient awareness of Fabrik (the GitHub-Project-driven SDLC pipeline orchestrator) for the human's interactive Claude Code session. Turns Claude into a product-management buddy and supervisor for projects that use Fabrik to automate issue processing.",
   "author": {
-    "name": "Tenacious Ventures",
-    "url": "https://github.com/handarbeit/fabrik"
+    "name": "handarbeit.io",
+    "url": "https://handarbeit.io"
   },
   "homepage": "https://fabrik.handarbeit.io",
   "repository": "https://github.com/handarbeit/fabrik"


### PR DESCRIPTION
The marketplace owner block and the `fabrik` and `fabrik-workflows` manifests all credited "Tenacious Ventures", with an author URL pointing at the GitHub repo. Credit handarbeit.io instead, and point the author URL at that site so the author block is internally coherent.

Four author blocks, eight lines, three files. the spec-authoring plugin already reads handarbeit.io from #1609, so after this every plugin and the marketplace itself agree.

## What is deliberately not changed

`repository` and the marketplace `source.url` still point at `github.com/handarbeit/fabrik`. Those are clone URLs — retargeting them at the website would break installs.

## One consequence worth knowing

`fabrik-workflows` is embedded in the binary via `plugin/embed.go`, so changing its manifest **moves the embedded plugin fingerprint**.

No action is needed. `scripts/cut-release.sh` recomputes the hash at release time and appends it to `plugin/known_embedded_versions.go` if it isn't already recorded. Flagging it only because it means this PR is not quite as inert as an eight-line metadata diff looks — it does change embedded binary content.

## Test plan

- [x] All three JSON files parse
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass
- [x] No occurrence of "Tenacious" remains anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEECnu53jBenQA7yxu3jS8