### PR TITLE
test(merge-train): cover the R8 fail-closed guard so it cannot rot unnoticed

### DIFF
--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -2562,6 +2562,23 @@ func isTrainPR(pr gh.PRDetails) bool {
 	return strings.HasPrefix(pr.HeadRefName, trainBranchPrefix)
 }
 
+// shouldCloseStaleTrainPR reports whether pr's head ref is a genuine
+// fabrik/merge-train/* branch, and therefore safe for reconstructTrainState's
+// stale-PR sweep to close (R8, #1615/#1622). It is deliberately *not*
+// implemented in terms of isTrainPR, even though the two bodies are
+// textually identical: R8 exists to be an independent, directly-testable
+// re-confirmation of structural identity immediately before the destructive
+// CloseIssue call, not merely inherited from the isTrainPR filter earlier in
+// the same loop. Today that filter already guarantees this is unreachable
+// with a false result — the value here is that a future change to isTrainPR,
+// or to the loop above it, cannot silently re-open the #1615 incident by
+// letting an unrecognized PR reach the close call, because this check would
+// still catch it independently. Delegating to isTrainPR would collapse the
+// two into one check and defeat that purpose.
+func shouldCloseStaleTrainPR(pr gh.PRDetails) bool {
+	return strings.HasPrefix(pr.HeadRefName, trainBranchPrefix)
+}
+
 // trialNameFromBranch strips the fabrik/merge-train/ prefix from a trial branch
 // head ref, returning the bare trial name (e.g. "merge-train-main-123"). Returns
 // "" when headRef is not a merge-train branch.
@@ -3253,7 +3270,7 @@ func (e *Engine) reconstructTrainState(ctx context.Context, state *mergeTrainWor
 			// filter (or to this loop) cannot silently re-open the #1615 incident by
 			// letting an unrecognized PR reach the close call. Ambiguity fails closed:
 			// skip and log, never close.
-			if !strings.HasPrefix(prs[i].HeadRefName, trainBranchPrefix) {
+			if !shouldCloseStaleTrainPR(prs[i]) {
 				e.logf(0, "merge-train", "reconstruct: skipping PR #%d (state=open, no members still Queued) — head ref %q is not a train branch, not closing\n", prs[i].Number, prs[i].HeadRefName)
 				continue
 			}

--- a/engine/merge_train_test.go
+++ b/engine/merge_train_test.go
@@ -4631,6 +4631,32 @@ func TestIsTrainPR(t *testing.T) {
 	}
 }
 
+// TestShouldCloseStaleTrainPR covers R8's independent re-check (#1622): the
+// identity guard reconstructTrainState's stale-PR sweep re-confirms immediately
+// before its destructive CloseIssue call. Deliberately mirrors TestIsTrainPR's
+// cases, including the exact #1615 shape (a non-train head ref whose body quotes
+// the batch marker) — that case must return false regardless of body content, so
+// deleting shouldCloseStaleTrainPR's identity check turns this test red (AC1).
+func TestShouldCloseStaleTrainPR(t *testing.T) {
+	cases := []struct {
+		name string
+		pr   gh.PRDetails
+		want bool
+	}{
+		{"marker in body alone, non-train branch — must NOT match (the #1615 shape)", gh.PRDetails{Body: "before " + mergeTrainBatchMarker + " after", HeadRefName: "fabrik/issue-1615"}, false},
+		{"marker in body alone, empty head ref — must NOT match", gh.PRDetails{Body: mergeTrainBatchMarker}, false},
+		{"non-train head ref, plain body", gh.PRDetails{Body: "just a normal PR", HeadRefName: "fabrik/issue-42"}, false},
+		{"train head branch, no marker (draft CI PR)", gh.PRDetails{HeadRefName: "fabrik/merge-train/merge-train-main-1"}, true},
+		{"train head branch with marker (landing PR)", gh.PRDetails{Body: mergeTrainBatchMarker, HeadRefName: "fabrik/merge-train/x"}, true},
+		{"empty", gh.PRDetails{}, false},
+	}
+	for _, tc := range cases {
+		if got := shouldCloseStaleTrainPR(tc.pr); got != tc.want {
+			t.Errorf("shouldCloseStaleTrainPR(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 // TestTrialNameFromBranch verifies stripping the fabrik/merge-train/ prefix from a
 // head ref, and the empty return for non-train branches.
 func TestTrialNameFromBranch(t *testing.T) {


### PR DESCRIPTION
Closes #1622

## What this does

Extracts the R8 fail-closed guard's identity check — the re-check `reconstructTrainState` performs immediately before its destructive `CloseIssue` call on a stale open merge-train PR — into a small, directly testable pure function, `shouldCloseStaleTrainPR(pr gh.PRDetails) bool`, and adds direct unit tests for it.

Before this change, R8 had zero test coverage: it could be deleted entirely and the whole suite stayed green, because R7 (`isTrainPR`'s structural branch-identity filter) already guarantees the reconstruct loop never reaches R8 with a non-train PR under normal execution. R8 exists specifically as an independent backstop against a *future* regression of R7 — but a backstop nobody can notice the loss of isn't really a backstop.

## Key changes

- **`engine/merge_train.go`**: added `shouldCloseStaleTrainPR`, placed next to `isTrainPR`. Its body is intentionally identical to `isTrainPR`'s (`strings.HasPrefix(pr.HeadRefName, trainBranchPrefix)`) but it does **not** delegate to `isTrainPR` — that would collapse R7 and R8 into one shared check and defeat the whole point of having two independent layers. The reconstruct loop's `if` at the R8 call site now calls this function; the skip-path log line, control flow, and close conditions are byte-for-byte unchanged.
- **`engine/merge_train_test.go`**: added `TestShouldCloseStaleTrainPR`, styled after `TestIsTrainPR`, covering the exact #1615 shape (a non-train head ref whose body quotes the batch marker → must return `false`), plus genuine train branches (with/without marker → `true`) and edge cases.

No production behavior change — this is a pure testability refactor (R3/R4 of #1622).

## How this was verified

- **AC1** (deleting the guard's identity check turns a test red): verified locally by temporarily stubbing `shouldCloseStaleTrainPR` to always return `true` — `TestShouldCloseStaleTrainPR` failed on all 4 `false`-expecting cases — then restored. Not committed; this was a demonstration, not a shipped mutation.
- **AC2**: `TestReconstructTrainState_StaleOpenPR_ClosedAndProceedsFresh` and `TestReconstructTrainState_MarkerOnlyNonTrainBranchPR_NeverClosed` pass unchanged.
- **AC3** (R8 is independently effective even if R7 regresses): verified locally by temporarily reverting `isTrainPR` to the pre-#1615 marker-`||`-branch form — `TestIsTrainPR` failed as expected, while `TestShouldCloseStaleTrainPR` stayed green, proving the two checks protect independently. Restored `isTrainPR` to its current form (`git diff` on it is empty in this PR).
- **AC4**: `go test -race ./engine/` clean; `go vet ./...` clean; `go build` clean.

## To test

```bash
go test -race ./engine/ -run 'TestShouldCloseStaleTrainPR|TestIsTrainPR|TestReconstructTrainState'
```