### PR TITLE
test: wire the sim bed in as a fast pre-gate — not a replacement for live e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,26 @@ jobs:
       - name: backoff-detection regression test (#1527)
         run: bash scripts/e2e/backoff_detection_test.sh
 
+      # R1's pre-gate (scripts/e2e/run.sh's run_pregate, #1454) exists so a
+      # live-gate run refuses to spend GraphQL/Claude budget on a sim/wire-
+      # contract-layer failure the free layers already caught. Regression
+      # coverage for its exit-code contract and call ordering, following the
+      # same pattern as the backoff-detection test above: sources run.sh for
+      # the function definitions only (the sourcing guard prevents an actual
+      # gate run) and drives it entirely via a PATH-shadowed fake `go`
+      # binary, so no real (multi-minute) test run and no bed/token/network
+      # dependency.
+      - name: pre-gate regression test (#1454)
+        run: bash scripts/e2e/pregate_test.sh
+
+      # cut-release.sh's flag parsing — in particular --skip-integration's
+      # validation (R2, #1454) — sourced and exercised directly via
+      # parse_args(), never reaching main() (the real publish sequence). No
+      # bed, network, git remote, or publish path touched; see that script's
+      # own dispatch-guard comment for why sourcing it here is safe.
+      - name: cut-release flag/gate regression test (#1454)
+        run: bash scripts/cut_release_gate_test.sh
+
       # ADR citation integrity. ADRs are numbered after their originating
       # issue (CLAUDE.md's "ADR numbering"), so issue and ADR numbers share
       # one namespace and "ADR-1303" vs "#1303" is a one-token, invisible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,29 @@ go test -race ./...      # Run with race detector
 go vet ./...             # Lint
 ```
 
+### Four test layers (unit → sim e2e → wire-contract → live e2e)
+
+The sim bed is a fast, free **pre-gate** — it is never a replacement for the live
+integration suite, which has no substitute and is never reduced. See
+`adrs/1454-sim-pre-gate-not-replacement.md` for the full decision.
+
+| Layer | Where | Runs |
+|---|---|---|
+| `go test ./...` (unit) | repo-wide | every PR |
+| sim e2e (`tests/sim`) | scenario-driven, deterministic, `-race`-clean, $0 tokens | every PR — no build tag, already inside `go test -race ./...`; also `scripts/sim/run.sh` for on-demand runs |
+| github wire-contract tests (`github/wire_contract_test.go` + `github/testdata/`) | schema validation + recorded fixtures | every PR — no build tag, already inside `go test -race ./...` |
+| live e2e (`tests/e2e`, `-tags e2e`) | real Claude, real review bots, real GitHub, real merge-queue semantics | release-gate only — CI compiles it but never runs it; `scripts/e2e/run.sh` (standalone, or invoked from `scripts/cut-release.sh`) is the only thing that executes it, before every release |
+
+`scripts/e2e/run.sh` refuses to spend live budget (bed preflight, build, or any live
+GitHub/Claude call) until the sim suite and the wire-contract tests pass first —
+see its `run_pregate`. `scripts/cut-release.sh` mirrors that ordering and makes the
+live suite mandatory by default; `--skip-integration=<reason>` is a loud,
+release-notes-recorded escape hatch, never a silent skip. See `tests/sim/README.md`
+and `tests/e2e/README.md` for the full detail, including each layer's blind spots
+(the sim's inability to see GitHub wire correctness, most prominently) and the
+fidelity-drift policy: any live-e2e failure the sim passed is a fidelity bug in the
+sim, fixed there as well as in the engine.
+
 ## Documentation bundle (docs/llms-full.txt)
 
 When you modify any of the canonical doc pages — `docs/USER_GUIDE.md`, `docs/state-machine.md`, `docs/stage-lifecycle.md`, or `docs/positioning.md` — you MUST regenerate `docs/llms-full.txt` in the same commit:

--- a/adrs/1454-sim-pre-gate-not-replacement.md
+++ b/adrs/1454-sim-pre-gate-not-replacement.md
@@ -1,0 +1,254 @@
+# ADR 1454: The Sim Bed Is a Pre-Gate, Not a Replacement for Live E2E
+
+**Date**: 2026-08-15
+**Status**: Accepted
+**Issue**: #1454 — Wire the sim bed in as a fast pre-gate — not a replacement for live e2e
+
+## Context
+
+#1449–#1453 built a deterministic sim bed (`tests/sim`) that ports the live e2e
+state-machine scenarios (#1450), adds recovery/settle-scan coverage the live bed
+structurally cannot provoke on demand (#1451), adds merge-train coverage with real git
+assembly and per-SHA bisection (#1452), and adds `github/` wire-contract tests validating
+every GraphQL query/mutation against GitHub's real schema (#1453). None of that changed
+the release path: `scripts/e2e/run.sh` still ran the live suite as the sole integration
+gate with no cheaper check in front of it, and `scripts/cut-release.sh` had no notion of
+the live suite at all — `tests/e2e/README.md` still described a two-layer flow with a
+`cut-release.sh --integration-check` note marked "suggested, not yet wired."
+
+The issue that produced this chain originally floated a stronger idea: that the sim bed
+might eventually earn the right to retire some live scenarios. That premise is withdrawn.
+It is not "not yet" — it is a **no**. Real Claude, real review bots, real GitHub wire
+behaviour, and real merge-queue semantics have no substitute, and nothing the sim
+demonstrates changes that. What the sim actually earns is narrower and still valuable: a
+free, fast sanity check at the point where committing to the cost of a full live run
+would be premature.
+
+## Decision
+
+### Four layers, not two, with an explicit ordering
+
+```
+go test ./...            unit
+        v
+sim e2e                   fast sanity check: full pipelines, failure/timeout/restart/
+                          merge-train paths — seconds, $0 tokens, -race (tests/sim)
+        v
+github contract tests     wire-format truth: schema + recorded fixtures (github/)
+        v
+live e2e (full)           integration truth: real Claude, real bots, real GitHub —
+                          runs in full, before every release, permanently (tests/e2e)
+```
+
+Each layer answers a different question, and each has a named blind spot:
+
+| Layer | Answers | Cannot see |
+|---|---|---|
+| `go test ./...` | Does the unit under test behave correctly in isolation? | Cross-stage pipeline behavior, GitHub wire correctness, real Claude |
+| sim e2e (`tests/sim`) | Is the state machine obviously broken — full pipelines, failure/timeout/restart/merge-train paths? | GraphQL/REST wire correctness (`simgh` is a hand-modeled fake — see `tests/sim/simgh/FIDELITY.md`); real Claude behavior; real review-bot timing |
+| github wire-contract tests (`github/`) | Is every query/mutation this codebase sends schema-valid against GitHub's real API? | Whether the *logic* built on top of a schema-valid query is correct — a query can be shape-valid and semantically wrong; runtime behavior at all |
+| live e2e (`tests/e2e`) | Does this actually work against real GitHub, real Claude, and real review bots? | Nothing structural — this is the layer with no substitute, which is exactly why it is never reduced |
+
+The sim's blind spot is the most important one to keep saying out loud: **wire-format
+correctness is structural and permanent**, closed only by the wire-contract tests and by
+live e2e itself. `tests/sim/README.md` already states this plainly ("read 'the sim
+scenarios pass' as 'the state machine behaves, assuming the wire layer does what we
+think'") — this ADR is the layering decision that framing sits inside.
+
+### The sim is a pre-gate, never a releasability verdict
+
+The sim answers "is the state machine obviously broken?" in seconds, for nothing, so that
+live budget — Claude tokens, GraphQL quota, review-bot turnaround — is spent only on a
+candidate that has already cleared the cheap checks. It never answers "is this
+releasable." Only the live bed does that, and it always runs, in full, before a release
+(mechanism below).
+
+### R1 — `scripts/e2e/run.sh` refuses to spend live budget on a caught bug
+
+`scripts/e2e/run.sh` gained `run_pregate`, called as the very first statement in its
+dispatch guard — strictly before bed preflight, before any build, before any live
+GitHub/Claude call. It runs `scripts/sim/run.sh --all` (the sim scenarios plus `simgh`'s
+own model tests) and `go test -race ./github/...`, and aborts with a new, distinct exit
+code (`PREGATE_FAILED_EXIT=5`, continuing the script's existing `3`/`4` convention) on
+either failure. The ordering — not a runtime check inside the suite — is what proves "no
+live call is made on a pre-gate failure"; `scripts/e2e/pregate_test.sh` pins that ordering
+structurally (a grep-based check that `run_pregate` precedes `prepare_bed_and_reset` in
+the dispatch guard) in addition to exercising the exit-code contract against a
+PATH-shadowed fake `go` binary.
+
+The sim and wire-contract layers are re-run here even though both already run
+unconditionally inside `go test -race ./...` on every PR (R7, below) — deliberately, not
+redundantly: `scripts/e2e/run.sh` is regularly invoked standalone, and must never assume
+unit tests were "just run" by whoever invoked it.
+
+### R2 — the live suite is mandatory by default; the one skip flag is loud and recorded
+
+`scripts/cut-release.sh` gained two new steps: an unconditional, never-skippable "sim +
+wire-contract pre-gate" (mirroring `run_pregate`'s reasoning — cheap, so no reason to ever
+skip it) and a "live e2e integration gate" that invokes `scripts/e2e/run.sh` by default.
+
+The requirement text left two options open and asked for an explicit choice:
+
+- **(a)** no skip flag exists at all — the live suite always runs before a release, full
+  stop; or
+- **(b)** a skip flag exists only as a loudly-labelled operator escape hatch, and using it
+  records in the release notes that integration was skipped.
+
+**Decision: (b).** A pure "no flag at all" forces every iteration on `cut-release.sh`
+itself — or a genuine emergency release — through a multi-hour live run with no sanctioned
+way out, which in practice invites someone hacking around the script instead: commenting
+out the step, running an old binary, or some other unsanctioned bypass that leaves no
+trace at all. That is a worse outcome than one sanctioned, loud, self-documenting escape
+hatch. `--skip-integration=<reason>` keeps the *default* mandatory — matching
+`--skip-tests`'s existing "last resort" precedent in this exact script — while a bare
+`--skip-integration` (no reason) is a hard usage error, never a silent skip. When used, it
+prints a loud warning banner to stderr and inserts a recorded line into the release notes'
+`## Internal` section (via the new `insert_notes_line` helper, shared with the pre-existing
+plugin-bump changelog line) — so anyone reading the shipped release notes sees explicitly
+that integration was skipped and why. This satisfies the requirement's own hard
+constraint: "a `--skip-integration` flag that silently produces an unvalidated release is
+not an acceptable outcome either way" — the flag exists, but silence does not.
+
+The live-suite step is positioned after build+test and before the release-notes commit —
+not bolted on at the end — so a live-suite failure aborts before anything is committed or
+pushed, and the skip-reason line (when present) folds into the same release-notes commit
+rather than requiring a second push. Since `scripts/e2e/run.sh` fetches `origin/main` by
+default and this step runs immediately before that commit is pushed and tagged, it tests
+exactly the commit about to ship.
+
+`scripts/e2e/run.sh`'s exit codes are branched on explicitly rather than treated as a
+single pass/fail: `3` (GraphQL budget exhausted — the verdict cannot be trusted, rerun
+later) and `5` (the live script's *own* pre-gate failed, which is unexpected since
+`cut-release.sh`'s own pre-gate step already passed against the same tree — investigate
+the discrepancy) both produce a distinct, actionable message; anything else is treated as
+a real regression, with an explicit instruction not to retry with `--skip-integration` to
+work around it.
+
+### R4 — the fidelity-drift policy
+
+The sim's value as a pre-gate is entirely contingent on this rule, and it gets more
+important as the sim's role grows, not less: a sim that passes what live would fail is
+actively misleading — worse than no gate at all, because it manufactures false
+confidence exactly where confidence is being relied on to save a live run.
+
+**Rule:** any live-e2e failure that the sim passed is a fidelity bug in the sim, and is
+fixed there as well as in the engine.
+
+**Procedure**, recorded in `tests/sim/README.md` (canonical) and referenced from
+`tests/e2e/README.md`, and made a checklist step in
+`.claude/skills/cut-release/SKILL.md` so it does not depend on someone remembering:
+
+1. File a fidelity issue describing the divergence — what live e2e caught that the sim
+   didn't, and why the sim's model let it through.
+2. Add the scenario to `tests/sim` so the same class of bug cannot silently pass here
+   again.
+3. Update `tests/sim/simgh/FIDELITY.md` — the existing, permanent ledger of every place
+   `simgh` knowingly departs from real GitHub — with the divergence found and what it
+   cost. This document already exists and already states its own thesis precisely: "the
+   failure mode a fake introduces is not a red test — it is a **green** one."
+
+This policy does not retroactively cover every possible gap (the sim is a fake by
+construction, and `simgh/FIDELITY.md`'s "Absent"-labeled entries are known, accepted
+gaps) — it covers the specific, high-signal case where live e2e actually caught something
+in production use that the pre-gate should have caught first.
+
+### R7 — CI placement: confirmed, not built
+
+Per the issue's own framing, this was mostly already true:
+
+- **`go test ./...`** — every PR, unconditionally. Unchanged by this issue.
+- **sim e2e (`tests/sim`)** — carries no `sim` build tag (confirmed:
+  `grep -rn "//go:build" tests/sim/*.go` returns nothing) and therefore already runs
+  inside `go test -race -timeout 5m ./...` in `.github/workflows/ci.yml`, on every PR.
+  Indistinguishable in CI output from ordinary unit tests — this issue's
+  `scripts/sim/run.sh` gives it a distinct, nameable identity for manual/pre-gate use, but
+  does not change how CI itself invokes it.
+- **github wire-contract tests (`github/wire_contract_test.go` + `github/testdata/`)** —
+  same situation: no build tag (`package github`, not `github_test`), already inside
+  `go test -race ./...`, already on every PR.
+- **live e2e (`tests/e2e`)** — deliberately excluded from `go test ./...` by its `e2e`
+  build tag. CI only compiles it (`go test -tags e2e -run '^$' ./tests/e2e/...`), never
+  runs it — unchanged, and correct: it drives a real Fabrik bed against real repos and
+  cannot run unattended in a PR job. `scripts/e2e/run.sh` (standalone, or via
+  `scripts/cut-release.sh`) is the only thing that actually executes it, and only against
+  the real `~/dev/fabrik-test` bed, before a release.
+
+The genuine gap this issue closes was entirely in the **release path**, not CI: layers
+1–3 already shared one `go test -race ./...` invocation and already ran on every PR;
+nothing tied that fact to "therefore live e2e is safe to run" or to whether a release
+should proceed. `scripts/e2e/run.sh`'s new pre-gate and `scripts/cut-release.sh`'s new
+steps are what make that ordering real in the one place it wasn't already: right before a
+release ships.
+
+### R8 — an on-demand entry point, with honest runtime numbers
+
+`scripts/sim/run.sh` is the frictionless "run the sim layer by hand at any point before
+committing to a full live run" entry point the issue asked for — a script, not a
+remembered `go test` incantation (no `Makefile` exists in this repo to hang a target off
+instead). It defaults to the scenario layer only (`./tests/sim`) — the part that matters
+for a pre-gate — and takes `--all` to run the full tree
+(`./tests/sim/...`, including `simgh`'s own model tests, `simclaude`, and
+`simgh/ghfault`). `run_pregate` in `scripts/e2e/run.sh` calls it with `--all`; a human
+iterating locally is expected to use the faster default.
+
+Runtime figures are inherently machine- and load-dependent — `tests/sim/README.md`'s own
+revision history shows several "Updated for #N" figures under different conditions — so
+this issue records one honest, dated measurement rather than chasing an exact number:
+
+```
+tests/sim               42.5s     the scenarios (this script's default)
+tests/sim/simgh        105.0s     unit tests of the model itself
+tests/sim/simclaude      1.1s
+tests/sim/simgh/ghfault  1.1s
+                        ~107s total wall clock (--all)
+```
+
+replacing the stale "~92s total" / "comfortably under the ~90s line" conclusion that
+predated the merge-train suite's addition (#1452) — see `tests/sim/README.md`'s own
+"Runtime and the `sim` tag decision" section for the discrepancy and the still-current "no
+build tag" decision it protects.
+
+## Consequences
+
+- The live suite is never reduced, retired, or made conditionally-optional by default.
+  This ADR does not revisit that; it is the governing constraint every decision above
+  operates inside.
+- A real `cut-release.sh` invocation now takes materially longer by default — build+test,
+  plus the sim/wire-contract pre-gate (~107s), plus a full live e2e run (hours) — unless
+  `--skip-integration=<reason>` is explicitly used. This is R2's intended effect, not an
+  accident: the script's whole job is to make skipping integration validation a visible,
+  justified choice rather than a fast default.
+- `--skip-integration`'s reason lands in shipped release notes verbatim. Authors of that
+  reason should write it for the audience that will read it there, not as an internal
+  note.
+- The fidelity-drift policy (R4) creates ongoing maintenance obligation on `tests/sim`
+  whenever live e2e catches something the sim missed — this is the cost of the sim's
+  value as a pre-gate being real rather than illusory, and is deliberately made a release
+  checklist item so it isn't optional in practice.
+- `scripts/e2e/run.sh`'s pre-gate and `scripts/cut-release.sh`'s pre-gate step both run
+  the sim + wire-contract layers, and both can fire in the same release cut (once
+  standalone via a manual `scripts/e2e/run.sh` invocation, once inside
+  `cut-release.sh`'s own step 3). This redundancy is accepted, not engineered away — the
+  two entry points serve different callers (a human iterating vs. the release script) and
+  the cost (~107s twice, at most) is cheap by this issue's own framing.
+
+## Related
+
+- #1449, #1450, #1451, #1452, #1453 — the chain that built the sim bed and the
+  wire-contract tests this ADR gates ahead of live e2e.
+- `adrs/1449-sim-harness-engine-seams.md`, `adrs/1451-sim-bed-restart-harness.md`,
+  `adrs/1452-mergetrain-sim-harness-seams.md`,
+  `adrs/1453-wire-contract-graphql-schema-validation.md` — the ADRs for each link in the
+  chain.
+- `tests/sim/README.md` — "What this layer is permanently blind to" (the sim's own
+  blind-spot statement this ADR's layer table restates), "Runtime and the `sim` tag
+  decision" (R8's numbers), and the fidelity-drift policy section (R4) added by this
+  issue.
+- `tests/sim/simgh/FIDELITY.md` — the permanent ledger of `simgh`'s known divergences
+  from real GitHub; the target of R4's step 3.
+- `tests/e2e/README.md` — "Where this lives in the release flow" (the four-layer diagram
+  added by this issue) and "Known limitations" (CI placement, clarified by this issue).
+- `scripts/e2e/run.sh`'s `run_pregate` and `scripts/cut-release.sh`'s pre-gate/live-gate
+  steps — the implementation.
+- `.claude/skills/cut-release/SKILL.md` — the release checklist R4's procedure is wired
+  into.

--- a/adrs/1454-sim-pre-gate-not-replacement.md
+++ b/adrs/1454-sim-pre-gate-not-replacement.md
@@ -135,8 +135,14 @@ confidence exactly where confidence is being relied on to save a live run.
 fixed there as well as in the engine.
 
 **Procedure**, recorded in `tests/sim/README.md` (canonical) and referenced from
-`tests/e2e/README.md`, and made a checklist step in
-`.claude/skills/cut-release/SKILL.md` so it does not depend on someone remembering:
+`tests/e2e/README.md`, and made a checklist step in `scripts/cut-release.sh`'s own
+header comment and its live-gate failure message so it does not depend on someone
+remembering. `.claude/skills/cut-release/SKILL.md`'s Steps section is the other
+sanctioned location per the issue's "and/or" wording, but this repo's tooling refuses
+writes to that specific path (a platform-level protection on installed skill files,
+confirmed not a project `settings.json` restriction) — it still describes the
+pre-#1454 8-step flow and should be brought into sync by a human with write access,
+including the new `--skip-integration=<reason>` flag and the pre-gate/live-gate steps.
 
 1. File a fidelity issue describing the divergence — what live e2e caught that the sim
    didn't, and why the sim's model let it through.
@@ -250,5 +256,6 @@ build tag" decision it protects.
   added by this issue) and "Known limitations" (CI placement, clarified by this issue).
 - `scripts/e2e/run.sh`'s `run_pregate` and `scripts/cut-release.sh`'s pre-gate/live-gate
   steps — the implementation.
-- `.claude/skills/cut-release/SKILL.md` — the release checklist R4's procedure is wired
-  into.
+- `.claude/skills/cut-release/SKILL.md` — the other sanctioned release-checklist location
+  per R4's "and/or" wording; not updated by this issue (see R4's own note above) and
+  still describes the pre-#1454 8-step flow.

--- a/adrs/1454-sim-pre-gate-not-replacement.md
+++ b/adrs/1454-sim-pre-gate-not-replacement.md
@@ -118,11 +118,15 @@ exactly the commit about to ship.
 
 `scripts/e2e/run.sh`'s exit codes are branched on explicitly rather than treated as a
 single pass/fail: `3` (GraphQL budget exhausted — the verdict cannot be trusted, rerun
-later) and `5` (the live script's *own* pre-gate failed, which is unexpected since
-`cut-release.sh`'s own pre-gate step already passed against the same tree — investigate
-the discrepancy) both produce a distinct, actionable message; anything else is treated as
-a real regression, with an explicit instruction not to retry with `--skip-integration` to
-work around it.
+later), `4` (bed preflight failed — an infrastructure problem, e.g. a stuck lock or
+unreachable SSH remote; the suite never actually ran), and `5` (the live script's *own*
+pre-gate failed, which is unexpected since `cut-release.sh`'s own pre-gate step already
+passed against the same tree — investigate the discrepancy) each produce a distinct,
+actionable message; anything else is treated as a real regression, with an explicit
+instruction not to retry with `--skip-integration` to work around it. `4` in particular
+must not be conflated with a fidelity-drift case — an infrastructure failure means the
+live suite never exercised the code at all, so there is nothing for the sim to have
+missed.
 
 ### R4 — the fidelity-drift policy
 

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -6,6 +6,12 @@
 #   scripts/cut-release.sh v0.0.67 --skip-tests       # skip race-tested suite (last-resort)
 #   scripts/cut-release.sh v0.0.67 --no-doc-issue     # skip filing the doc-update issue
 #   scripts/cut-release.sh v0.0.67 --no-plugin-bump   # skip the plugin/fabrik version auto-bump
+#   scripts/cut-release.sh v0.0.67 --skip-integration=<reason>
+#       # Skip the mandatory live e2e integration gate (step 5 below). This is
+#       # a LOUD, RECORDED escape hatch, not a quiet default — see step 5's own
+#       # comment and adrs/1454-sim-pre-gate-not-replacement.md for why the
+#       # live suite is mandatory by default and what this flag costs. A bare
+#       # `--skip-integration` (no reason) is refused.
 #
 # Prereqs:
 #   - On main, clean working tree, ff'd to origin/main
@@ -18,45 +24,33 @@
 # What it does:
 #   1. Pre-flight: branch, clean tree, ff-pull, release-notes heading match
 #   2. PAT identity check (must be arbeithand)
-#   3. go build + go test -race
-#   4. Commit release-notes.md (if dirty) as arbeithand
-#   4b. If plugin/fabrik's source changed since the previous tag, patch-bump
+#   3. Sim suite + github wire-contract tests — unconditional pre-gate (R1/R2, #1454)
+#   4. go build + go test -race (skippable with --skip-tests; the pre-gate above never is)
+#   5. Live e2e integration gate — mandatory by default; --skip-integration=<reason> is the
+#      one sanctioned, loud, release-notes-recorded escape hatch (R2, #1454)
+#   6. Commit release-notes.md (if dirty) as arbeithand
+#   6b. If plugin/fabrik's source changed since the previous tag, patch-bump
 #       plugin/fabrik/.claude-plugin/plugin.json and commit as arbeithand
 #       (skippable with --no-plugin-bump)
-#   5. Tag, push tag with credential helpers nuked + PAT-in-URL
-#   6. Watch the release workflow run; fail loudly on non-success
-#   7. Verify the published release author and discussion author are both arbeithand
-#   8. File doc-update issue and add to project at Status=Specify
+#   7. Tag, push tag with credential helpers nuked + PAT-in-URL
+#   8. Watch the release workflow run; fail loudly on non-success
+#   9. Verify the published release author and discussion author are both arbeithand
+#   10. File doc-update issue and add to project at Status=Specify
 #
 # On failure after the tag is pushed, the script does NOT auto-clean. It prints the
 # exact cleanup commands you'd need so you can decide whether to scrub and retry.
+#
+# parse_args() and main() are split, and both sit behind the same
+# BASH_SOURCE[0]==$0 dispatch guard scripts/e2e/run.sh already uses (see that
+# script's own precedent). This lets scripts/cut_release_gate_test.sh `source`
+# this file and exercise parse_args()'s flag validation — including the
+# mandatory-by-default live suite's --skip-integration handling — directly,
+# without ever reaching main() (the real publish sequence: tag, push, watch
+# workflow, file issue). This is a pure mechanical wrap: no step's logic,
+# ordering, or behavior changed as part of the split, only where the code
+# lives.
 
 set -euo pipefail
-
-# ─── arg parsing ──────────────────────────────────────────────────────────────
-VERSION="${1:-}"
-SKIP_TESTS=0
-NO_DOC_ISSUE=0
-NO_PLUGIN_BUMP=0
-shift || true
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --skip-tests)     SKIP_TESTS=1 ;;
-    --no-doc-issue)   NO_DOC_ISSUE=1 ;;
-    --no-plugin-bump) NO_PLUGIN_BUMP=1 ;;
-    *) echo "Unknown flag: $1" >&2; exit 2 ;;
-  esac
-  shift
-done
-
-if [ -z "$VERSION" ]; then
-  echo "Usage: $0 vX.Y.Z [--skip-tests] [--no-doc-issue] [--no-plugin-bump]" >&2
-  exit 2
-fi
-if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-  echo "Version must look like v0.0.67 (got: $VERSION)" >&2
-  exit 2
-fi
 
 # ─── constants ────────────────────────────────────────────────────────────────
 REPO="handarbeit/fabrik"
@@ -73,6 +67,90 @@ ok()   { printf '  \033[1;32m✓\033[0m %s\n' "$*"; }
 warn() { printf '  \033[1;33m!\033[0m %s\n' "$*"; }
 die()  { printf '\n\033[1;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
 
+# insert_notes_line appends $2 into $1's "## Internal" section — creating
+# that section (just before "## Upgrading", the schema's always-last
+# section) if it doesn't exist yet. Shared by the plugin-bump changelog line
+# (step 6b, pre-existing) and the --skip-integration recorded-skip line
+# (step 5, R2/#1454), so the two call sites can't drift into different
+# insertion logic.
+insert_notes_line() {
+  local file="$1"
+  local line="$2"
+  if grep -Eq '^## Internal[[:space:]]*$' "$file"; then
+    awk -v line="$line" '
+      { print }
+      /^## Internal[[:space:]]*$/ && !inserted { print line; inserted=1 }
+    ' "$file" > "${file}.tmp"
+    mv "${file}.tmp" "$file"
+  elif grep -Eq '^## Upgrading[[:space:]]*$' "$file"; then
+    # No existing Internal section: insert a new one directly before
+    # Upgrading (always the last section in the notes schema) rather than
+    # appending at the file's end, which would land after the closing
+    # ```bash fence and break the canonical section order.
+    awk -v line="$line" '
+      /^## Upgrading[[:space:]]*$/ && !inserted {
+        print "## Internal"
+        print line
+        print ""
+        inserted=1
+      }
+      { print }
+    ' "$file" > "${file}.tmp"
+    mv "${file}.tmp" "$file"
+  else
+    {
+      echo ""
+      echo "## Internal"
+      echo "$line"
+    } >> "$file"
+  fi
+}
+
+# ─── arg parsing ──────────────────────────────────────────────────────────────
+parse_args() {
+  VERSION="${1:-}"
+  SKIP_TESTS=0
+  NO_DOC_ISSUE=0
+  NO_PLUGIN_BUMP=0
+  SKIP_INTEGRATION=0
+  INTEGRATION_SKIP_REASON=""
+  shift || true
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --skip-tests)     SKIP_TESTS=1 ;;
+      --no-doc-issue)   NO_DOC_ISSUE=1 ;;
+      --no-plugin-bump) NO_PLUGIN_BUMP=1 ;;
+      --skip-integration=*)
+        SKIP_INTEGRATION=1
+        INTEGRATION_SKIP_REASON="${1#--skip-integration=}"
+        [ -n "$INTEGRATION_SKIP_REASON" ] \
+          || { echo "--skip-integration requires a non-empty reason: --skip-integration=<reason>" >&2; exit 2; }
+        ;;
+      --skip-integration)
+        echo "--skip-integration requires a reason: --skip-integration=<reason> (a bare flag is not accepted — R2/#1454: the live suite is mandatory by default, and its one sanctioned escape hatch must be loud and self-documenting)" >&2
+        exit 2
+        ;;
+      *) echo "Unknown flag: $1" >&2; exit 2 ;;
+    esac
+    shift
+  done
+
+  if [ -z "$VERSION" ]; then
+    echo "Usage: $0 vX.Y.Z [--skip-tests] [--no-doc-issue] [--no-plugin-bump] [--skip-integration=<reason>]" >&2
+    exit 2
+  fi
+  if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "Version must look like v0.0.67 (got: $VERSION)" >&2
+    exit 2
+  fi
+}
+
+# main runs the real, side-effecting publish sequence (git commits/pushes, a
+# real tag push, watching a real workflow run, filing a real issue) — never
+# invoked on source, only from the dispatch guard at the bottom when this
+# script is executed directly. Reads the globals parse_args sets.
+main() {
+
 # ─── 1. pre-flight ────────────────────────────────────────────────────────────
 step "Pre-flight checks"
 
@@ -82,11 +160,11 @@ ok "on main"
 
 # Allow uncommitted release-notes/<version>.md, plugin/known_embedded_versions.go,
 # and plugin/fabrik/.claude-plugin/plugin.json (all three are updated by this
-# script itself, after the build step and in step 4b).
+# script itself, after the build step and in step 6b).
 #
 # Allowlist disposition (reviewed for #1070, extended for #816): all three
-# files are committed by this script's own step 4 / step 4b, *before* the tag
-# is created and pushed in step 5. By the time release.yml's CI job checks
+# files are committed by this script's own step 6 / step 6b, *before* the tag
+# is created and pushed in step 7. By the time release.yml's CI job checks
 # out the tag, it's a fresh clone — it never sees this local working tree,
 # dirty or not. So this allowlist cannot affect the CI-built artifact and
 # does not need to be tightened; the built-artifact VCS check lives in
@@ -143,7 +221,28 @@ PAT_OWNER="$(GH_TOKEN="$FABRIK_TOKEN" gh api user --jq .login)"
   || die "FABRIK_TOKEN does not belong to $BOT_LOGIN (got: $PAT_OWNER)"
 ok "FABRIK_TOKEN authenticated as @$BOT_LOGIN"
 
-# ─── 3. build + test ──────────────────────────────────────────────────────────
+# ─── 3. sim + wire-contract pre-gate (unconditional — R1/R2, #1454) ──────────
+# Unlike the full go test -race ./... below, this step is NEVER skippable —
+# not even by --skip-tests. It's the same free, fast pre-gate
+# scripts/e2e/run.sh runs ahead of its own live suite (see that script's
+# run_pregate), re-run here so a release cut through this script pays the
+# same "cheap layers first" ordering even if someone hand-invokes
+# scripts/e2e/run.sh separately with E2E_SKIP_PREGATE set. Cheap (~107s
+# total per tests/sim/README.md), so making it unconditional costs nothing
+# real while removing an entire class of "the live suite failed for a
+# reason the sim would have caught for free" incidents.
+step "Sim + wire-contract pre-gate"
+if ! "$REPO_ROOT/scripts/sim/run.sh" --all; then
+  die "sim suite failed — fix it before cutting a release (scripts/sim/run.sh --all to reproduce)"
+fi
+ok "sim suite passed"
+if ! go test -race -count=1 ./github/... >/tmp/cut-release-pregate-test.log 2>&1; then
+  tail -40 /tmp/cut-release-pregate-test.log >&2
+  die "github wire-contract tests failed (full log: /tmp/cut-release-pregate-test.log)"
+fi
+ok "github wire-contract tests passed"
+
+# ─── 4. build + test ──────────────────────────────────────────────────────────
 step "Build"
 go build ./... >/dev/null || die "go build failed"
 ok "go build clean"
@@ -165,7 +264,7 @@ else
 fi
 
 if [ "$SKIP_TESTS" -eq 1 ]; then
-  warn "--skip-tests was passed; race-tested suite was NOT run"
+  warn "--skip-tests was passed; go test -race ./... was NOT run (the sim + wire-contract pre-gate above still ran unconditionally)"
 else
   step "Race-tested suite"
   if ! go test -race ./... >/tmp/cut-release-test.log 2>&1; then
@@ -176,11 +275,63 @@ else
 fi
 
 # Capture the previous release tag now, before this release's tag exists,
-# for the plugin-bump change-detection diff in step 4b. Tags were already
+# for the plugin-bump change-detection diff in step 6b. Tags were already
 # fetched in pre-flight. Empty on a first-ever release (no v* tag yet).
 PREV_TAG="$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || true)"
 
-# ─── 4. commit release notes as arbeithand ────────────────────────────────────
+# ─── 5. live e2e integration gate (mandatory by default — R2, #1454) ────────
+# The live suite is the only layer that exercises real Claude, real review
+# bots, and real GitHub wire behaviour — nothing else in this pipeline can
+# substitute for it, and it is never retired or reduced (see
+# adrs/1454-sim-pre-gate-not-replacement.md). So unlike --skip-tests above,
+# there is no quiet default here: either the suite runs, or a human
+# explicitly said why not, and that "why not" ships in the release notes
+# where anyone reading them can see it. A --skip-integration that silently
+# produced an unvalidated release was rejected outright (R2's option (a) vs
+# (b) decision — see the ADR).
+#
+# Positioned here — after build+test, before the release-notes commit below
+# — so (a) a live-suite failure aborts before anything is committed or
+# pushed, and (b) the skip-reason line (or nothing, on a pass) folds into
+# the SAME release-notes commit rather than needing a second push, and (c)
+# since scripts/e2e/run.sh fetches origin/main by default, this tests
+# exactly the commit about to ship, right before it ships.
+step "Live e2e integration gate"
+if [ "$SKIP_INTEGRATION" -eq 1 ]; then
+  cat >&2 <<EOF
+
+################################################################################
+## SKIPPING THE LIVE E2E INTEGRATION SUITE (--skip-integration)
+## Reason: $INTEGRATION_SKIP_REASON
+##
+## This release has NOT been validated against real GitHub, real Claude, and
+## real review bots. This is being recorded in $NOTES_FILE.
+################################################################################
+
+EOF
+  insert_notes_line "$NOTES_FILE" "- ⚠️ Live e2e integration suite SKIPPED for this release: $INTEGRATION_SKIP_REASON"
+  warn "live e2e integration suite SKIPPED — reason recorded in $NOTES_FILE"
+else
+  echo "   running scripts/e2e/run.sh against origin/main (this can take hours — see tests/e2e/README.md)"
+  E2E_RC=0
+  "$REPO_ROOT/scripts/e2e/run.sh" || E2E_RC=$?
+  case "$E2E_RC" in
+    0)
+      ok "live e2e integration suite passed"
+      ;;
+    3)
+      die "live e2e integration suite aborted: GraphQL budget exhausted mid-run (exit 3) — the verdict cannot be trusted. Wait for the budget window to reset and re-run scripts/cut-release.sh $VERSION."
+      ;;
+    5)
+      die "live e2e integration suite aborted: its own sim/wire-contract pre-gate failed (exit 5) inside scripts/e2e/run.sh. Unexpected, since this script's own pre-gate step (step 3) already passed against the same tree — investigate the discrepancy (different ref? dirty tree in the bed?) before retrying."
+      ;;
+    *)
+      die "live e2e integration suite FAILED (exit $E2E_RC) — see scripts/e2e/run.sh output above. This is a real regression; do not retry with --skip-integration to work around it."
+      ;;
+  esac
+fi
+
+# ─── 6. commit release notes as arbeithand ────────────────────────────────────
 step "Commit release notes"
 # Stage the per-version source-of-truth file and the updated known-versions list.
 # The workflow reads release-notes/<version>.md directly — no copy step needed.
@@ -208,7 +359,7 @@ else
   ok "release-notes commit pushed"
 fi
 
-# ─── 4b. auto-bump plugin/fabrik version if source changed ───────────────────
+# ─── 6b. auto-bump plugin/fabrik version if source changed ───────────────────
 # Claude Code's /plugin update compares plugin.json's version field against
 # marketplace.json@main; same version number means no refresh fires even if
 # the plugin's source changed. Patch-bump plugin/fabrik's manifest whenever
@@ -236,35 +387,7 @@ else
     # Release notes. release-notes/<version>.md was already committed and
     # pushed above, so this lands in a second commit alongside the manifest
     # bump rather than amending the already-pushed one.
-    CHANGELOG_LINE="- Auto-bumped fabrik plugin to $NEW_PLUGIN_VER (source changed since $PREV_TAG)"
-    if grep -Eq '^## Internal[[:space:]]*$' "$NOTES_FILE"; then
-      awk -v line="$CHANGELOG_LINE" '
-        { print }
-        /^## Internal[[:space:]]*$/ && !inserted { print line; inserted=1 }
-      ' "$NOTES_FILE" > "${NOTES_FILE}.tmp"
-      mv "${NOTES_FILE}.tmp" "$NOTES_FILE"
-    elif grep -Eq '^## Upgrading[[:space:]]*$' "$NOTES_FILE"; then
-      # No existing Internal section: insert a new one directly before
-      # Upgrading (always the last section in the notes schema) rather than
-      # appending at the file's end, which would land after the closing
-      # ```bash fence and break the canonical section order.
-      awk -v line="$CHANGELOG_LINE" '
-        /^## Upgrading[[:space:]]*$/ && !inserted {
-          print "## Internal"
-          print line
-          print ""
-          inserted=1
-        }
-        { print }
-      ' "$NOTES_FILE" > "${NOTES_FILE}.tmp"
-      mv "${NOTES_FILE}.tmp" "$NOTES_FILE"
-    else
-      {
-        echo ""
-        echo "## Internal"
-        echo "$CHANGELOG_LINE"
-      } >> "$NOTES_FILE"
-    fi
+    insert_notes_line "$NOTES_FILE" "- Auto-bumped fabrik plugin to $NEW_PLUGIN_VER (source changed since $PREV_TAG)"
 
     git add "$PLUGIN_MANIFEST" "$NOTES_FILE"
     GIT_AUTHOR_NAME="$BOT_LOGIN" \
@@ -287,7 +410,7 @@ else
   fi
 fi
 
-# ─── 5. tag + push ────────────────────────────────────────────────────────────
+# ─── 7. tag + push ────────────────────────────────────────────────────────────
 step "Tag and push as @$BOT_LOGIN"
 TAG_COMMIT="$(git rev-parse HEAD)"
 git tag "$VERSION" "$TAG_COMMIT"
@@ -301,7 +424,7 @@ git \
   || die "tag push failed — local tag $VERSION still present, remove with: git tag -d $VERSION"
 ok "tag $VERSION pushed (commit $TAG_COMMIT)"
 
-# ─── 6. watch workflow ────────────────────────────────────────────────────────
+# ─── 8. watch workflow ────────────────────────────────────────────────────────
 step "Locate release workflow run"
 RUN_ID=""
 for attempt in 1 2 3 4 5 6; do
@@ -327,7 +450,7 @@ if [ "$CONCLUSION" != "success" ]; then
 fi
 ok "workflow conclusion: success"
 
-# ─── 7. identity verification ─────────────────────────────────────────────────
+# ─── 9. identity verification ─────────────────────────────────────────────────
 step "Verify release + discussion author = @$BOT_LOGIN"
 RELEASE_AUTHOR="$(GH_TOKEN="$FABRIK_TOKEN" gh api "/repos/$REPO/releases/tags/$VERSION" --jq .author.login)"
 [ "$RELEASE_AUTHOR" = "$BOT_LOGIN" ] || die "release author is '$RELEASE_AUTHOR', expected '$BOT_LOGIN'. The repo secret PUBLIC_REPO_RELEASE_TOKEN is wrong — rotate it to an arbeithand PAT at: https://github.com/${REPO}/settings/secrets/actions/PUBLIC_REPO_RELEASE_TOKEN, then delete the release+discussion+tag (see cleanup below) and re-run."
@@ -349,7 +472,7 @@ else
   ok "discussion author: @$DISCUSSION_AUTHOR"
 fi
 
-# ─── 8. file doc-update issue ─────────────────────────────────────────────────
+# ─── 10. file doc-update issue ─────────────────────────────────────────────────
 if [ "$NO_DOC_ISSUE" -eq 1 ]; then
   warn "--no-doc-issue was passed; skipping doc-update issue + project placement"
 else
@@ -388,6 +511,20 @@ step "Release $VERSION published"
 echo "  release:    https://github.com/${REPO}/releases/tag/${VERSION}"
 echo "  workflow:   https://github.com/${REPO}/actions/runs/${RUN_ID}"
 echo "  author:     @$BOT_LOGIN (verified)"
+
+}
+
+# Guarded so scripts/cut_release_gate_test.sh can `source` this file to reach
+# parse_args() and insert_notes_line() (and every other function above)
+# without triggering an actual publish. Everything above this guard is safe
+# to execute on source — constants, cd to repo root, and pure function
+# definitions, no publish side effects. When executed directly
+# (./cut-release.sh or `bash cut-release.sh`), BASH_SOURCE[0] equals $0, so
+# this still dispatches exactly as before this guard existed.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  parse_args "$@"
+  main
+fi
 
 # ─── cleanup reference (not executed) ─────────────────────────────────────────
 # If a release goes out under the wrong identity (or you need to redo it):

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -111,6 +111,40 @@ insert_notes_line() {
   fi
 }
 
+# interpret_e2e_exit_code prints the operator-facing message for a given
+# scripts/e2e/run.sh exit code ($1) and returns 0 if that code means success,
+# 1 otherwise — main() calls `ok`/`die` with the result accordingly. Extracted
+# into its own function (R2, #1454) so scripts/cut_release_gate_test.sh can
+# assert on the message for each known exit code — in particular that `4`
+# (PREFLIGHT_FAILED_EXIT, a bed/infrastructure problem where the suite never
+# actually ran) gets its own distinct, non-misleading message rather than
+# falling through to the generic "real regression, check fidelity-drift"
+# branch, which would wrongly send an operator investigating a stuck lock or
+# an unreachable SSH remote down the fidelity-drift procedure instead.
+# Mirrors scripts/e2e/run.sh's own exit-code convention (3/4/5) exactly — see
+# that script's header comment for where each code originates.
+interpret_e2e_exit_code() {
+  local rc="$1"
+  case "$rc" in
+    0)
+      echo "live e2e integration suite passed"
+      ;;
+    3)
+      echo "live e2e integration suite aborted: GraphQL budget exhausted mid-run (exit 3) — the verdict cannot be trusted. Wait for the budget window to reset and re-run scripts/cut-release.sh $VERSION."
+      ;;
+    4)
+      echo "live e2e integration suite aborted: bed preflight failed (exit 4) inside scripts/e2e/run.sh — the suite never ran. This is an infrastructure problem (stuck lock, unreachable SSH remote, dirty tracked files in the bed checkout, etc.), NOT a regression and NOT a fidelity-drift case — see scripts/e2e/run.sh's own preflight_bed output above for the specific cause, fix it, and re-run scripts/cut-release.sh $VERSION."
+      ;;
+    5)
+      echo "live e2e integration suite aborted: its own sim/wire-contract pre-gate failed (exit 5) inside scripts/e2e/run.sh. Unexpected, since this script's own pre-gate step (step 3) already passed against the same tree — investigate the discrepancy (different ref? dirty tree in the bed?) before retrying."
+      ;;
+    *)
+      echo "live e2e integration suite FAILED (exit $rc) — see scripts/e2e/run.sh output above. This is a real regression; do not retry with --skip-integration to work around it. FIDELITY-DRIFT CHECK (R4, #1454): this script's own sim + wire-contract pre-gate (step 3) already passed against this same tree, so whatever the live suite just caught is exactly the case that policy covers — file a fidelity issue, add the scenario to tests/sim, and update tests/sim/simgh/FIDELITY.md (see tests/sim/README.md's 'Fidelity-drift policy' section) once the underlying regression itself is fixed."
+      ;;
+  esac
+  [ "$rc" -eq 0 ]
+}
+
 # ─── arg parsing ──────────────────────────────────────────────────────────────
 parse_args() {
   VERSION="${1:-}"
@@ -320,20 +354,12 @@ else
   echo "   running scripts/e2e/run.sh against origin/main (this can take hours — see tests/e2e/README.md)"
   E2E_RC=0
   "$REPO_ROOT/scripts/e2e/run.sh" || E2E_RC=$?
-  case "$E2E_RC" in
-    0)
-      ok "live e2e integration suite passed"
-      ;;
-    3)
-      die "live e2e integration suite aborted: GraphQL budget exhausted mid-run (exit 3) — the verdict cannot be trusted. Wait for the budget window to reset and re-run scripts/cut-release.sh $VERSION."
-      ;;
-    5)
-      die "live e2e integration suite aborted: its own sim/wire-contract pre-gate failed (exit 5) inside scripts/e2e/run.sh. Unexpected, since this script's own pre-gate step (step 3) already passed against the same tree — investigate the discrepancy (different ref? dirty tree in the bed?) before retrying."
-      ;;
-    *)
-      die "live e2e integration suite FAILED (exit $E2E_RC) — see scripts/e2e/run.sh output above. This is a real regression; do not retry with --skip-integration to work around it. FIDELITY-DRIFT CHECK (R4, #1454): this script's own sim + wire-contract pre-gate (step 3) already passed against this same tree, so whatever the live suite just caught is exactly the case that policy covers — file a fidelity issue, add the scenario to tests/sim, and update tests/sim/simgh/FIDELITY.md (see tests/sim/README.md's 'Fidelity-drift policy' section) once the underlying regression itself is fixed."
-      ;;
-  esac
+  E2E_MSG="$(interpret_e2e_exit_code "$E2E_RC")"
+  if [ "$E2E_RC" -eq 0 ]; then
+    ok "$E2E_MSG"
+  else
+    die "$E2E_MSG"
+  fi
 fi
 
 # ─── 6. commit release notes as arbeithand ────────────────────────────────────

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -27,7 +27,12 @@
 #   3. Sim suite + github wire-contract tests — unconditional pre-gate (R1/R2, #1454)
 #   4. go build + go test -race (skippable with --skip-tests; the pre-gate above never is)
 #   5. Live e2e integration gate — mandatory by default; --skip-integration=<reason> is the
-#      one sanctioned, loud, release-notes-recorded escape hatch (R2, #1454)
+#      one sanctioned, loud, release-notes-recorded escape hatch (R2, #1454).
+#      FIDELITY-DRIFT CHECK (R4, #1454): if this step fails on something step 3's
+#      pre-gate passed, that's a fidelity bug in the sim, not just a live regression —
+#      file it and fix it in tests/sim too (procedure: tests/sim/README.md's
+#      "Fidelity-drift policy" section). This is a release-checklist step, not
+#      something left to memory.
 #   6. Commit release-notes.md (if dirty) as arbeithand
 #   6b. If plugin/fabrik's source changed since the previous tag, patch-bump
 #       plugin/fabrik/.claude-plugin/plugin.json and commit as arbeithand
@@ -326,7 +331,7 @@ else
       die "live e2e integration suite aborted: its own sim/wire-contract pre-gate failed (exit 5) inside scripts/e2e/run.sh. Unexpected, since this script's own pre-gate step (step 3) already passed against the same tree — investigate the discrepancy (different ref? dirty tree in the bed?) before retrying."
       ;;
     *)
-      die "live e2e integration suite FAILED (exit $E2E_RC) — see scripts/e2e/run.sh output above. This is a real regression; do not retry with --skip-integration to work around it."
+      die "live e2e integration suite FAILED (exit $E2E_RC) — see scripts/e2e/run.sh output above. This is a real regression; do not retry with --skip-integration to work around it. FIDELITY-DRIFT CHECK (R4, #1454): this script's own sim + wire-contract pre-gate (step 3) already passed against this same tree, so whatever the live suite just caught is exactly the case that policy covers — file a fidelity issue, add the scenario to tests/sim, and update tests/sim/simgh/FIDELITY.md (see tests/sim/README.md's 'Fidelity-drift policy' section) once the underlying regression itself is fixed."
       ;;
   esac
 fi

--- a/scripts/cut_release_gate_test.sh
+++ b/scripts/cut_release_gate_test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# scripts/cut_release_gate_test.sh — regression coverage for cut-release.sh's
+# flag parsing, in particular the mandatory-by-default live e2e integration
+# gate's --skip-integration handling (R2/AC7, #1454), without ever touching a
+# real bed, network, git remote, or publish path.
+#
+# Sources cut-release.sh for parse_args() (and insert_notes_line()) only —
+# the BASH_SOURCE[0]==$0 dispatch guard at the bottom (mirroring
+# scripts/e2e/run.sh's own precedent) prevents this from triggering main()
+# (the real publish sequence: tag, push, watch workflow, file issue) on
+# source. This is how AC7 ("cut-release.sh's new flags exercised on a
+# no-publish path") is satisfied: parse_args is called directly and its
+# resulting globals are asserted against; main() is never reached.
+#
+# Usage: scripts/cut_release_gate_test.sh
+# Exit 0 if all assertions pass, 1 otherwise.
+
+set -uo pipefail # no -e: assertions below intentionally continue past failures
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Source cut-release.sh for its function definitions only. Its own
+# `set -euo pipefail` becomes active in this shell too once sourced; the
+# `set +e` right after turns errexit back off so this script's own
+# assertions (several of which deliberately provoke parse_args's non-zero
+# exit) don't abort it.
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/cut-release.sh"
+set +e
+
+FAILED=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc (expected '$expected', got '$actual')"
+    FAILED=1
+  fi
+}
+
+# assert_exits runs parse_args in a SUBSHELL (so its `exit` on a validation
+# failure terminates only the subshell, not this test script) and asserts
+# the resulting exit code.
+assert_exits() {
+  local desc="$1" expected_rc="$2"
+  shift 2
+  local rc=0
+  ( parse_args "$@" ) >/dev/null 2>&1
+  rc=$?
+  assert_eq "$desc" "$expected_rc" "$rc"
+}
+
+# --- default: no --skip-integration, no other flags ---
+parse_args v0.0.99
+assert_eq "default VERSION" "v0.0.99" "$VERSION"
+assert_eq "default SKIP_INTEGRATION" "0" "$SKIP_INTEGRATION"
+assert_eq "default INTEGRATION_SKIP_REASON" "" "$INTEGRATION_SKIP_REASON"
+assert_eq "default SKIP_TESTS" "0" "$SKIP_TESTS"
+assert_eq "default NO_DOC_ISSUE" "0" "$NO_DOC_ISSUE"
+assert_eq "default NO_PLUGIN_BUMP" "0" "$NO_PLUGIN_BUMP"
+
+# --- --skip-integration=<reason> sets the flag and records the reason verbatim ---
+parse_args v0.0.99 --skip-integration=testing-the-flag-itself
+assert_eq "--skip-integration=<reason> sets SKIP_INTEGRATION" "1" "$SKIP_INTEGRATION"
+assert_eq "--skip-integration=<reason> records the reason" "testing-the-flag-itself" "$INTEGRATION_SKIP_REASON"
+
+# A reason with spaces (the real-world shape, quoted on the command line).
+parse_args v0.0.99 --skip-integration="bed is mid-reset, rerunning tomorrow"
+assert_eq "--skip-integration=<reason with spaces> records it verbatim" "bed is mid-reset, rerunning tomorrow" "$INTEGRATION_SKIP_REASON"
+
+# --- bare --skip-integration (no reason at all) is a hard usage error — the
+# live suite is mandatory by default and the one sanctioned escape hatch
+# must be self-documenting, never silent. ---
+assert_exits "bare --skip-integration exits 2" "2" v0.0.99 --skip-integration
+
+# --- --skip-integration= (present but empty reason) is also a hard usage error ---
+assert_exits "--skip-integration= (empty reason) exits 2" "2" v0.0.99 --skip-integration=
+
+# --- pre-existing flags still parse correctly post-refactor (no behavior
+# change from the parse_args()/main() split) ---
+parse_args v0.0.99 --skip-tests --no-doc-issue --no-plugin-bump
+assert_eq "--skip-tests still parses" "1" "$SKIP_TESTS"
+assert_eq "--no-doc-issue still parses" "1" "$NO_DOC_ISSUE"
+assert_eq "--no-plugin-bump still parses" "1" "$NO_PLUGIN_BUMP"
+
+# --- flags can combine with --skip-integration ---
+parse_args v0.0.99 --skip-tests --skip-integration=combo-check
+assert_eq "--skip-tests + --skip-integration: SKIP_TESTS" "1" "$SKIP_TESTS"
+assert_eq "--skip-tests + --skip-integration: SKIP_INTEGRATION" "1" "$SKIP_INTEGRATION"
+
+# --- missing version is a hard usage error (pre-existing behavior) ---
+assert_exits "missing version exits 2" "2"
+
+# --- malformed version is a hard usage error (pre-existing behavior) ---
+assert_exits "malformed version exits 2" "2" not-a-version
+
+# --- unknown flag is a hard usage error (pre-existing behavior) ---
+assert_exits "unknown flag exits 2" "2" v0.0.99 --not-a-real-flag
+
+# --- insert_notes_line: exercised directly against a scratch file, proving
+# the helper both call sites (plugin-bump changelog, --skip-integration
+# recorded-skip line) now share behaves identically to the pre-refactor
+# inline logic it replaced. No network, no real release-notes file touched. ---
+SCRATCH="$(mktemp)"
+trap 'rm -f "$SCRATCH"' EXIT
+
+cat > "$SCRATCH" <<'EOF'
+# Fabrik v0.0.99
+
+## Summary
+
+Test fixture.
+
+## Upgrading
+
+```bash
+echo hi
+```
+EOF
+insert_notes_line "$SCRATCH" "- ⚠️ Live e2e integration suite SKIPPED for this release: fixture reason"
+if grep -Fq '## Internal' "$SCRATCH" && grep -Fq 'SKIPPED for this release: fixture reason' "$SCRATCH"; then
+  echo "PASS: insert_notes_line creates ## Internal section and inserts the line (no pre-existing section)"
+else
+  echo "FAIL: insert_notes_line did not create ## Internal / insert the line as expected"
+  FAILED=1
+  cat "$SCRATCH" >&2
+fi
+
+insert_notes_line "$SCRATCH" "- second line, existing ## Internal section"
+if [ "$(grep -c 'second line, existing' "$SCRATCH")" -eq 1 ]; then
+  echo "PASS: insert_notes_line appends into an already-existing ## Internal section"
+else
+  echo "FAIL: insert_notes_line did not correctly append to an existing ## Internal section"
+  FAILED=1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "=== cut_release_gate_test.sh: FAILED ==="
+  exit 1
+fi
+echo "=== cut_release_gate_test.sh: all checks passed ==="

--- a/scripts/cut_release_gate_test.sh
+++ b/scripts/cut_release_gate_test.sh
@@ -99,6 +99,51 @@ assert_exits "malformed version exits 2" "2" not-a-version
 # --- unknown flag is a hard usage error (pre-existing behavior) ---
 assert_exits "unknown flag exits 2" "2" v0.0.99 --not-a-real-flag
 
+# --- interpret_e2e_exit_code: each known scripts/e2e/run.sh exit code gets
+# its own distinct, non-misleading message and success/failure classification
+# — in particular exit 4 (PREFLIGHT_FAILED_EXIT, a bed/infrastructure
+# problem) must NOT be conflated with a fidelity-drift regression, which is
+# what a prior version of this script did by falling through to the generic
+# "*)" branch for it. ---
+VERSION="v0.0.99" # interpret_e2e_exit_code's exit-3/4/5 messages interpolate $VERSION
+
+msg="$(interpret_e2e_exit_code 0)"; rc=$?
+assert_eq "exit 0 message" "live e2e integration suite passed" "$msg"
+assert_eq "exit 0 classified as success" "0" "$rc"
+
+msg="$(interpret_e2e_exit_code 3)"; rc=$?
+case "$msg" in
+  *"budget exhausted"*) echo "PASS: exit 3 message mentions budget exhaustion" ;;
+  *) echo "FAIL: exit 3 message does not mention budget exhaustion: $msg"; FAILED=1 ;;
+esac
+assert_eq "exit 3 classified as failure" "1" "$rc"
+
+msg="$(interpret_e2e_exit_code 4)"; rc=$?
+case "$msg" in
+  *"infrastructure problem"*"NOT a regression"*"NOT a fidelity-drift case"*)
+    echo "PASS: exit 4 message is distinct and explicitly disclaims fidelity-drift" ;;
+  *) echo "FAIL: exit 4 message does not distinctly disclaim fidelity-drift: $msg"; FAILED=1 ;;
+esac
+case "$msg" in
+  *"FIDELITY-DRIFT"*) echo "FAIL: exit 4 message wrongly mentions the fidelity-drift procedure"; FAILED=1 ;;
+  *) echo "PASS: exit 4 message does not mention the fidelity-drift procedure" ;;
+esac
+assert_eq "exit 4 classified as failure" "1" "$rc"
+
+msg="$(interpret_e2e_exit_code 5)"; rc=$?
+case "$msg" in
+  *"own sim/wire-contract pre-gate failed"*) echo "PASS: exit 5 message mentions the live script's own pre-gate" ;;
+  *) echo "FAIL: exit 5 message does not mention the live script's own pre-gate: $msg"; FAILED=1 ;;
+esac
+assert_eq "exit 5 classified as failure" "1" "$rc"
+
+msg="$(interpret_e2e_exit_code 1)"; rc=$?
+case "$msg" in
+  *"FIDELITY-DRIFT"*) echo "PASS: exit 1 (real regression) message mentions the fidelity-drift procedure" ;;
+  *) echo "FAIL: exit 1 message does not mention the fidelity-drift procedure: $msg"; FAILED=1 ;;
+esac
+assert_eq "exit 1 classified as failure" "1" "$rc"
+
 # --- insert_notes_line: exercised directly against a scratch file, proving
 # the helper both call sites (plugin-bump changelog, --skip-integration
 # recorded-skip line) now share behaves identically to the pre-refactor

--- a/scripts/e2e/pregate_test.sh
+++ b/scripts/e2e/pregate_test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# scripts/e2e/pregate_test.sh — regression coverage for R1's (#1454) pre-gate
+# in scripts/e2e/run.sh: the sim suite and github wire-contract tests must run
+# — and must be seen to run — before any bed preflight, build, or live
+# GitHub/Claude call, and a failure there must abort with a distinct exit
+# code before any of that happens.
+#
+# This is what proves AC1 ("deliberately breaking a sim test and showing no
+# live call is made") without paying for an actual multi-minute `go test`
+# run or a real, temporary breakage of tests/sim: it exercises the real
+# run_pregate function from run.sh (sourced, mirroring
+# backoff_detection_test.sh's precedent) against a PATH-shadowed fake `go`
+# binary that records every invocation and exits with a scripted status —
+# so both "pass" and "fail" are simulated in milliseconds, and the fake
+# being invoked at all is itself asserted (a marker file), not just trusted.
+#
+# Usage: scripts/e2e/pregate_test.sh
+# Exit 0 if all assertions pass, 1 otherwise.
+
+set -uo pipefail # no -e: assertions below intentionally continue past failures
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Source run.sh for its function definitions only — the sourcing guard at the
+# bottom of run.sh (BASH_SOURCE[0] == $0) prevents this from triggering an
+# actual gate run. run.sh's own `set -euo pipefail` becomes active in this
+# shell too once sourced; `set +e` below turns errexit back off so this
+# script's own assertions (several of which deliberately provoke a non-zero
+# exit) don't abort it.
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/e2e/run.sh"
+set +e
+
+FAILED=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc (expected '$expected', got '$actual')"
+    FAILED=1
+  fi
+}
+
+# fake_go_bin creates a directory on $FAKE_BIN_DIR containing a `go` script
+# that appends one line to $MARKER_FILE per invocation (so callers can count
+# and inspect calls) and exits with $FAKE_GO_EXIT (default 0). Prepending it
+# to PATH shadows the real toolchain for both scripts/sim/run.sh's own `go
+# test` call and run_pregate's direct `go test ./github/...` call — both are
+# separate child processes, so PATH (not a shell function) is what's needed
+# to shadow both.
+FAKE_BIN_DIR="$(mktemp -d)"
+MARKER_FILE="$(mktemp)"
+trap 'rm -rf "$FAKE_BIN_DIR" "$MARKER_FILE"' EXIT
+
+cat > "$FAKE_BIN_DIR/go" <<'EOF'
+#!/usr/bin/env bash
+echo "FAKE_GO_CALLED: $*" >> "$MARKER_FILE"
+exit "${FAKE_GO_EXIT:-0}"
+EOF
+chmod +x "$FAKE_BIN_DIR/go"
+
+reset_marker() { : > "$MARKER_FILE"; }
+marker_count() { wc -l < "$MARKER_FILE" | tr -d ' '; }
+
+export PATH="$FAKE_BIN_DIR:$PATH"
+export MARKER_FILE
+
+# --- Case 1: E2E_SKIP_PREGATE=1 — the escape hatch skips entirely, no `go`
+# invocation of any kind, and returns success. ---
+reset_marker
+( E2E_SKIP_PREGATE=1 FAKE_GO_EXIT=1 run_pregate ) >/dev/null 2>&1
+rc=$?
+assert_eq "E2E_SKIP_PREGATE=1 exits 0" "0" "$rc"
+assert_eq "E2E_SKIP_PREGATE=1 makes no go call" "0" "$(marker_count)"
+
+# --- Case 2: both layers "pass" (fake go exits 0) — run_pregate exits 0 and
+# both the sim-suite go invocation and the github-tests go invocation
+# actually happened (2 calls: one from scripts/sim/run.sh, one from
+# run_pregate's own `go test ./github/...`). ---
+reset_marker
+( FAKE_GO_EXIT=0 run_pregate ) >/dev/null 2>&1
+rc=$?
+assert_eq "both layers passing exits 0" "0" "$rc"
+assert_eq "both layers passing calls go twice (sim + github)" "2" "$(marker_count)"
+
+# --- Case 3: the sim layer "fails" (fake go exits 1) — run_pregate aborts
+# with PREGATE_FAILED_EXIT (5) after exactly ONE go call (scripts/sim/run.sh's
+# own), and never reaches the github wire-contract tests call. This is the
+# mechanism AC1 relies on: the ordering guarantees the second (and any live)
+# call never happens once the first layer fails. ---
+reset_marker
+( FAKE_GO_EXIT=1 run_pregate ) >/dev/null 2>&1
+rc=$?
+assert_eq "sim-layer failure exits PREGATE_FAILED_EXIT (5)" "5" "$rc"
+assert_eq "sim-layer failure stops after exactly one go call (github tests never run)" "1" "$(marker_count)"
+
+# --- Structural check: run_pregate must precede prepare_bed_and_reset inside
+# the dispatch guard, textually — this is what makes "no live call is made"
+# true by construction rather than by accident of today's implementation.
+# Guards against a future edit reordering the two calls without any of the
+# behavioral assertions above catching it (they only exercise run_pregate in
+# isolation, not the guard's own call order). ---
+GUARD_BLOCK="$(awk '/^if \[ "\$\{BASH_SOURCE\[0\]\}" = "\$\{0\}" \]; then$/,0' "$REPO_ROOT/scripts/e2e/run.sh")"
+PREGATE_LINE="$(printf '%s\n' "$GUARD_BLOCK" | grep -n 'run_pregate' | head -1 | cut -d: -f1)"
+PREPARE_LINE="$(printf '%s\n' "$GUARD_BLOCK" | grep -n 'prepare_bed_and_reset "\$@"' | head -1 | cut -d: -f1)"
+if [ -n "$PREGATE_LINE" ] && [ -n "$PREPARE_LINE" ] && [ "$PREGATE_LINE" -lt "$PREPARE_LINE" ]; then
+  echo "PASS: run_pregate precedes prepare_bed_and_reset in the dispatch guard (line $PREGATE_LINE < $PREPARE_LINE)"
+else
+  echo "FAIL: run_pregate does not precede prepare_bed_and_reset in the dispatch guard (pregate=$PREGATE_LINE, prepare=$PREPARE_LINE)"
+  FAILED=1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "=== pregate_test.sh: FAILED ==="
+  exit 1
+fi
+echo "=== pregate_test.sh: all checks passed ==="

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -13,6 +13,19 @@
 # --clean (if given, must be the first argument) runs scripts/e2e/reset.sh for a
 # clean-slate bed before the run. Anything else is passed to `go test`.
 #
+# Pre-gate (R1, #1454): before ANY of the above — before bed preflight, before
+# the build, before a single live GitHub/Claude call — this script runs the
+# free, fast layers first (scripts/sim/run.sh --all, then the github/
+# wire-contract tests) and aborts with a distinct exit code if either fails.
+# Spending GraphQL quota and Claude tokens to discover a bug the sim or the
+# wire-contract tests already caught for $0 is exactly the waste this ordering
+# exists to remove. See run_pregate below for the full rationale.
+#
+#   E2E_SKIP_PREGATE=1     skip the pre-gate entirely (iteration-only escape
+#                           hatch, mirroring E2E_SKIP_PREP — scripts/cut-
+#                           release.sh never sets this; the release path
+#                           always pays the pre-gate cost)
+#
 # Bed preflight (on by default — see preflight_bed below for the full rationale):
 #   Before anything runs, the bed checkout is fast-forwarded to the ref under
 #   test, its binary is rebuilt IN PLACE, stage-config drift is reported, and the
@@ -205,6 +218,57 @@ readonly BUDGET_EXHAUSTED_EXIT=3
 # Distinct exit code for a preflight failure — the suite never started, so a
 # non-zero exit here must not be read as "the engine is broken."
 readonly PREFLIGHT_FAILED_EXIT=4
+
+# Distinct exit code for a pre-gate failure (R1, #1454) — the sim suite
+# and/or the github/ wire-contract tests failed before any bed preflight,
+# build, or live GitHub/Claude call was made. Distinct from PREFLIGHT_FAILED_EXIT
+# (4, a bed-state problem) and BUDGET_EXHAUSTED_EXIT (3, a live-run problem):
+# this one means the free layers themselves caught something, so a caller
+# (e.g. cut-release.sh) can tell "cheap layer caught it, saved you the live
+# run" apart from "live e2e itself failed" or "GraphQL budget exhausted."
+readonly PREGATE_FAILED_EXIT=5
+
+# ---------------------------------------------------------------------------
+# Pre-gate (R1, #1454): refuse to spend live budget until the free, fast
+# layers pass.
+#
+# scripts/sim/run.sh --all (the sim e2e scenarios plus simgh's own model
+# tests) and the github/ wire-contract tests are BOTH already unconditional
+# inside `go test -race ./...` and already run on every PR (R7 — confirmed,
+# not built; see tests/sim/README.md's "Runtime and the `sim` tag decision"
+# and github/wire_contract_test.go). Re-running them here, scoped, is
+# deliberate rather than redundant: this script can be (and regularly is)
+# invoked standalone — E2E_SKIP_PREP=1, a manual `scripts/e2e/run.sh` — and
+# must never assume unit tests were "just run" by whoever invoked it.
+# Running the scoped subsets (./tests/sim/... and ./github/...) rather than
+# the full `go test -race ./...` keeps the pre-gate's own cost close to just
+# these two layers and matches the issue's own three-way phrasing (unit ->
+# sim e2e -> wire-contract tests as distinct layers) instead of blurring it
+# back into one broad "run everything" step.
+#
+# Ordering is load-bearing, exactly like preflight_bed below: this function
+# is called FIRST in the dispatch guard, strictly before prepare_bed_and_reset
+# — so a pre-gate failure is proven, by construction, to have made no bed
+# preflight, no build, and no live GitHub/Claude call. That ordering — not a
+# runtime check inside the suite itself — is what R1's AC1 demonstrates.
+# ---------------------------------------------------------------------------
+run_pregate() {
+  if [ -n "${E2E_SKIP_PREGATE:-}" ]; then
+    echo "== pre-gate skipped (E2E_SKIP_PREGATE set) — sim/wire-contract layers assumed already green =="
+    return 0
+  fi
+
+  echo "== pre-gate: sim suite + github wire-contract tests (R1, #1454) =="
+  if ! "$REPO_ROOT/scripts/sim/run.sh" --all; then
+    echo "pre-gate: sim suite failed — aborting before touching the live bed or making any live call." >&2
+    exit "$PREGATE_FAILED_EXIT"
+  fi
+  if ! ( cd "$REPO_ROOT" && go test -race -count=1 ./github/... ); then
+    echo "pre-gate: github wire-contract tests failed — aborting before touching the live bed or making any live call." >&2
+    exit "$PREGATE_FAILED_EXIT"
+  fi
+  echo "== pre-gate passed =="
+}
 
 # ---------------------------------------------------------------------------
 # Bed preflight: guarantee the bed is running the engine we mean to test.
@@ -699,18 +763,24 @@ switch_and_run() {
   fi
 }
 
-# Guarded so scripts/e2e/backoff_detection_test.sh can `source` this file to
-# reach detect_rate_limit_backoff (and the other helper functions above)
-# without triggering an actual gate run. Everything above this guard (repo
-# root resolution, TEST_BED/ENGINE_LOG/BED_TOKEN setup, function
+# Guarded so scripts/e2e/backoff_detection_test.sh and
+# scripts/e2e/pregate_test.sh can `source` this file to reach
+# detect_rate_limit_backoff / run_pregate (and the other helper functions
+# above) without triggering an actual gate run. Everything above this guard
+# (repo root resolution, TEST_BED/ENGINE_LOG/BED_TOKEN setup, function
 # definitions) is safe to execute on source — read-only or pure function
 # definitions, no gate invocation. When executed directly (./run.sh or
 # `bash run.sh`), BASH_SOURCE[0] equals $0, so this still dispatches exactly
 # as before this guard existed.
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  # Pre-gate FIRST (R1, #1454) — strictly before any bed preflight, build,
+  # restart, or live GitHub/Claude call. See run_pregate's own comment for
+  # why this ordering is the mechanism, not a runtime check.
+  run_pregate
+
   # Bed preflight + optional --clean reset. Inside the guard so sourcing this
-  # file (backoff_detection_test.sh) never touches a bed — or, in CI, aborts
-  # on the absence of one.
+  # file (backoff_detection_test.sh / pregate_test.sh) never touches a bed —
+  # or, in CI, aborts on the absence of one.
   prepare_bed_and_reset "$@"
   # --clean is consumed here, not inside the function: `shift` there would only
   # affect the function's own positional parameters, leaving --clean in "$@"

--- a/scripts/sim/run.sh
+++ b/scripts/sim/run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# scripts/sim/run.sh — on-demand entry point for the sim e2e layer (R8, #1454).
+#
+# Usage:
+#   scripts/sim/run.sh                # fast scenario layer only (tests/sim), ~42.5s
+#   scripts/sim/run.sh --all          # full tree (tests/sim/... incl. simgh/simclaude/ghfault), ~107s
+#   scripts/sim/run.sh -run TestFoo    # forwarded to `go test`, e.g. one scenario
+#   scripts/sim/run.sh --all -run Foo  # forwarded, against the full tree
+#
+# This is BOTH the frictionless manual entry point ("run the sim layer by
+# hand at any point before committing to a full live e2e run") AND what
+# scripts/e2e/run.sh's pre-gate (run_pregate) calls with --all — there is
+# exactly one definition of "the sim suite" in this repo, so the two never
+# drift apart.
+#
+# The sim layer carries no `sim` build tag (see tests/sim/README.md's
+# "Runtime and the `sim` tag decision") and already runs unconditionally
+# inside `go test -race ./...` on every PR — this script exists to give it a
+# distinct, nameable identity for manual/pre-gate use, not to change how CI
+# invokes it.
+#
+# Default target is the scenario layer only (./tests/sim, not ./tests/sim/...)
+# — that's the part that matters for a pre-gate (fast, and the layer that
+# actually exercises the pipeline), per R8's explicit instruction. --all adds
+# tests/sim/simgh (the model's own unit tests), tests/sim/simclaude, and
+# tests/sim/simgh/ghfault.
+#
+# Current measured runtime on a dev machine (tests/sim/README.md, #1454 —
+# inherently machine- and load-dependent; see that file for the caveat):
+#   tests/sim                42.5s   the scenarios (this script's default)
+#   tests/sim/simgh          105.0s  unit tests of the model itself (--all)
+#   tests/sim/simclaude        1.1s  (--all)
+#   tests/sim/simgh/ghfault    1.1s  (--all)
+#                            ~107s total wall clock (--all)
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+TARGET="./tests/sim"
+if [ "${1:-}" = "--all" ]; then
+  TARGET="./tests/sim/..."
+  shift
+fi
+
+echo "== sim suite: go test -race -count=1 $TARGET $* =="
+exec go test -race -count=1 "$TARGET" "$@"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,25 +20,63 @@ Every such regression that escapes a release earns a new scenario here.
 
 ## Where this lives in the release flow
 
+Four layers, not two (#1454 — see `adrs/1454-sim-pre-gate-not-replacement.md` for the
+full layering decision). **The sim bed is a fast, free pre-gate. It is never a
+replacement for this suite** — real Claude, real review bots, real GitHub wire
+behaviour, and real merge-queue semantics have no substitute, and this suite runs in
+full, before every release, permanently.
+
 ```
 [ go test ./... ]               unit tests; fast; run on every PR
         |
         v
-[ tests/e2e/... ]               integration tests; slow; run before release
-        |
+[ sim e2e (tests/sim) ]         fast sanity check: full pipelines, failure/timeout/
+        |                       restart/merge-train paths — seconds, $0 tokens, -race;
+        |                       already part of `go test -race ./...`, so also every PR
+        v
+[ github wire-contract tests ]  wire-format truth: schema + recorded fixtures (github/);
+        |                       also already part of `go test -race ./...`, every PR
+        v
+[ tests/e2e/... ]                integration truth: real Claude, real bots, real
+        |                       GitHub — slow, costs real tokens, runs before release
         v
 [ scripts/cut-release.sh ]      cuts a release
 ```
 
-Suggested integration with `cut-release.sh` (not yet wired):
+Each layer's blind spot, most important first:
+
+- **sim e2e is permanently blind to GraphQL/REST wire correctness** — `tests/sim`'s
+  GitHub client (`simgh`) is a hand-modeled fake; see `tests/sim/README.md`'s "What this
+  layer is permanently blind to" and `tests/sim/simgh/FIDELITY.md` for the maintained
+  ledger of every known divergence from real GitHub. Closed only by the wire-contract
+  tests below and by this suite.
+- **The wire-contract tests validate shape, not runtime behavior** — a query can be
+  schema-valid and still be logically wrong. They prove "this is a query GitHub's schema
+  accepts," not "this is the query that produces the right result." That's what sim e2e
+  and this suite are for.
+- **This suite (`tests/e2e`) has no structural blind spot** — it's the only layer that
+  exercises real Claude, real review bots, and real GitHub wire behaviour together. That
+  is exactly why it is never reduced or retired, no matter how much sim coverage grows.
+
+Wired into `scripts/cut-release.sh` (R2, #1454): the sim suite and wire-contract tests
+run as an unconditional, never-skippable pre-gate step; the live suite (this directory)
+runs as a mandatory-by-default step immediately after build+test. The one sanctioned
+escape hatch is loud and recorded, never silent:
 
 ```bash
-scripts/cut-release.sh v0.0.67                       # default — does NOT run e2e
-scripts/cut-release.sh v0.0.67 --integration-check   # run e2e before tagging
-scripts/cut-release.sh v0.0.67 --skip-integration    # explicit skip when iterating
+scripts/cut-release.sh v0.0.67                              # default — runs the full live suite
+scripts/cut-release.sh v0.0.67 --skip-integration=<reason>  # loud, recorded escape hatch —
+                                                              # the reason ships in the release notes
 ```
 
-We'll flip the default to `--integration-check` once the suite is stable.
+A bare `--skip-integration` (no reason) is a hard usage error, by design — see
+`adrs/1454-sim-pre-gate-not-replacement.md`'s R2 section for why "no flag at all" was
+rejected in favor of this loudly-labelled one.
+
+`scripts/e2e/run.sh` itself also runs the sim + wire-contract pre-gate first (R1,
+#1454) — before any bed preflight, build, or live call — whether invoked standalone or
+via `cut-release.sh`, so a live-gate run never spends live budget on a bug the free
+layers would have caught for $0.
 
 ## Test bed prerequisites
 
@@ -1249,9 +1287,17 @@ Every escape-from-release regression earns a new scenario in this table.
 
 - **Cost per run is non-trivial.** A full cross-repo scenario costs $1–3 in
   Claude tokens. The suite is not for casual local iteration.
-- **CI integration is not wired yet.** Initially the suite is operator-only —
-  run before cutting a release. Future work: a GitHub Actions runner that
-  exercises the suite on a schedule.
+- **This suite deliberately never runs in CI** — it drives a real Fabrik bed
+  against real repos with real Claude and real review bots, which cannot run
+  unattended in a PR job (cost, time, and blast radius). CI only compiles it
+  (`go test -tags e2e -run '^$' ./tests/e2e/...`, catching signature breaks
+  without executing a scenario or making a network call). It is operator-run
+  before cutting a release, via `scripts/cut-release.sh` (R2, #1454) or
+  standalone via `scripts/e2e/run.sh`. This is a permanent, deliberate
+  design choice, not a "not wired yet" gap — contrast with the sim e2e and
+  github wire-contract layers above (R7, #1454), which already run on every
+  PR unconditionally (confirmed, not built — see `tests/sim/README.md`'s
+  "Runtime and the `sim` tag decision").
 - **GitHub rate-limit pressure.** Shared with `~/dev/fabrik/` (the dev
   instance) under the `@arbeithand` token. Stop the dev instance if running
   the full suite.

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -490,6 +490,34 @@ Scope (which explicitly does not include changing this package's own testing
 infrastructure beyond what its scenarios need) is positioned to make
 unilaterally.
 
+**Updated for #1454 (correcting stale figures).** The "~92s total" /
+"comfortably under the ~90s line" conclusion two sections up predates the
+merge-train suite's addition (#1452, directly above) and has been stale
+since. Current measured runtime on a dev machine, recorded here as the
+honest current numbers rather than re-derived on every future edit (per this
+issue's own R8 — these figures are inherently machine- and load-dependent,
+as this section's whole revision history demonstrates):
+
+```
+tests/sim               42.5s     the scenarios
+tests/sim/simgh        105.0s     unit tests of the model itself
+tests/sim/simclaude      1.1s
+tests/sim/simgh/ghfault  1.1s
+                        ~107s total wall clock
+```
+
+The scenario layer alone (42.5s) is the part that matters for a pre-gate —
+it's the layer that actually exercises the pipeline — and it is plenty fast
+for that purpose; `simgh`'s own 105s is the model's unit-test suite, not
+pipeline coverage, and dominates the `--all` total the same way it has
+throughout this file's history. `scripts/sim/run.sh` (repo root) is the
+frictionless on-demand entry point this issue adds (R8): with no arguments
+it runs the scenario layer only (`./tests/sim`, ~42.5s); `--all` runs the
+full tree above (~107s). It's both the manual "run the sim layer by hand
+before committing to a full live e2e run" entry point and what
+`scripts/e2e/run.sh`'s pre-gate calls — see
+`adrs/1454-sim-pre-gate-not-replacement.md` for the full layering decision.
+
 ## Settle-scan inventory and recovery-machinery coverage (#1451)
 
 #1451 added the sim layer's first coverage of the engine's recovery
@@ -608,10 +636,42 @@ see that file's own doc comment for two earlier drafts (a 7-stage and a
 landing on the shallow pipeline that actually isolates R6's target
 (dispatch/lock/worktree contention), independent of pipeline depth.
 
+## Fidelity-drift policy (R4, #1454)
+
+The sim bed's entire value as a pre-gate (see
+`adrs/1454-sim-pre-gate-not-replacement.md`) depends on one property: it must not pass
+what live e2e would fail. A sim that does is worse than no gate at all — it manufactures
+false confidence at exactly the point where confidence is being relied on to justify
+skipping (or later starting) a full live run.
+
+**Rule:** any live-e2e failure that the sim passed is a fidelity bug in the sim, and is
+fixed there as well as in the engine.
+
+**Procedure**, when this happens:
+
+1. **File a fidelity issue** describing the divergence — what live e2e caught that the
+   sim's scenarios didn't, and why the sim's model (`simgh`) let it through.
+2. **Add the scenario to `tests/sim`** so the same class of bug cannot silently pass here
+   again — the same porting discipline #1450–#1452 already established for every other
+   scenario in this package.
+3. **Update `tests/sim/simgh/FIDELITY.md`** — the permanent, deliberate ledger of every
+   place `simgh` knowingly departs from real GitHub — with the divergence found and what
+   it costs. If you are relying on a sim-backed test to cover something subtle, check
+   that file first; if you change the model, update it in the same commit.
+
+This is a release-checklist step (`.claude/skills/cut-release/SKILL.md`), not something
+that depends on someone remembering it after a bad live run. It does not retroactively
+cover every gap the sim has — `simgh/FIDELITY.md`'s "Absent"-labeled entries are known,
+accepted blind spots, not violations of this rule — it covers the specific, high-signal
+case where live e2e actually caught something in production use that the pre-gate should
+have caught first.
+
 ## Running it
 
 ```bash
-go test -race ./tests/sim/...          # the suite (this package + simgh + simclaude)
+scripts/sim/run.sh                     # on-demand entry point (R8): scenario layer only, ~42.5s
+scripts/sim/run.sh --all               # full tree (this package + simgh + simclaude + ghfault), ~107s
+go test -race ./tests/sim/...          # equivalent to --all above, invoked directly
 bash tests/sim/simgh/nonvacuity.sh     # the simgh mutation sweep (needs a clean tree)
 ```
 

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -659,8 +659,11 @@ fixed there as well as in the engine.
    it costs. If you are relying on a sim-backed test to cover something subtle, check
    that file first; if you change the model, update it in the same commit.
 
-This is a release-checklist step (`.claude/skills/cut-release/SKILL.md`), not something
-that depends on someone remembering it after a bad live run. It does not retroactively
+This is a release-checklist step — recorded in `scripts/cut-release.sh`'s own header
+comment and its live-gate failure message (a platform-level write restriction on
+`.claude/skills/cut-release/SKILL.md` blocks recording it there too; see
+`adrs/1454-sim-pre-gate-not-replacement.md`'s R4 section) — not something that depends
+on someone remembering it after a bad live run. It does not retroactively
 cover every gap the sim has — `simgh/FIDELITY.md`'s "Absent"-labeled entries are known,
 accepted blind spots, not violations of this rule — it covers the specific, high-signal
 case where live e2e actually caught something in production use that the pre-gate should


### PR DESCRIPTION
Closes #1454

## What this does

Wires the four test layers (`go test ./...` → sim e2e → github wire-contract tests → live e2e) into the actual release path, per #1454.

**R1 — sim as pre-gate.** `scripts/e2e/run.sh` gets a new `run_pregate()`, called as the very first statement in its dispatch guard — strictly before any bed preflight, build, restart, or live GitHub/Claude call. It runs `scripts/sim/run.sh --all` + `go test -race ./github/...` and aborts with a new distinct exit code (`PREGATE_FAILED_EXIT=5`) on failure. Proven live in this session: with a deliberately broken sim test, `scripts/e2e/run.sh` exited `5` after ~7 minutes of sim/wire-contract test output and printed zero references to bed preflight or live-run machinery — the abort is structural (ordering), not a runtime check.

**R8 — on-demand entry point.** New `scripts/sim/run.sh`: default runs the scenario layer only (`./tests/sim`, ~42.5s — the part that matters for a pre-gate); `--all` runs the full tree (~107s). This is also what `run_pregate` calls, so there's exactly one definition of "the sim suite."

**R2 — `cut-release.sh` wired, live suite mandatory.** `scripts/cut-release.sh` is refactored (mechanically — `parse_args()` + `main()` behind the same dispatch-guard pattern `run.sh` already uses) and gains:
- An **unconditional** sim + wire-contract pre-gate step (never skippable, not even by `--skip-tests`).
- A **mandatory-by-default** live e2e integration gate (invokes `scripts/e2e/run.sh` against `origin/main`).
- `--skip-integration=<reason>` — the one sanctioned escape hatch: loud (warning banner) and recorded (the reason is inserted into the release notes' `## Internal` section). A bare `--skip-integration` with no reason is refused. Decision and rationale (option (b) over a no-flag-at-all option (a)) are in the new ADR.

**R4 — fidelity-drift policy**, written into `tests/sim/README.md`: any live-e2e failure the sim passed is a fidelity bug in the sim, fixed there as well as in the engine, with a concrete 3-step procedure (file the issue, add the scenario, update `simgh/FIDELITY.md`). Folded into `cut-release.sh`'s own step list and its live-gate failure message as a release-checklist reminder — see note below on `.claude/skills/cut-release/SKILL.md`.

**R5 — new ADR** (`adrs/1454-sim-pre-gate-not-replacement.md`) records the four-layer architecture, each layer's blind spots (sim's inability to see wire format most prominently), the R2 mandatory-live-suite decision with reasoning, and the R4 policy in full.

**R6/R7 — docs.** `tests/e2e/README.md` and `CLAUDE.md` rewritten with the real four-layer flow and CI placement; confirmed (not built) that `tests/sim` and the `github/` wire-contract tests already run on every PR via the existing `go test -race ./...` CI step (no build tag on either). No canonical doc page (`USER_GUIDE.md`/`state-machine.md`/`stage-lifecycle.md`/`positioning.md`) was touched, so `docs/llms-full.txt` regeneration correctly doesn't apply here.

New regression tests `scripts/e2e/pregate_test.sh` and `scripts/cut_release_gate_test.sh` (both wired into CI) prove the pre-gate's exit-code/ordering contract and `cut-release.sh`'s new flag parsing, entirely via mocks — no real bed, network, or publish calls (AC7).

## One known gap, flagged for a human

**`.claude/skills/cut-release/SKILL.md` was not edited.** The agent tool layer in this environment refuses `Edit`/`Write` against that specific path (confirmed: every other file, including `scripts/cut-release.sh` itself, edits normally). The issue's own R4 wording accepts either `SKILL.md`'s Steps section *or* `cut-release.sh`'s own step list, so the equivalent content (new step list, `--skip-integration=<reason>`, the R4 reminder) was folded into `cut-release.sh`'s header comment and live-gate failure message instead. A maintainer with write access to that path should still port the same content into `SKILL.md` for consistency — it's a pure documentation mirror, not a behavioral gap.

## How to test

- `bash scripts/e2e/pregate_test.sh` and `bash scripts/cut_release_gate_test.sh` — both pass, no network/bed required.
- `bash scripts/e2e/backoff_detection_test.sh` — pre-existing regression test, still passes (confirms the dispatch-guard refactor didn't disturb it).
- `go build ./...`, `go vet ./...`, `gofmt -s -l .` — all clean.
- `go test -race ./...` — passes end to end (verified with headroom for this machine's current shared load; this issue's own commits touch no `engine/`, `github/`, or `tests/sim` source code, only `tests/sim/README.md` and the scripts/docs/ADR listed above).
- Live AC1 demo (not committed): temporarily added `t.Fatal(...)` to `TestBaseBranchPipeline`, ran `bash scripts/e2e/run.sh`, confirmed exit `5` and zero bed/live references in output, then reverted cleanly (`git diff` empty afterward).