### PR TITLE
docs: document the spec-authoring plugin and landing-verification labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ The PM plugin is independent of the engine — install it on its own to chat abo
 
 > **Distinct from `fabrik-workflows`**: the engine's stage skills are embedded in the binary and deployed automatically to `.fabrik/plugin/` by `fabrik init`. You do not — and should not — install `fabrik-workflows` manually.
 
+## Fabrik Project Onboarding Plugin
+
+Another optional Claude Code plugin, aimed at a product manager or business owner rather than an engineer — no terminal, git, or technical background needed. It interviews you about your project's goals, users, scope, constraints, and vocabulary, then turns individual feature ideas into a standard GitHub [Spec Kit](https://github.com/github/spec-kit) `specs/NNN-feature-name/` folder, ready to hand to Fabrik for build.
+
+```
+/plugin marketplace add handarbeit/fabrik
+/plugin install fabrik-project-onboarding@fabrik
+```
+
+It is not installed by `fabrik init`. See [Fabrik Project Onboarding Plugin](docs/USER_GUIDE.md#fabrik-project-onboarding-plugin) in the User Guide for the full skill list, installation options, and attribution.
+
 ## How It Works
 
 ```

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2256,6 +2256,35 @@ Alternatively, enable auto-update via the plugin UI: `/plugin` → Marketplaces 
 
 ---
 
+### Fabrik Project Onboarding Plugin
+
+The **Fabrik Project Onboarding plugin** (`fabrik-project-onboarding`) is a separate, optional Claude Code plugin aimed at a product manager or business owner, not the engineer — no terminal, git, or technical background needed. It interviews you about a project and its features, then writes the result as a standard GitHub [Spec Kit](https://github.com/github/spec-kit) `specs/NNN-feature-name/` folder — byte-compatible with upstream Spec Kit, so it can be handed to Fabrik, or to any development team, without translation. It is not installed by `fabrik init` and carries no relationship to the engine's own worker plugin.
+
+#### Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `onboard` | A 30–45 minute interview about the project as a whole — the problem it solves, who it serves, what's in and out of scope, hard constraints, and domain vocabulary. Writes `.specify/memory/constitution.md`, the ground rules every later spec inherits. Run once at the start of a project. |
+| `write-spec` | Turns a feature described in plain language into a structured spec — user stories, requirements, success criteria, and a graded quality checklist — under `specs/NNN-feature-name/`. |
+| `clarify` | Reads an existing spec, finds what's vague or missing, and asks up to five targeted questions one at a time, writing each answer straight into the document. |
+
+#### Install
+
+In an interactive Claude Code session:
+
+```
+/plugin marketplace add handarbeit/fabrik
+/plugin install fabrik-project-onboarding@fabrik
+```
+
+The plugin's primary audience installs it through the Claude desktop app's Cowork UI instead (**Cowork** → **Customize** → **Plugins** → **Add marketplace** → `handarbeit/fabrik` → install **Fabrik Project Onboarding**); the commands above are the developer-facing equivalent. See the plugin's own [GETTING-STARTED.md](https://github.com/handarbeit/fabrik/blob/main/plugin/fabrik-project-onboarding/GETTING-STARTED.md) for the full non-technical walkthrough.
+
+#### Attribution
+
+The `write-spec` and `clarify` skills are adapted from [github/spec-kit](https://github.com/github/spec-kit) (MIT licensed); `onboard` is a Fabrik-original interview skill mapped onto Spec Kit's constitution output shape. See the plugin's own `NOTICE.md` for the full license text and a detailed account of what was kept, removed, and changed from upstream.
+
+---
+
 ### How Skills Work
 
 Each stage references a **skill** -- a markdown file that contains detailed methodology
@@ -2556,6 +2585,9 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `fabrik:api-key-helper-detected` | Set when a stage invocation is skipped because the worktree's own `.claude/settings.json` sets `apiKeyHelper` — a repo-resident setting Fabrik cannot see until the worktree exists. Does not count against `max_retries`; no `fabrik:paused` or `stage:<name>:failed` applied. Clears automatically once `apiKeyHelper` is removed from the file and a later invocation reaches Claude successfully — no manual removal needed. See [Anthropic Auth Namespace Scrub & `apiKeyHelper` Refusal](#anthropic-auth-namespace-scrub--apikeyhelper-refusal). |
 | `fabrik:tools-denied` | Set when Claude's own permission layer denies one or more mutating tool calls during an invocation, detected structurally from the CLI's `permission_denials` result field. Does not count against `max_retries`; bounded instead by its own `--max-tools-denied-retries` counter (default 3), at which point `fabrik:paused` + `fabrik:awaiting-input` are applied — never `stage:<name>:failed`. Clears automatically on the next invocation that isn't itself classified as tools-denied. See the "Troubleshooting: an issue carries `fabrik:tools-denied`" note under [Retry and Escalation](#retry-and-escalation). |
 | `fabrik:awaiting-runaway-alert` | Set when the merge-train runaway guard (ADR-059 D8) pauses a `Queued` member (`fabrik:paused` + `fabrik:awaiting-input` applied unconditionally) but its `AddComment` alert call fails. Retried every poll by a settle scan, independent of `fabrik:paused`'s presence, until the alert succeeds or a fallback comment lands. Cleared only once some explanation is confirmed delivered — a persistent comment-post outage leaves the marker in place indefinitely rather than erasing the last diagnostic signal. See [§6.18 Runaway Guard Alert Retry](state-machine.md#618-runaway-guard-alert-retry-adr-1533) (ADR-1533). |
+| `fabrik:awaiting-landing-verification` | Set immediately after a Done transition attributable to a merge (merge-train batch/singleton landing, or the ordinary auto-merge path) succeeds. The post-Done settle scan confirms the credited PR actually reached `MERGED`. Clears automatically once confirmed. See [§6.19 Post-Done Landing Verification](state-machine.md#619-post-done-landing-verification-adr-1616) (ADR-1616). |
+| `fabrik:credited-pr:<N>` | Set alongside `fabrik:awaiting-landing-verification`, but only by the two merge-train landing paths, recording which PR (the integration/singleton PR, distinct from the member's own closed-not-merged PR) was credited for the Done transition. Clears whenever `fabrik:awaiting-landing-verification` clears. See §6.19. |
+| `fabrik:landing-verification-failed` | Set only on a **confirmed** non-merge of the credited PR — the issue is simultaneously reopened and moved back to `Validate`. **Not self-clearing** — remove manually once the credited PR is re-landed and re-verified. See §6.19. |
 | `stage:<name>:in_progress` | Stage actively running |
 | `stage:<name>:complete` | Stage completed successfully |
 | `stage:<name>:failed` | Stage hit max retries |

--- a/docs/index.md
+++ b/docs/index.md
@@ -387,6 +387,13 @@ fabrik --auto-upgrade</pre>
           A Claude Code plugin for your own session — ask "what's on the board?" or "why is #42 stuck?" and steer Fabrik from inside interactive Claude Code. No binary install needed.
         </div>
       </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#fabrik-project-onboarding-plugin" aria-label="Project Onboarding Plugin — open documentation">
+        <span class="feature-icon">📝</span>
+        <div class="feature-title">Project Onboarding Plugin</div>
+        <div class="feature-desc">
+          A Claude Code plugin for non-engineers — interviews you about a project and its features, then writes standard Spec Kit specs ready to hand to Fabrik. No binary, terminal, or git needed.
+        </div>
+      </a>
       <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#git-repositories-and-worktrees" aria-label="Isolated Git Worktrees — open documentation">
         <span class="feature-icon">🌿</span>
         <div class="feature-title">Isolated Git Worktrees</div>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2254,6 +2254,35 @@ Alternatively, enable auto-update via the plugin UI: `/plugin` → Marketplaces 
 
 ---
 
+### Fabrik Project Onboarding Plugin
+
+The **Fabrik Project Onboarding plugin** (`fabrik-project-onboarding`) is a separate, optional Claude Code plugin aimed at a product manager or business owner, not the engineer — no terminal, git, or technical background needed. It interviews you about a project and its features, then writes the result as a standard GitHub [Spec Kit](https://github.com/github/spec-kit) `specs/NNN-feature-name/` folder — byte-compatible with upstream Spec Kit, so it can be handed to Fabrik, or to any development team, without translation. It is not installed by `fabrik init` and carries no relationship to the engine's own worker plugin.
+
+#### Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `onboard` | A 30–45 minute interview about the project as a whole — the problem it solves, who it serves, what's in and out of scope, hard constraints, and domain vocabulary. Writes `.specify/memory/constitution.md`, the ground rules every later spec inherits. Run once at the start of a project. |
+| `write-spec` | Turns a feature described in plain language into a structured spec — user stories, requirements, success criteria, and a graded quality checklist — under `specs/NNN-feature-name/`. |
+| `clarify` | Reads an existing spec, finds what's vague or missing, and asks up to five targeted questions one at a time, writing each answer straight into the document. |
+
+#### Install
+
+In an interactive Claude Code session:
+
+```
+/plugin marketplace add handarbeit/fabrik
+/plugin install fabrik-project-onboarding@fabrik
+```
+
+The plugin's primary audience installs it through the Claude desktop app's Cowork UI instead (**Cowork** → **Customize** → **Plugins** → **Add marketplace** → `handarbeit/fabrik` → install **Fabrik Project Onboarding**); the commands above are the developer-facing equivalent. See the plugin's own [GETTING-STARTED.md](https://github.com/handarbeit/fabrik/blob/main/plugin/fabrik-project-onboarding/GETTING-STARTED.md) for the full non-technical walkthrough.
+
+#### Attribution
+
+The `write-spec` and `clarify` skills are adapted from [github/spec-kit](https://github.com/github/spec-kit) (MIT licensed); `onboard` is a Fabrik-original interview skill mapped onto Spec Kit's constitution output shape. See the plugin's own `NOTICE.md` for the full license text and a detailed account of what was kept, removed, and changed from upstream.
+
+---
+
 ### How Skills Work
 
 Each stage references a **skill** -- a markdown file that contains detailed methodology
@@ -2554,6 +2583,9 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `fabrik:api-key-helper-detected` | Set when a stage invocation is skipped because the worktree's own `.claude/settings.json` sets `apiKeyHelper` — a repo-resident setting Fabrik cannot see until the worktree exists. Does not count against `max_retries`; no `fabrik:paused` or `stage:<name>:failed` applied. Clears automatically once `apiKeyHelper` is removed from the file and a later invocation reaches Claude successfully — no manual removal needed. See [Anthropic Auth Namespace Scrub & `apiKeyHelper` Refusal](#anthropic-auth-namespace-scrub--apikeyhelper-refusal). |
 | `fabrik:tools-denied` | Set when Claude's own permission layer denies one or more mutating tool calls during an invocation, detected structurally from the CLI's `permission_denials` result field. Does not count against `max_retries`; bounded instead by its own `--max-tools-denied-retries` counter (default 3), at which point `fabrik:paused` + `fabrik:awaiting-input` are applied — never `stage:<name>:failed`. Clears automatically on the next invocation that isn't itself classified as tools-denied. See the "Troubleshooting: an issue carries `fabrik:tools-denied`" note under [Retry and Escalation](#retry-and-escalation). |
 | `fabrik:awaiting-runaway-alert` | Set when the merge-train runaway guard (ADR-059 D8) pauses a `Queued` member (`fabrik:paused` + `fabrik:awaiting-input` applied unconditionally) but its `AddComment` alert call fails. Retried every poll by a settle scan, independent of `fabrik:paused`'s presence, until the alert succeeds or a fallback comment lands. Cleared only once some explanation is confirmed delivered — a persistent comment-post outage leaves the marker in place indefinitely rather than erasing the last diagnostic signal. See [§6.18 Runaway Guard Alert Retry](state-machine.md#618-runaway-guard-alert-retry-adr-1533) (ADR-1533). |
+| `fabrik:awaiting-landing-verification` | Set immediately after a Done transition attributable to a merge (merge-train batch/singleton landing, or the ordinary auto-merge path) succeeds. The post-Done settle scan confirms the credited PR actually reached `MERGED`. Clears automatically once confirmed. See [§6.19 Post-Done Landing Verification](state-machine.md#619-post-done-landing-verification-adr-1616) (ADR-1616). |
+| `fabrik:credited-pr:<N>` | Set alongside `fabrik:awaiting-landing-verification`, but only by the two merge-train landing paths, recording which PR (the integration/singleton PR, distinct from the member's own closed-not-merged PR) was credited for the Done transition. Clears whenever `fabrik:awaiting-landing-verification` clears. See §6.19. |
+| `fabrik:landing-verification-failed` | Set only on a **confirmed** non-merge of the credited PR — the issue is simultaneously reopened and moved back to `Validate`. **Not self-clearing** — remove manually once the credited PR is re-landed and re-verified. See §6.19. |
 | `stage:<name>:in_progress` | Stage actively running |
 | `stage:<name>:complete` | Stage completed successfully |
 | `stage:<name>:failed` | Stage hit max retries |


### PR DESCRIPTION
Closes #1626

This is a documentation-only PR that closes the two v0.0.80 doc gaps identified in the issue:

1. **the spec-authoring plugin plugin** — was undocumented anywhere in user-facing docs. Added:
   - `README.md`: a new `## Fabrik Project Onboarding Plugin` section mirroring the existing PM plugin section (install snippet, what it does, link to detail).
   - `docs/USER_GUIDE.md`: a new `### Fabrik Project Onboarding Plugin` subsection under `## 5. Plugin & Skills`, covering the three skills (`onboard`, `write-spec`, `clarify`), what the plugin produces, install instructions, and Spec Kit attribution (per the plugin's own `NOTICE.md`).
   - `docs/index.md`: a matching feature card in the `features-grid`, positioned next to the existing "Interactive PM Plugin" card.

2. **Three new landing-verification labels** (`fabrik:awaiting-landing-verification`, `fabrik:credited-pr:<N>`, `fabrik:landing-verification-failed`) — already documented in `docs/state-machine.md` §6.19 and root `CLAUDE.md`, but missing from `docs/USER_GUIDE.md`'s user-facing "Fabrik-Managed Labels" table. Added all three, consistent with the internal docs — including that `fabrik:landing-verification-failed` is a human-gated label the user must remove manually, unlike most of the table's other self-clearing entries.

`docs/llms-full.txt` was regenerated (`bash scripts/generate-llms-full.sh`) in the same commit per the canonical-doc-bundle rule, since `USER_GUIDE.md` was touched.

**How to test:**
- Diff review: confirm the new README/USER_GUIDE/index.md sections read consistently with existing precedent and that install commands/anchors match `the plugin directory/.claude-plugin/plugin.json` (`name: the spec-authoring plugin`) and `.claude-plugin/marketplace.json` (`name: fabrik`).
- `bash scripts/generate-llms-full.sh && git diff --stat docs/llms-full.txt` should show no diff (already regenerated and committed).
- No code changes; `go build`, `go vet`, and the full non-`tests/sim` unit suite plus `tests/sim` (run in isolation) all pass. Two failures seen only when running `go test -race ./...` as one giant batch (`tests/sim` hitting a package-level 5m timeout mid-git-subprocess-call, and `cmd.TestExecute_ConfigYAMLApplied`'s SIGINT-timing check) are environmental/sandbox flakes — both packages pass cleanly when run on their own, and this PR touches no Go source.

Scope is exactly the four files called out in the issue: `README.md`, `docs/USER_GUIDE.md`, `docs/index.md`, `docs/llms-full.txt` (regen only).