### PR TITLE
fix(sim,e2e): cap sim suite parallelism, bound git timeouts, reap orphans, dedup pre-gate (#1624)

### DIFF
--- a/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
+++ b/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
@@ -123,12 +123,24 @@ children it forks inherit that group — without an external dependency, on both
 needs a different shape: it is a multi-stage pipe (`go test -json | tee | jq`) whose exit
 code capture already depends on `pipefail`, and naively backgrounding only the pipe's last
 stage would make `$!` resolve to `jq`'s PID, not `go test`'s — silently breaking both the
-reap and the exit-code capture. It uses process substitution (`> >(tee ... | jq ...) 2>&1 &`)
-instead, so `$!` is `go test`'s own PID, preserving the existing log-capture and
-`wait ... || rc=$?` exit-code discipline unchanged. (This exact file has a prior incident
-from getting a similar restructuring wrong — see #1547 — which is why this shape was chosen
-deliberately rather than by the more obvious but fragile "just background the pipeline"
-route.)
+reap and the exit-code capture. It uses process substitution (`exec 3> >(tee ... | jq ...)`,
+`go test ... >&3 2>&1 &`) instead, so `$!` (captured right after backgrounding `go test`) is
+`go test`'s own PID, preserving the existing log-capture and `wait ... || rc=$?` exit-code
+discipline unchanged. (This exact file has a prior incident from getting a similar
+restructuring wrong — see #1547 — which is why this shape was chosen deliberately rather
+than by the more obvious but fragile "just background the pipeline" route.)
+
+The process substitution is opened on an explicit fd (3) rather than inline on the `go test`
+command specifically so its own PID can be captured and `wait`ed on separately from `go
+test`'s: `wait "$suite_pid"` only blocks until `go test` exits, not until the `tee`/`jq`
+consumer reading its now-closed pipe has finished flushing `$jsonlog` to disk. During review,
+the first version of this fix backgrounded `go test` with the process substitution written
+inline (`go test ... > >(tee ... | jq ...) 2>&1 &`) and captured only `go test`'s PID — this
+reproducibly raced `report_test_timings`/`report_test_outcomes`/the `E2E_TIMEOUT` grep
+against a still-writing consumer (confirmed with a deliberately slow consumer: the log file
+was empty or truncated immediately after `wait` returned, and only complete after an
+additional, unbounded delay). Opening the substitution on fd 3 and `wait`ing on its PID too,
+after `wait "$suite_pid"`, closes that gap.
 
 ### R5 — a tree-scoped pre-gate dedup signal, not a blanket opt-out
 

--- a/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
+++ b/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
@@ -43,19 +43,26 @@ had to win the flaky suite's coin flip twice in a row to publish.
 
 `scripts/sim/run.sh` — the sole entry point both manual runs and `scripts/e2e/run.sh`'s
 pre-gate go through, so there is exactly one place this number lives — now passes
-`-parallel "$SIM_PARALLEL"` (default **8**, env-overridable) instead of leaving `go test` to
-inherit `GOMAXPROCS`. This is the actual root-cause mitigation: fewer concurrent scenarios
-means fewer concurrent `fork/exec` calls, which is what makes the wedge, the SIGSEGV, and
-the TSan abort rare in the first place.
+`-parallel "$SIM_PARALLEL"` (default **`min(8, host cores)`**, env-overridable) instead of
+leaving `go test` to inherit `GOMAXPROCS` uncapped. This is the actual root-cause mitigation:
+fewer concurrent scenarios means fewer concurrent `fork/exec` calls, which is what makes the
+wedge, the SIGSEGV, and the TSan abort rare in the first place.
 
-**8 is a reasoned starting point, not an empirically re-tuned value.** It sits comfortably
+**8 is a reasoned upper bound, not an empirically re-tuned value — and the default is not a
+flat 8.** An earlier version of this default was a flat 8 regardless of host core count;
+review caught that this would *increase* concurrent git-spawning, versus the previous
+`GOMAXPROCS`-derived default, on any host with fewer than 8 cores (a modest laptop or CI
+runner) — the exact mechanism this cap exists to guard against, just at smaller absolute
+scale. The shipped default is `min(8, host cores)` (`sim_default_parallel()` in
+`scripts/sim/run.sh`, probed via the portable `getconf _NPROCESSORS_ONLN` with an `nproc`
+fallback), so a low-core host is never worse off than before this change, while every host
+still caps at 8 regardless of how many cores it has above that. 8 itself sits comfortably
 below the 28-core host that produced the incident, close to (but not below) the interim
 `GOMAXPROCS`-reduction mitigation used in production, and above the pre-existing
 `mergeTrainSlots` semaphore (cap 3) that already throttles a narrower, heavier real-git
 subset (merge-train scenarios specifically) — this cap is a suite-wide analogue of a pattern
 that already existed in miniature. If a future high-core-count run still shows contention at
-this value, or if it turns out to over-constrain a low-core CI runner, the number itself is
-cheap to change; nothing else depends on its exact value.
+this value, the number itself is cheap to change; nothing else depends on its exact value.
 
 This does not touch CI's own `go test -race -timeout 5m ./...` (unscoped `-parallel`) — CI
 runners are 2-4 cores, well below where this class of contention appears, which is also why
@@ -251,7 +258,8 @@ before this existed — the original policy for that case is unchanged.
   and its flake exposure, exactly once instead of twice — but this is purely an efficiency
   and exposure win layered on top of R1-R4, not a substitute for them. A standalone
   `scripts/e2e/run.sh` invocation is unaffected.
-- `SIM_PARALLEL=8` and `gitCommandTimeout=30s` are both reasoned defaults, not values proven
-  optimal by exhaustive testing — see the R1 and R2/R4 sections above for the reasoning
-  behind each, and revisit them if future evidence (a still-flaky very-high-core-count run,
-  or a genuinely slow git operation timing out falsely) suggests otherwise.
+- `SIM_PARALLEL`'s `min(8, host cores)` default and `gitCommandTimeout=30s` are both reasoned
+  defaults, not values proven optimal by exhaustive testing — see the R1 and R2/R4 sections
+  above for the reasoning behind each, and revisit them if future evidence (a still-flaky
+  very-high-core-count run, or a genuinely slow git operation timing out falsely) suggests
+  otherwise.

--- a/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
+++ b/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
@@ -1,0 +1,186 @@
+# ADR 1624: Sim Suite Concurrency Bounds and Pre-Gate Dedup
+
+**Date**: 2026-08-17
+**Status**: Accepted
+**Issue**: #1624 — sim suite intermittently hangs in git fork/exec, stranding gitMu and
+leaking 20-hour CPU-burning orphans
+
+## Context
+
+During the v0.0.80 release gate, the sim suite (`tests/sim`) failed three distinct ways in
+one day, on the same 28-core machine, all tracing to one root cause:
+
+1. **A wedged `fork/exec`** — a goroutine stuck inside `syscall.forkExec` for 9 minutes,
+   which strands the repo's `gitMu` for every other goroutine waiting on it (the lock
+   holder never releases it, because it never got far enough to), until the whole suite
+   dies at the 10-minute test timeout.
+2. **A child `git` process killed outright** (`signal: segmentation fault`) — tests that
+   pass cleanly standalone.
+3. **A `-race` (ThreadSanitizer) runtime abort** — `CHECK failed: tsan_rtl.cpp:94`, the
+   child process exiting 66.
+
+All three share a common factor: `go test`'s default `-parallel` is `GOMAXPROCS` — on this
+machine, 28 — and nearly every one of the suite's ~84 `t.Parallel()` test functions spawns
+real `git` subprocesses (directly, or via `NewEnv`'s unconditional `SeedRepo` → `initBare`
+call during setup). High-concurrency `fork/exec` from a heavily multi-threaded Go process is
+a known source of exactly this trio of failure modes. None of it is proportional to how much
+real work the suite is doing — it is purely a function of host core count, which means the
+gate's reliability depended on which machine happened to run it. A bigger machine made the
+same suite *less* reliable, which is backwards.
+
+Separately, orphaned `sim.test` processes were found alive at ~97% CPU each, with ages up to
+20+ hours — nothing had ever reaped a `go test` invocation's children when the runner
+itself was killed mid-run.
+
+Also separately, but compounding the exposure: `scripts/cut-release.sh` runs the sim +
+wire-contract pre-gate as its own Step 3, then invokes `scripts/e2e/run.sh` at Step 5, whose
+first act re-runs the identical pre-gate against the same unchanged tree — meaning a release
+had to win the flaky suite's coin flip twice in a row to publish.
+
+## Decision
+
+### R1 — an explicit, host-core-count-independent `-parallel` cap
+
+`scripts/sim/run.sh` — the sole entry point both manual runs and `scripts/e2e/run.sh`'s
+pre-gate go through, so there is exactly one place this number lives — now passes
+`-parallel "$SIM_PARALLEL"` (default **8**, env-overridable) instead of leaving `go test` to
+inherit `GOMAXPROCS`. This is the actual root-cause mitigation: fewer concurrent scenarios
+means fewer concurrent `fork/exec` calls, which is what makes the wedge, the SIGSEGV, and
+the TSan abort rare in the first place.
+
+**8 is a reasoned starting point, not an empirically re-tuned value.** It sits comfortably
+below the 28-core host that produced the incident, close to (but not below) the interim
+`GOMAXPROCS`-reduction mitigation used in production, and above the pre-existing
+`mergeTrainSlots` semaphore (cap 3) that already throttles a narrower, heavier real-git
+subset (merge-train scenarios specifically) — this cap is a suite-wide analogue of a pattern
+that already existed in miniature. If a future high-core-count run still shows contention at
+this value, or if it turns out to over-constrain a low-core CI runner, the number itself is
+cheap to change; nothing else depends on its exact value.
+
+This does not touch CI's own `go test -race -timeout 5m ./...` (unscoped `-parallel`) — CI
+runners are 2-4 cores, well below where this class of contention appears, which is also why
+the flake was effectively unreproducible there.
+
+### R2/R4 — bounded, diagnostic git subprocess calls, with an explicit acknowledged gap
+
+`tests/sim/simgh`'s three git-invoking helpers (`runGit`, `runGitAllowFail`, and
+`runGitStdin` — the third, less-used sibling not named in the issue's own text but treated
+identically since it's the very first git call every scenario makes) now run through a
+shared `newGitCmd` builder: `exec.CommandContext` bound by a 30s `gitCommandTimeout`, with a
+`WaitDelay` bounding how long `Wait` spends on I/O-pipe closure after the process is killed.
+A timeout produces a diagnostic naming the git subcommand and its working directory (R4) —
+before this, learning which invocation wedged required reading a goroutine dump.
+
+**This does not, by itself, close the exact incident that Symptom 1 describes**, and that is
+a deliberate, documented trade-off rather than an oversight. Go's `os/exec.Cmd.Start()` calls
+`os.StartProcess` — the fork/exec syscall itself — **synchronously**, and only wires up the
+context-cancellation watcher goroutine *after* `Start()` returns. Symptom 1's own goroutine
+dump shows the hang *inside* that synchronous `Start()` call, before the watcher exists to
+kill anything. So:
+
+- `context.WithTimeout` + `exec.CommandContext` fully protects the post-`Start()` phase — a
+  process that starts and then hangs (a stub `git` that sleeps, or a genuinely wedged real
+  `git` invocation once it has begun running) is killed and reported. This is what AC1's
+  proof scenario exercises, and what `tests/sim/simgh/git_timeout_test.go` pins as a
+  permanent regression test.
+- It does **not** preempt a hang during the fork/exec syscall itself — the literal failure
+  point in the production incident.
+
+We considered racing the entire `Start()`+`Wait()` call in a goroutine against the timeout,
+so a caller could return early (releasing `gitMu` for other waiters) even while the
+underlying OS-level fork stays stuck. We rejected this: it satisfies AC1 exactly as well as
+the simpler fix, it does not actually kill the stuck fork/exec (it only relocates the leak
+from "a stuck git process" to "a stuck git process plus a leaked goroutine holding a
+reference to it," unprovable by any test), and it adds a more complex concurrency primitive
+around `gitMu`'s already fragile "no `Sim.mu` while holding this" convention for a benefit
+that is real but narrower than it looks. R1 (fewer concurrent forks, so the syscall-level
+wedge becomes rare) and R3 (below) together are what actually address the residual case: R1
+prevents it, R3 bounds the blast radius the rare time it still happens.
+
+**Do not read "R2 is done" as "the Symptom 1 incident cannot recur."** It closes the
+post-start hang class outright and gives every timeout a useful diagnostic; the pre-start
+fork/exec wedge is addressed by R1 and R3, not by R2.
+
+### R3 — process-group reaping in both runner scripts
+
+Both `scripts/sim/run.sh` and `scripts/e2e/run.sh` now launch their `go test` invocations as
+backgrounded jobs under bash job control (`set -m`), with an `INT`/`TERM` trap (`sim/run.sh`
+also traps `EXIT`, since it has no competing trap installer; `e2e/run.sh`'s shared
+`run_reaped` helper deliberately does not, since its own test-harness scripts `source` it and
+install their own `EXIT` trap in the same shell) that sends `kill -TERM` to the negative PID
+— the whole process group, not just the immediate child. Killing the runner (Ctrl-C, a CI
+job cancellation, a plain `kill`) now reaps `go test`'s own children (concretely, the
+compiled `*.test` binary — the literal orphans in the issue's evidence) instead of leaving
+them running headless.
+
+**Portable bash job control, not `setsid`.** `setsid(1)`, the usual Linux idiom for giving a
+child its own session/process group, is not shipped on macOS by default (this environment,
+and the machine that produced the incident, are both Darwin). `set -m` plus a backgrounded
+job achieves the same thing — the job becomes its own process group leader, and any further
+children it forks inherit that group — without an external dependency, on both platforms.
+
+`scripts/e2e/run.sh`'s main suite invocation (`switch_and_run`) is the one call site that
+needs a different shape: it is a multi-stage pipe (`go test -json | tee | jq`) whose exit
+code capture already depends on `pipefail`, and naively backgrounding only the pipe's last
+stage would make `$!` resolve to `jq`'s PID, not `go test`'s — silently breaking both the
+reap and the exit-code capture. It uses process substitution (`> >(tee ... | jq ...) 2>&1 &`)
+instead, so `$!` is `go test`'s own PID, preserving the existing log-capture and
+`wait ... || rc=$?` exit-code discipline unchanged. (This exact file has a prior incident
+from getting a similar restructuring wrong — see #1547 — which is why this shape was chosen
+deliberately rather than by the more obvious but fragile "just background the pipeline"
+route.)
+
+### R5 — a tree-scoped pre-gate dedup signal, not a blanket opt-out
+
+`scripts/cut-release.sh` already runs the sim + wire-contract pre-gate unconditionally as
+its own Step 3. Step 5 then invokes `scripts/e2e/run.sh`, whose own `run_pregate` re-ran the
+identical checks against the same, unchanged tree — doubling the release's exposure to
+whatever flake the pre-gate might hit, for zero additional coverage (HEAD is provably
+unchanged between the two steps; `cut-release.sh` commits nothing until well after Step 5).
+
+The fix is `FABRIK_PREGATE_VERIFIED_SHA`: an environment variable, exported by
+`cut-release.sh`'s `export_pregate_verified_sha` immediately after its own Step 3 pre-gate
+passes, carrying the exact `git rev-parse HEAD` that was just verified. `run.sh`'s
+`run_pregate` checks this against its own freshly-resolved `HEAD` before running anything; a
+match skips the pre-gate, anything else (unset, or a mismatch) falls through to the full
+run.
+
+This was chosen over two alternatives:
+
+- **Reusing `E2E_SKIP_PREGATE`** — the existing, deliberately blanket escape hatch that
+  `cut-release.sh`'s own header comment says it "never sets." Doing so would conflate "I
+  know this pre-gate is redundant for this specific tree" with "skip the pre-gate,
+  unconditionally, for whatever reason" — the latter is meant for interactive iteration
+  only, and giving it a second, silent caller inside the release path would erode that
+  distinction.
+- **A file marker on disk** — introduces staleness and cleanup concerns (what deletes it? on
+  what trigger? what if a prior failed run left one behind?) that an env var doesn't have.
+  `cut-release.sh` invokes `run.sh` as a direct child process, so an exported env var is
+  naturally scoped to exactly this invocation — it cannot leak into a later, unrelated
+  invocation the way a file could.
+
+Critically, `run_pregate` **re-resolves `HEAD` itself** rather than trusting the caller's
+claim — a stale or mismatched value always falls through to the full pre-gate, never a
+silent false skip. A standalone `scripts/e2e/run.sh` invocation (outside `cut-release.sh`)
+never sees this variable at all, so it continues to pay the full pre-gate price exactly as
+before this existed — the original policy for that case is unchanged.
+
+## Consequences
+
+- The sim suite's reliability no longer depends on the host's core count — a developer on a
+  high-core-count machine gets the same `-parallel` bound as CI, rather than a worse one.
+- A wedged git subprocess now fails the specific test it belongs to, with a diagnostic
+  naming the command and directory, rather than hanging the entire suite to its 10-minute
+  timeout — for the class of hang that occurs after the process has started. A hang inside
+  the fork/exec syscall itself is not directly preemptable by this fix; R1 makes it rare, R3
+  bounds its cost when it still happens.
+- Killing either runner script mid-suite leaves no surviving `*.test` processes, closing the
+  20-hour-orphan failure mode.
+- A release cut through `cut-release.sh` now pays the sim + wire-contract pre-gate's cost,
+  and its flake exposure, exactly once instead of twice — but this is purely an efficiency
+  and exposure win layered on top of R1-R4, not a substitute for them. A standalone
+  `scripts/e2e/run.sh` invocation is unaffected.
+- `SIM_PARALLEL=8` and `gitCommandTimeout=30s` are both reasoned defaults, not values proven
+  optimal by exhaustive testing — see the R1 and R2/R4 sections above for the reasoning
+  behind each, and revisit them if future evidence (a still-flaky very-high-core-count run,
+  or a genuinely slow git operation timing out falsely) suggests otherwise.

--- a/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
+++ b/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
@@ -157,6 +157,20 @@ the time it returns) and background it as a genuine job (`{ tee ... | jq ...; } 
 own process group under `set -m`, confirmed during review to be fully, cleanly reapable via
 the same `kill -TERM -"$consumer_pid"` idiom already used for `$suite_pid`.
 
+A third review pass caught one more gap in that same fix: the INT/TERM trap covering both
+PIDs was installed only after *both* the consumer and `go test` had already been
+backgrounded, leaving a narrow startup window (between capturing `consumer_pid` and the trap
+statements executing) with no signal handler at all — a kill landing there would hit bash's
+default disposition and orphan whatever had already started, the same failure class one
+level up. Fixed by declaring `suite_pid` empty and installing the trap immediately after
+`consumer_pid` is captured, before `go test` is even started; because a trap's command
+string is re-expanded at signal-delivery time rather than at install time, referencing
+`$suite_pid` before it's assigned is safe (`kill -TERM -""` is a harmless no-op under
+`|| true`), and the same trap text protects `go test` once `suite_pid` is set below it.
+Confirmed during review, with a deliberately widened window, that a kill landing anywhere
+from immediately after `consumer_pid` is captured through mid-`go test` reaps both processes
+cleanly.
+
 ### R5 — a tree-scoped pre-gate dedup signal, not a blanket opt-out
 
 `scripts/cut-release.sh` already runs the sim + wire-contract pre-gate unconditionally as

--- a/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
+++ b/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
@@ -123,24 +123,39 @@ children it forks inherit that group — without an external dependency, on both
 needs a different shape: it is a multi-stage pipe (`go test -json | tee | jq`) whose exit
 code capture already depends on `pipefail`, and naively backgrounding only the pipe's last
 stage would make `$!` resolve to `jq`'s PID, not `go test`'s — silently breaking both the
-reap and the exit-code capture. It uses process substitution (`exec 3> >(tee ... | jq ...)`,
-`go test ... >&3 2>&1 &`) instead, so `$!` (captured right after backgrounding `go test`) is
-`go test`'s own PID, preserving the existing log-capture and `wait ... || rc=$?` exit-code
+reap and the exit-code capture. `go test`'s stdout/stderr are instead routed to the `tee |
+jq` consumer through a named pipe (`mkfifo`), with the consumer backgrounded as its own real
+job before `go test` starts, so `$!` (captured right after backgrounding `go test`) is `go
+test`'s own PID, preserving the existing log-capture and `wait ... || rc=$?` exit-code
 discipline unchanged. (This exact file has a prior incident from getting a similar
 restructuring wrong — see #1547 — which is why this shape was chosen deliberately rather
 than by the more obvious but fragile "just background the pipeline" route.)
 
-The process substitution is opened on an explicit fd (3) rather than inline on the `go test`
-command specifically so its own PID can be captured and `wait`ed on separately from `go
-test`'s: `wait "$suite_pid"` only blocks until `go test` exits, not until the `tee`/`jq`
-consumer reading its now-closed pipe has finished flushing `$jsonlog` to disk. During review,
-the first version of this fix backgrounded `go test` with the process substitution written
-inline (`go test ... > >(tee ... | jq ...) 2>&1 &`) and captured only `go test`'s PID — this
+The consumer's own PID (`consumer_pid`) is captured separately from `go test`'s
+(`suite_pid`) specifically so it can be `wait`ed on too: `wait "$suite_pid"` only blocks
+until `go test` exits, not until the `tee`/`jq` consumer reading its now-closed pipe has
+finished flushing `$jsonlog` to disk. During review, the first version of this fix
+backgrounded `go test` with the consumer fed via a *process substitution*
+(`go test ... > >(tee ... | jq ...) 2>&1 &`) and captured only `go test`'s PID — this
 reproducibly raced `report_test_timings`/`report_test_outcomes`/the `E2E_TIMEOUT` grep
 against a still-writing consumer (confirmed with a deliberately slow consumer: the log file
 was empty or truncated immediately after `wait` returned, and only complete after an
-additional, unbounded delay). Opening the substitution on fd 3 and `wait`ing on its PID too,
-after `wait "$suite_pid"`, closes that gap.
+additional, unbounded delay). Opening the process substitution on an explicit fd (3) and
+`wait`ing on its own PID too, after `wait "$suite_pid"`, closed that specific race — but a
+second review pass on that fix surfaced a further, more serious problem: a process
+substitution does not get its own process group under `set -m`. Traced during review:
+group-killing a process substitution's `$!` is a silent no-op (no such group exists — the
+consumer instead sits inside whatever group was current when it started), and even a plain,
+non-group kill of that one PID only takes down the process substitution's own top-level
+shell, leaving `tee`/`jq`'s own descendants running, reparented to pid 1 — reproducing
+exactly the orphan class this whole issue exists to close, one process stage further down
+than `go test` itself. The fix landed here instead: feed the consumer through a named pipe
+(`mkfifo` + `exec 3> "$fifo"`, safe to `rm -f` immediately after — the `exec` blocks until
+the backgrounded reader has already opened its end, so both ends are provably connected by
+the time it returns) and background it as a genuine job (`{ tee ... | jq ...; } < "$fifo"
+&`) rather than an anonymous process substitution. A real backgrounded job *does* get its
+own process group under `set -m`, confirmed during review to be fully, cleanly reapable via
+the same `kill -TERM -"$consumer_pid"` idiom already used for `$suite_pid`.
 
 ### R5 — a tree-scoped pre-gate dedup signal, not a blanket opt-out
 

--- a/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
+++ b/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
@@ -119,6 +119,23 @@ and the machine that produced the incident, are both Darwin). `set -m` plus a ba
 job achieves the same thing — the job becomes its own process group leader, and any further
 children it forks inherit that group — without an external dependency, on both platforms.
 
+**Trap-before-background, everywhere a PID is captured.** Every one of this PR's three
+trap-installing call sites (`scripts/sim/run.sh`'s own top-level trap, `run_reaped`, and
+`switch_and_run`) declares its PID variable(s) empty and installs the INT/TERM trap *before*
+backgrounding the job, not after capturing `$!` — caught in review across three separate
+passes, one per call site, all the same defect: backgrounding first and installing the trap
+a few statements later leaves a window with no handler at all, where a signal hits bash's
+default disposition and orphans the job that had just started — the exact leak class R3
+exists to close, recurring at its own fix sites. Since a trap's command string is
+re-expanded at signal-delivery time, not install time, referencing a not-yet-assigned PID
+variable is safe (`kill -TERM -""` is a harmless no-op under `|| true`); the same trap text
+protects the job once its PID is assigned a line or two later. This is the tightest ordering
+bash allows — the single-statement gap between backgrounding a job and capturing its `$!`
+cannot itself be closed, since there is no atomic "start and capture PID" primitive — but it
+reduces the exposed window from "several statements, including possible I/O" to "one
+assignment," and was confirmed clean via kills timed at (and, for `switch_and_run`,
+deliberately widened past) that boundary.
+
 `scripts/e2e/run.sh`'s main suite invocation (`switch_and_run`) is the one call site that
 needs a different shape: it is a multi-stage pipe (`go test -json | tee | jq`) whose exit
 code capture already depends on `pipefail`, and naively backgrounding only the pipe's last

--- a/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
+++ b/adrs/1624-sim-suite-concurrency-and-pregate-dedup.md
@@ -172,6 +172,19 @@ passes, carrying the exact `git rev-parse HEAD` that was just verified. `run.sh`
 match skips the pre-gate, anything else (unset, or a mismatch) falls through to the full
 run.
 
+**HEAD alone is not sufficient — found during Review.** "HEAD is provably unchanged between
+the two steps" is true of the git *commit*, but Step 4 (Build), which runs in between, can
+rewrite `plugin/known_embedded_versions.go` on disk without committing it — whenever the
+embedded plugin content changed since the last release, which is the common case. `git
+rev-parse HEAD` cannot see that: a SHA match would silently vouch for a tree that no longer
+matched what Step 3 actually checked, even though the mechanism's whole premise is "the
+exact tree that was checked." `run_pregate` therefore also requires `git status --porcelain`
+to be empty before honoring a SHA match; any uncommitted change (tracked or untracked) falls
+through to the full pre-gate exactly like a SHA mismatch already did. `run_pregate`'s own
+comment had already claimed this case "always falls through to the full pre-gate" before the
+fix landed — it just wasn't actually implemented, which is exactly the kind of gap a
+prose-only claim (unverified by anything that runs) tends to hide.
+
 This was chosen over two alternatives:
 
 - **Reusing `E2E_SKIP_PREGATE`** — the existing, deliberately blanket escape hatch that

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -24,7 +24,9 @@
 # What it does:
 #   1. Pre-flight: branch, clean tree, ff-pull, release-notes heading match
 #   2. PAT identity check (must be arbeithand)
-#   3. Sim suite + github wire-contract tests — unconditional pre-gate (R1/R2, #1454)
+#   3. Sim suite + github wire-contract tests — unconditional pre-gate (R1/R2, #1454).
+#      Exports FABRIK_PREGATE_VERIFIED_SHA on success so step 5 doesn't pay for the
+#      identical pre-gate a second time (R5, #1624) — see export_pregate_verified_sha.
 #   4. go build + go test -race (skippable with --skip-tests; the pre-gate above never is)
 #   5. Live e2e integration gate — mandatory by default; --skip-integration=<reason> is the
 #      one sanctioned, loud, release-notes-recorded escape hatch (R2, #1454).
@@ -111,6 +113,29 @@ insert_notes_line() {
   fi
 }
 
+# export_pregate_verified_sha exports FABRIK_PREGATE_VERIFIED_SHA as the
+# exact commit this invocation's own sim + wire-contract pre-gate (step 3,
+# below) just verified. Called right after that step passes, while HEAD is
+# still guaranteed unchanged (this script commits nothing until step 6, well
+# after step 5's live e2e gate runs) — so the value names the exact tree
+# that was checked, not merely "some release."
+#
+# scripts/e2e/run.sh's own pre-gate (run_pregate) checks this against a
+# freshly-resolved `git rev-parse HEAD` of its own before deciding whether
+# to re-run the identical sim + wire-contract checks (R5, #1624) — see that
+# function's own comment. An exported env var, not a file marker: run.sh is
+# invoked as this script's direct child process (step 5), so there is no
+# on-disk staleness/cleanup concern, and the value is naturally scoped to
+# exactly this invocation (env vars do not outlive the child process) —
+# unlike E2E_SKIP_PREGATE, a blanket opt-out this script deliberately never
+# sets (see step 5's own comment), this is a narrow, tree-scoped signal that
+# a standalone `scripts/e2e/run.sh` invocation never sees and so still pays
+# the full pre-gate price, exactly as before this existed.
+export_pregate_verified_sha() {
+  FABRIK_PREGATE_VERIFIED_SHA="$(git rev-parse HEAD)"
+  export FABRIK_PREGATE_VERIFIED_SHA
+}
+
 # interpret_e2e_exit_code prints the operator-facing message for a given
 # scripts/e2e/run.sh exit code ($1) and returns 0 if that code means success,
 # 1 otherwise — main() calls `ok`/`die` with the result accordingly. Extracted
@@ -136,7 +161,7 @@ interpret_e2e_exit_code() {
       echo "live e2e integration suite aborted: bed preflight failed (exit 4) inside scripts/e2e/run.sh — the suite never ran. This is an infrastructure problem (stuck lock, unreachable SSH remote, dirty tracked files in the bed checkout, etc.), NOT a regression and NOT a fidelity-drift case — see scripts/e2e/run.sh's own preflight_bed output above for the specific cause, fix it, and re-run scripts/cut-release.sh $VERSION."
       ;;
     5)
-      echo "live e2e integration suite aborted: its own sim/wire-contract pre-gate failed (exit 5) inside scripts/e2e/run.sh. Unexpected, since this script's own pre-gate step (step 3) already passed against the same tree — investigate the discrepancy (different ref? dirty tree in the bed?) before retrying."
+      echo "live e2e integration suite aborted: its own sim/wire-contract pre-gate failed (exit 5) inside scripts/e2e/run.sh. Unexpected: this script's own pre-gate step (step 3) already passed against the same tree, and R5's FABRIK_PREGATE_VERIFIED_SHA (#1624) should have made run.sh skip re-running it rather than fail it a second time — investigate the discrepancy (different ref? dirty tree in the bed? the SHA guard itself misfiring) before retrying."
       ;;
     *)
       echo "live e2e integration suite FAILED (exit $rc) — see scripts/e2e/run.sh output above. This is a real regression; do not retry with --skip-integration to work around it. FIDELITY-DRIFT CHECK (R4, #1454): this script's own sim + wire-contract pre-gate (step 3) already passed against this same tree, so whatever the live suite just caught is exactly the case that policy covers — file a fidelity issue, add the scenario to tests/sim, and update tests/sim/simgh/FIDELITY.md (see tests/sim/README.md's 'Fidelity-drift policy' section) once the underlying regression itself is fixed."
@@ -270,6 +295,12 @@ ok "FABRIK_TOKEN authenticated as @$BOT_LOGIN"
 # total per tests/sim/README.md), so making it unconditional costs nothing
 # real while removing an entire class of "the live suite failed for a
 # reason the sim would have caught for free" incidents.
+#
+# Once this passes, export_pregate_verified_sha (R5, #1624) records HEAD so
+# step 5's invocation of scripts/e2e/run.sh can skip re-running the
+# identical checks against the same, unchanged tree — see that function's
+# own comment. This does NOT weaken the check: it still runs here, in full,
+# exactly as before; it only stops step 5 from paying for it a second time.
 step "Sim + wire-contract pre-gate"
 if ! "$REPO_ROOT/scripts/sim/run.sh" --all; then
   die "sim suite failed — fix it before cutting a release (scripts/sim/run.sh --all to reproduce)"
@@ -280,6 +311,7 @@ if ! go test -race -count=1 ./github/... >/tmp/cut-release-pregate-test.log 2>&1
   die "github wire-contract tests failed (full log: /tmp/cut-release-pregate-test.log)"
 fi
 ok "github wire-contract tests passed"
+export_pregate_verified_sha
 
 # ─── 4. build + test ──────────────────────────────────────────────────────────
 step "Build"

--- a/scripts/cut_release_gate_test.sh
+++ b/scripts/cut_release_gate_test.sh
@@ -144,6 +144,20 @@ case "$msg" in
 esac
 assert_eq "exit 1 classified as failure" "1" "$rc"
 
+# --- export_pregate_verified_sha (R5, #1624): sets and exports
+# FABRIK_PREGATE_VERIFIED_SHA to the current repo's `git rev-parse HEAD`,
+# which is what scripts/e2e/run.sh's run_pregate compares against its own
+# freshly-resolved HEAD before deciding whether to re-run the pre-gate. ---
+unset FABRIK_PREGATE_VERIFIED_SHA
+export_pregate_verified_sha
+EXPECTED_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+assert_eq "export_pregate_verified_sha sets FABRIK_PREGATE_VERIFIED_SHA to HEAD" "$EXPECTED_SHA" "$FABRIK_PREGATE_VERIFIED_SHA"
+# Confirm it's actually exported (visible to a child process), not just a
+# local shell variable — that's what makes it reach scripts/e2e/run.sh, a
+# direct child process of cut-release.sh, in the real invocation.
+CHILD_VISIBLE="$(bash -c 'echo "$FABRIK_PREGATE_VERIFIED_SHA"')"
+assert_eq "export_pregate_verified_sha's value is visible to a child process" "$EXPECTED_SHA" "$CHILD_VISIBLE"
+
 # --- insert_notes_line: exercised directly against a scratch file, proving
 # the helper both call sites (plugin-bump changelog, --skip-integration
 # recorded-skip line) now share behaves identically to the pre-refactor

--- a/scripts/e2e/pregate_test.sh
+++ b/scripts/e2e/pregate_test.sh
@@ -96,6 +96,26 @@ rc=$?
 assert_eq "sim-layer failure exits PREGATE_FAILED_EXIT (5)" "5" "$rc"
 assert_eq "sim-layer failure stops after exactly one go call (github tests never run)" "1" "$(marker_count)"
 
+# --- Case 4 (R5, #1624): FABRIK_PREGATE_VERIFIED_SHA matching the current
+# HEAD skips the pre-gate entirely — zero go calls, exit 0 — even though the
+# fake go is scripted to fail, proving the skip really does short-circuit
+# before either layer runs rather than merely tolerating a pass. ---
+reset_marker
+CURRENT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+( FAKE_GO_EXIT=1 FABRIK_PREGATE_VERIFIED_SHA="$CURRENT_SHA" run_pregate ) >/dev/null 2>&1
+rc=$?
+assert_eq "matching FABRIK_PREGATE_VERIFIED_SHA exits 0" "0" "$rc"
+assert_eq "matching FABRIK_PREGATE_VERIFIED_SHA makes no go call" "0" "$(marker_count)"
+
+# --- Case 5 (R5, #1624): a stale/mismatched FABRIK_PREGATE_VERIFIED_SHA falls
+# through to the full pre-gate, same as if it had never been set — never a
+# silent false skip. ---
+reset_marker
+( FAKE_GO_EXIT=0 FABRIK_PREGATE_VERIFIED_SHA="0000000000000000000000000000000000000dead" run_pregate ) >/dev/null 2>&1
+rc=$?
+assert_eq "mismatched FABRIK_PREGATE_VERIFIED_SHA exits 0 (full pre-gate ran and passed)" "0" "$rc"
+assert_eq "mismatched FABRIK_PREGATE_VERIFIED_SHA runs the full pre-gate (2 go calls)" "2" "$(marker_count)"
+
 # --- Structural check: run_pregate must precede prepare_bed_and_reset inside
 # the dispatch guard, textually — this is what makes "no live call is made"
 # true by construction rather than by accident of today's implementation.

--- a/scripts/e2e/pregate_test.sh
+++ b/scripts/e2e/pregate_test.sh
@@ -52,7 +52,12 @@ assert_eq() {
 # to shadow both.
 FAKE_BIN_DIR="$(mktemp -d)"
 MARKER_FILE="$(mktemp)"
-trap 'rm -rf "$FAKE_BIN_DIR" "$MARKER_FILE"' EXIT
+# DIRTY_TREE_FILE: an untracked scratch file used by Case 6 below to make
+# $REPO_ROOT's working tree dirty without touching any tracked file. Declared
+# here (not created yet) so the EXIT trap can unconditionally clean it up
+# even if a later case is added between here and Case 6 and aborts first.
+DIRTY_TREE_FILE="$REPO_ROOT/.pregate_test_dirty_tree_scratch"
+trap 'rm -rf "$FAKE_BIN_DIR" "$MARKER_FILE" "$DIRTY_TREE_FILE"' EXIT
 
 cat > "$FAKE_BIN_DIR/go" <<'EOF'
 #!/usr/bin/env bash
@@ -115,6 +120,22 @@ reset_marker
 rc=$?
 assert_eq "mismatched FABRIK_PREGATE_VERIFIED_SHA exits 0 (full pre-gate ran and passed)" "0" "$rc"
 assert_eq "mismatched FABRIK_PREGATE_VERIFIED_SHA runs the full pre-gate (2 go calls)" "2" "$(marker_count)"
+
+# --- Case 6 (R5, #1624 — found during Review): a matching
+# FABRIK_PREGATE_VERIFIED_SHA does NOT skip the pre-gate if the working tree
+# has picked up an uncommitted change since the SHA was captured — a HEAD
+# match alone can't detect that (a real gap: cut-release.sh's own step 4 can
+# rewrite plugin/known_embedded_versions.go on disk between capturing the SHA
+# and this check running). An untracked scratch file is enough to make the
+# tree dirty without touching anything tracked. ---
+reset_marker
+: > "$DIRTY_TREE_FILE"
+CURRENT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+( FAKE_GO_EXIT=0 FABRIK_PREGATE_VERIFIED_SHA="$CURRENT_SHA" run_pregate ) >/dev/null 2>&1
+rc=$?
+rm -f "$DIRTY_TREE_FILE"
+assert_eq "matching SHA + dirty tree exits 0 (full pre-gate ran and passed)" "0" "$rc"
+assert_eq "matching SHA + dirty tree runs the full pre-gate (2 go calls), not a skip" "2" "$(marker_count)"
 
 # --- Structural check: run_pregate must precede prepare_bed_and_reset inside
 # the dispatch guard, textually — this is what makes "no live call is made"

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -714,28 +714,48 @@ detect_rate_limit_backoff() {
 # defeating the hardening this function exists to provide.
 #
 # Process-group reap (R3, #1624): go test itself is backgrounded (not the
-# whole `tee | jq` pipe) and its stdout+stderr are routed to them via a
-# process substitution opened on fd 3 (`exec 3> >(tee ... | jq ...)`,
-# `go test ... >&3 2>&1 &`) instead — this is NOT run_reaped, which
-# backgrounds a plain command and waits for its own exit status directly. A
-# pipe's last stage is what `$!`/`wait` would report if the whole
-# `cmd1 | cmd2 | cmd3` were backgrounded as one job, and jq is wrapped in
-# `|| true` precisely so a jq hiccup can't fail the leg — meaning `wait`ing
-# on that PID would silently always see 0, discarding go test's real exit
-# code the same `pipefail` trick below exists to preserve for a *foreground*
-# pipeline. Backgrounding go test alone sidesteps this: `$!` is go test's own
-# PID, its own exit status is what `wait` reports directly (no pipefail
-# needed), and it still gets a process group of its own (`set -m`, top of
-# file) that the INT/TERM traps below can kill.
+# whole `tee | jq` pipe) and its stdout+stderr are routed to it via a named
+# pipe on fd 3 (`mkfifo`, a backgrounded `{ tee ... | jq ...; } < "$fifo" &`
+# reader, then `go test ... >&3 2>&1 &`) instead — this is NOT run_reaped,
+# which backgrounds a plain command and waits for its own exit status
+# directly. A pipe's last stage is what `$!`/`wait` would report if the
+# whole `cmd1 | cmd2 | cmd3` were backgrounded as one job, and jq is wrapped
+# in `|| true` precisely so a jq hiccup can't fail the leg — meaning
+# `wait`ing on that PID would silently always see 0, discarding go test's
+# real exit code the same `pipefail` trick below exists to preserve for a
+# *foreground* pipeline. Backgrounding go test alone sidesteps this: `$!` is
+# go test's own PID, its own exit status is what `wait` reports directly (no
+# pipefail needed), and it still gets a process group of its own (`set -m`,
+# top of file) that the INT/TERM traps below can kill.
 #
-# The process substitution is opened explicitly on fd 3, rather than inline
-# on the go test command, specifically so its own PID can be captured and
-# `wait`ed on too: `wait "$suite_pid"` only blocks until go test exits, not
-# until the tee/jq consumer reading its now-closed pipe has finished
-# flushing $jsonlog — without a second, explicit `wait` on the consumer,
-# report_test_timings/report_test_outcomes/the E2E_TIMEOUT grep below can
-# race a still-writing consumer and observe a truncated or momentarily-empty
-# $jsonlog (reproduced with a deliberately slow consumer during review).
+# The consumer (`tee | jq`) is fed via a named pipe rather than a process
+# substitution (`exec 3> >(tee ... | jq ...)`), and backgrounded as a real
+# job (`{ ...; } &`, capturing its own `$!` as consumer_pid) rather than left
+# anonymous, specifically so it too gets its own process group under `set
+# -m` and can be group-killed exactly like $suite_pid. A process substitution
+# does NOT get its own process group — traced during review: killing only
+# its own top-level PID (with or without the `-`-prefixed group form; the
+# group form is simply a no-op there, since no such group exists) leaves the
+# `tee`/`jq` pipeline's own descendants running, reparented to pid 1 — i.e.
+# it reproduces exactly the orphan class this whole issue exists to close,
+# just one process stage further down. The named-pipe form was confirmed
+# (during review) to fully reap `tee` and `jq` together via
+# `kill -TERM -"$consumer_pid"`, the same idiom used for `$suite_pid` below.
+# `mkfifo` + `exec 3> "$fifo"` is also what makes the consumer job's `$!`
+# capturable *before* go test starts writing to fd 3 — the `exec 3> "$fifo"`
+# open blocks until the backgrounded reader has already opened its end (FIFO
+# open rendezvous), so it is safe to `rm -f "$fifo"` immediately afterward:
+# both ends are already connected by then, and unlinking only removes the
+# now-unneeded directory entry, not the open file descriptors.
+#
+# The consumer's own PID is captured (rather than relying on `wait
+# "$suite_pid"` alone) specifically so it can be `wait`ed on too:
+# `wait "$suite_pid"` only blocks until go test exits, not until the tee/jq
+# consumer reading its now-closed pipe has finished flushing $jsonlog —
+# without a second, explicit `wait` on the consumer, report_test_timings/
+# report_test_outcomes/the E2E_TIMEOUT grep below can race a still-writing
+# consumer and observe a truncated or momentarily-empty $jsonlog (reproduced
+# with a deliberately slow consumer during review).
 #
 # After the suite invocation, regardless of $rc, this function also checks
 # fabrik.log in full (not from a captured byte offset — see below) for the
@@ -785,28 +805,34 @@ switch_and_run() {
     budget_before=$(GH_TOKEN="$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
   fi
 
-  # fd 3 is opened onto the process substitution (tee | jq) explicitly,
-  # rather than inline on the go test command, so its own PID ($!) is
-  # captured separately from go test's — see the R3 comment above for why
-  # `wait "$suite_pid"` alone is not enough: it only waits for go test to
-  # exit, not for the tee/jq consumer reading go test's closed pipe to
-  # finish flushing $jsonlog to disk. Without this, report_test_timings /
-  # report_test_outcomes / the E2E_TIMEOUT grep below could race a still-
-  # writing consumer and see a truncated (or momentarily empty) file —
-  # confirmed reproducible with a deliberately slow consumer.
-  exec 3> >(tee "$jsonlog" | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; })
+  # The consumer (tee | jq) is fed via a named pipe and backgrounded as its
+  # own real job, so it gets its own process group and can be group-killed
+  # exactly like $suite_pid — see the R3 comment above for why a process
+  # substitution can't do this safely. mkfifo's rendezvous means the
+  # `rm -f "$fifo"` right after `exec 3>` is race-free: that `exec` blocks
+  # until the backgrounded reader below has already opened its end.
+  local fifo
+  fifo="$(mktemp -u)"
+  mkfifo "$fifo"
+  { tee "$jsonlog" | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; }; } < "$fifo" &
   local consumer_pid=$!
+  exec 3> "$fifo"
+  rm -f "$fifo"
+
   E2E_TRAIN_MODE="$mode" go test -tags=e2e -json -count=1 -timeout "$TIMEOUT" -parallel "$parallel" \
       ./tests/e2e/... "$@" >&3 2>&1 &
   local suite_pid=$!
   exec 3>&-
-  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; exit 130' INT
-  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; exit 143' TERM
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; exit 130' INT
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; exit 143' TERM
   wait "$suite_pid" || rc=$?
-  trap - INT TERM
-  # Wait for the consumer to drain and finish writing $jsonlog before any
-  # of it is read below — see the comment above the `exec 3>` line.
+  # Wait for the consumer to drain and finish writing $jsonlog before any of
+  # it is read below — see the comment above. Still under the INT/TERM trap
+  # (not cleared until after this), so a kill of this script while the
+  # consumer is draining reaps its whole group too, rather than leaving this
+  # wait unbounded with no signal path.
   wait "$consumer_pid" 2>/dev/null || true
+  trap - INT TERM
 
   budget_after=""
   if [ -n "$BED_TOKEN" ]; then

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -294,12 +294,22 @@ readonly PREGATE_FAILED_EXIT=5
 # (see switch_and_run's own comment), and backgrounding only the pipe's last
 # stage would silently lose that — see switch_and_run for the process-
 # substitution restructuring that avoids the problem instead.
+#
+# `pid` is declared and the trap installed BEFORE "$@" is backgrounded, not
+# after: a signal landing between starting the job and capturing `$!` would
+# otherwise have no handler yet, leaving the just-started job unreaped — the
+# exact orphan class this function exists to close (found during Review,
+# #1624; mirrors switch_and_run's own fix for the identical gap). A trap's
+# command string is re-expanded at signal-delivery time, not install time,
+# so referencing $pid before it's assigned is safe — `kill -TERM -""` is a
+# harmless no-op under `|| true`.
 # ---------------------------------------------------------------------------
 run_reaped() {
-  "$@" &
-  local pid=$!
+  local pid=""
   trap 'kill -TERM -"$pid" 2>/dev/null || true; exit 130' INT
   trap 'kill -TERM -"$pid" 2>/dev/null || true; exit 143' TERM
+  "$@" &
+  pid=$!
   local rc=0
   wait "$pid" || rc=$?
   trap - INT TERM

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -27,21 +27,31 @@
 #                           always pays the pre-gate cost)
 #
 #   FABRIK_PREGATE_VERIFIED_SHA=<sha>   tree-scoped dedup signal (R5, #1624):
-#                           if set and equal to a freshly-resolved `git
-#                           rev-parse HEAD`, the pre-gate is skipped because
-#                           it was already run, in full, against this exact
-#                           tree earlier in the same invocation.
+#                           if set, equal to a freshly-resolved `git
+#                           rev-parse HEAD`, AND the working tree is clean
+#                           (`git status --porcelain` empty), the pre-gate is
+#                           skipped because it was already run, in full,
+#                           against this exact tree earlier in the same
+#                           invocation. The clean-tree check matters because
+#                           HEAD alone only identifies the committed tree —
+#                           a step running between the SHA being captured and
+#                           this check that rewrites a tracked file on disk
+#                           without committing it (cut-release.sh's own
+#                           step 4 does this to plugin/known_embedded_versions.go)
+#                           would otherwise leave a HEAD match vouching for a
+#                           tree that no longer matches what was actually
+#                           checked (found during Review, #1624).
 #                           scripts/cut-release.sh exports this itself, right
 #                           after its own step 3 pre-gate passes, so its step
 #                           5 call into this script doesn't pay for the
 #                           identical sim + wire-contract checks a second
 #                           time. Unlike E2E_SKIP_PREGATE (a blanket,
 #                           deliberately-never-set-by-cut-release.sh opt-out),
-#                           this is narrow: a mismatched or unset value
-#                           always falls through to the full pre-gate, so a
-#                           standalone `scripts/e2e/run.sh` invocation (which
-#                           never sees this var) still pays full price,
-#                           exactly as before this existed. See
+#                           this is narrow: a mismatched or unset SHA, or a
+#                           dirty tree, always falls through to the full
+#                           pre-gate, so a standalone `scripts/e2e/run.sh`
+#                           invocation (which never sees this var) still pays
+#                           full price, exactly as before this existed. See
 #                           export_pregate_verified_sha in cut-release.sh.
 #
 # Bed preflight (on by default — see preflight_bed below for the full rationale):
@@ -331,13 +341,28 @@ run_pregate() {
   # mismatched value (wrong ref, dirty tree since the caller's own pre-gate
   # ran) always falls through to the full pre-gate below, never a silent
   # false skip. See the header comment for the full rationale.
+  #
+  # The SHA match alone is not sufficient: `git rev-parse HEAD` only
+  # identifies the committed tree, and cut-release.sh's own step 4 (Build,
+  # between the SHA being captured and this check) can rewrite
+  # plugin/known_embedded_versions.go on disk without committing it —
+  # a HEAD match would then be silently vouching for a tree that no longer
+  # matches what was actually checked (found during Review, #1624). So this
+  # also requires a clean working tree (`git status --porcelain` empty) —
+  # any uncommitted change, tracked or untracked, falls through to the full
+  # pre-gate exactly like a SHA mismatch does.
   if [ -n "${FABRIK_PREGATE_VERIFIED_SHA:-}" ]; then
     current_sha="$(git rev-parse HEAD)"
-    if [ "$FABRIK_PREGATE_VERIFIED_SHA" = "$current_sha" ]; then
+    dirty="$(git status --porcelain)"
+    if [ "$FABRIK_PREGATE_VERIFIED_SHA" = "$current_sha" ] && [ -z "$dirty" ]; then
       echo "== pre-gate skipped (already verified for $current_sha in this invocation, R5 #1624) =="
       return 0
     fi
-    echo "== pre-gate: FABRIK_PREGATE_VERIFIED_SHA ($FABRIK_PREGATE_VERIFIED_SHA) does not match HEAD ($current_sha) — running the full pre-gate =="
+    if [ "$FABRIK_PREGATE_VERIFIED_SHA" != "$current_sha" ]; then
+      echo "== pre-gate: FABRIK_PREGATE_VERIFIED_SHA ($FABRIK_PREGATE_VERIFIED_SHA) does not match HEAD ($current_sha) — running the full pre-gate =="
+    else
+      echo "== pre-gate: FABRIK_PREGATE_VERIFIED_SHA matches HEAD ($current_sha) but the working tree has uncommitted changes since it was verified — running the full pre-gate =="
+    fi
   fi
 
   echo "== pre-gate: sim suite + github wire-contract tests (R1, #1454) =="

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -362,6 +362,7 @@ run_pregate() {
   # any uncommitted change, tracked or untracked, falls through to the full
   # pre-gate exactly like a SHA mismatch does.
   if [ -n "${FABRIK_PREGATE_VERIFIED_SHA:-}" ]; then
+    local current_sha dirty
     current_sha="$(git rev-parse HEAD)"
     dirty="$(git status --porcelain)"
     if [ "$FABRIK_PREGATE_VERIFIED_SHA" = "$current_sha" ] && [ -z "$dirty" ]; then

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -186,8 +186,17 @@
 #   - handarbeit/projects/2 ("Fabrik Test") exists with stage columns
 #   - Fabrik instance running at ~/dev/fabrik-test/ (typically with --auto-upgrade)
 # See tests/e2e/README.md for setup details.
+#
+# Process-group reap (R3, #1624): every `go test` invocation below runs via
+# run_reaped (or an inline equivalent for the one call site with more complex
+# redirection — see switch_and_run), so killing this script reaps that
+# invocation's process group instead of leaving its own children (most
+# concretely, a compiled `*.test` binary) running headless. See run_reaped's
+# own doc comment for the mechanism and why it traps INT/TERM only, never
+# EXIT.
 
 set -euo pipefail
+set -m
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
@@ -229,6 +238,47 @@ readonly PREFLIGHT_FAILED_EXIT=4
 readonly PREGATE_FAILED_EXIT=5
 
 # ---------------------------------------------------------------------------
+# run_reaped (R3, #1624): run "$@" as a backgrounded job in its own process
+# group and reap that whole group if this script is killed while it's in
+# flight, instead of leaving its children (most concretely, a compiled
+# `*.test` binary) running headless after the runner that spawned them is
+# gone. `set -m` (top of file) is what gives every backgrounded job its own
+# process group, led by the job itself — any further children it forks
+# inherit that same group, so `kill -TERM -"$pid"` (a negative PID targets
+# the whole process group, not just that one process) reaches all of them.
+#
+# Deliberately traps only INT/TERM, never EXIT: scripts/e2e/pregate_test.sh
+# and scripts/e2e/backoff_detection_test.sh `source` this file for its
+# function definitions and install their OWN EXIT trap for fixture cleanup
+# in that same shell (traps are shell-wide, not per-function) — an EXIT trap
+# set and cleared here would clobber theirs. On a caught signal the trap
+# kills the job's process group and re-exits with the shell-conventional
+# 128+signum code (130 for INT, 143 for TERM) rather than letting the script
+# continue past an interrupt it was told to stop for.
+#
+# `setsid`, the usual Linux idiom for giving a child its own process group,
+# is not shipped on macOS by default, so this uses portable bash job control
+# instead — the same approach scripts/sim/run.sh's own R3 fix uses.
+#
+# Not used for switch_and_run's main suite invocation below, which needs its
+# own inline variant: that call is a multi-stage pipe (go test | tee | jq)
+# whose exit code capture already depends on `pipefail`
+# (see switch_and_run's own comment), and backgrounding only the pipe's last
+# stage would silently lose that — see switch_and_run for the process-
+# substitution restructuring that avoids the problem instead.
+# ---------------------------------------------------------------------------
+run_reaped() {
+  "$@" &
+  local pid=$!
+  trap 'kill -TERM -"$pid" 2>/dev/null || true; exit 130' INT
+  trap 'kill -TERM -"$pid" 2>/dev/null || true; exit 143' TERM
+  local rc=0
+  wait "$pid" || rc=$?
+  trap - INT TERM
+  return "$rc"
+}
+
+# ---------------------------------------------------------------------------
 # Pre-gate (R1, #1454): refuse to spend live budget until the free, fast
 # layers pass.
 #
@@ -263,7 +313,7 @@ run_pregate() {
     echo "pre-gate: sim suite failed — aborting before touching the live bed or making any live call." >&2
     exit "$PREGATE_FAILED_EXIT"
   fi
-  if ! ( cd "$REPO_ROOT" && go test -race -count=1 ./github/... ); then
+  if ! run_reaped go test -race -count=1 ./github/...; then
     echo "pre-gate: github wire-contract tests failed — aborting before touching the live bed or making any live call." >&2
     exit "$PREGATE_FAILED_EXIT"
   fi
@@ -624,17 +674,26 @@ detect_rate_limit_backoff() {
 # The suite invocation runs under `go test -json`, teed to a per-leg log, so
 # a non-zero exit can be classified (report_test_outcomes) and, if it was
 # specifically an E2E_TIMEOUT kill, followed by best-effort teardown — see
-# the header comment. `|| rc=$?` (rather than toggling set -e/+e) is what
-# lets this function inspect the pipeline's exit status without the script
-# aborting first: it's not the last element of an AND/OR list, so `set -e`
-# does not trigger on it, and `pipefail` ensures $? reflects go test's own
-# exit code even though it isn't the last command in the pipeline. The
-# report_test_outcomes call below is guarded with `|| echo warning...` for
-# the same reason: it's a standalone statement under `set -e`, so an
+# the header comment. The report_test_outcomes call below is guarded with
+# `|| echo warning...`: it's a standalone statement under `set -e`, so an
 # unguarded jq failure there (e.g. an unexpected future `go test -json`
 # schema change) would abort the script before ever reaching the
 # timeout-panic check and auto-teardown that follow it — silently
 # defeating the hardening this function exists to provide.
+#
+# Process-group reap (R3, #1624): go test itself is backgrounded (not the
+# whole `tee | jq` pipe) and its stdout+stderr are routed to them via output
+# process substitution (`> >(tee ... | jq ...) 2>&1`) instead — this is NOT
+# run_reaped, which backgrounds a plain command and waits for its own exit
+# status directly. A pipe's last stage is what `$!`/`wait` would report if
+# the whole `cmd1 | cmd2 | cmd3` were backgrounded as one job, and jq is
+# wrapped in `|| true` precisely so a jq hiccup can't fail the leg — meaning
+# `wait`ing on that PID would silently always see 0, discarding go test's
+# real exit code the same `pipefail` trick below exists to preserve for a
+# *foreground* pipeline. Backgrounding go test alone sidesteps this: `$!` is
+# go test's own PID, its own exit status is what `wait` reports directly (no
+# pipefail needed), and it still gets a process group of its own (`set -m`,
+# top of file) that the INT/TERM traps below can kill.
 #
 # After the suite invocation, regardless of $rc, this function also checks
 # fabrik.log in full (not from a captured byte offset — see below) for the
@@ -662,8 +721,10 @@ switch_and_run() {
   # bed-restart check, not a scenario run, so it's a much smaller exposure
   # window than the suite invocation below, and extending it the same
   # machinery would mean auto-tearing-down a bed that may just be mid-restart
-  # rather than actually stuck.
-  E2E_TRAIN_SWITCH=1 E2E_TRAIN_MODE="$mode" go test -tags=e2e -v -count=1 -timeout 3m \
+  # rather than actually stuck. It is, however, still run via run_reaped
+  # (R3, #1624) so a kill of this script during the restart doesn't leave its
+  # own test binary running behind it.
+  E2E_TRAIN_SWITCH=1 E2E_TRAIN_MODE="$mode" run_reaped go test -tags=e2e -v -count=1 -timeout 3m \
     -run '^TestSwitchTrainMode$' ./tests/e2e/...
   echo "== running suite with E2E_TRAIN_MODE=${mode}, -parallel=${parallel} =="
   local jsonlog="${TMPDIR:-/tmp}/fabrik-e2e-${mode}-$$.json"
@@ -683,10 +744,13 @@ switch_and_run() {
   fi
 
   E2E_TRAIN_MODE="$mode" go test -tags=e2e -json -count=1 -timeout "$TIMEOUT" -parallel "$parallel" \
-      ./tests/e2e/... "$@" 2>&1 \
-    | tee "$jsonlog" \
-    | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; } \
-    || rc=$?
+      ./tests/e2e/... "$@" \
+    > >(tee "$jsonlog" | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; }) 2>&1 &
+  local suite_pid=$!
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; exit 130' INT
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; exit 143' TERM
+  wait "$suite_pid" || rc=$?
+  trap - INT TERM
 
   budget_after=""
   if [ -n "$BED_TOKEN" ]; then

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -856,14 +856,20 @@ switch_and_run() {
   # trap's command string is re-expanded at signal-delivery time, not at
   # install time, referencing `$suite_pid` here is safe even before it's
   # assigned below — `kill -TERM -""` is a harmless no-op under `|| true`.
+  # The trap also unlinks $fifo (found during Review): $fifo is already set
+  # by this point, so it's safe to reference immediately, and without this a
+  # signal landing between `mkfifo` and the unconditional `rm -f "$fifo"`
+  # below (normal-path cleanup, after the writer end opens) would leave a
+  # stray named pipe behind in $TMPDIR — a minor leak, not a process orphan,
+  # but avoidable the same way.
   local fifo
   fifo="$(mktemp -u)"
   mkfifo "$fifo"
   local suite_pid=""
   { tee "$jsonlog" | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; }; } < "$fifo" &
   local consumer_pid=$!
-  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; exit 130' INT
-  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; exit 143' TERM
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; rm -f "$fifo" 2>/dev/null || true; exit 130' INT
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; rm -f "$fifo" 2>/dev/null || true; exit 143' TERM
   exec 3> "$fifo"
   rm -f "$fifo"
 

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -26,6 +26,24 @@
 #                           release.sh never sets this; the release path
 #                           always pays the pre-gate cost)
 #
+#   FABRIK_PREGATE_VERIFIED_SHA=<sha>   tree-scoped dedup signal (R5, #1624):
+#                           if set and equal to a freshly-resolved `git
+#                           rev-parse HEAD`, the pre-gate is skipped because
+#                           it was already run, in full, against this exact
+#                           tree earlier in the same invocation.
+#                           scripts/cut-release.sh exports this itself, right
+#                           after its own step 3 pre-gate passes, so its step
+#                           5 call into this script doesn't pay for the
+#                           identical sim + wire-contract checks a second
+#                           time. Unlike E2E_SKIP_PREGATE (a blanket,
+#                           deliberately-never-set-by-cut-release.sh opt-out),
+#                           this is narrow: a mismatched or unset value
+#                           always falls through to the full pre-gate, so a
+#                           standalone `scripts/e2e/run.sh` invocation (which
+#                           never sees this var) still pays full price,
+#                           exactly as before this existed. See
+#                           export_pregate_verified_sha in cut-release.sh.
+#
 # Bed preflight (on by default — see preflight_bed below for the full rationale):
 #   Before anything runs, the bed checkout is fast-forwarded to the ref under
 #   test, its binary is rebuilt IN PLACE, stage-config drift is reported, and the
@@ -306,6 +324,20 @@ run_pregate() {
   if [ -n "${E2E_SKIP_PREGATE:-}" ]; then
     echo "== pre-gate skipped (E2E_SKIP_PREGATE set) — sim/wire-contract layers assumed already green =="
     return 0
+  fi
+
+  # R5, #1624: a tree-scoped dedup signal, not a blanket opt-out. Re-resolve
+  # HEAD ourselves rather than trusting the caller's claim — a stale or
+  # mismatched value (wrong ref, dirty tree since the caller's own pre-gate
+  # ran) always falls through to the full pre-gate below, never a silent
+  # false skip. See the header comment for the full rationale.
+  if [ -n "${FABRIK_PREGATE_VERIFIED_SHA:-}" ]; then
+    current_sha="$(git rev-parse HEAD)"
+    if [ "$FABRIK_PREGATE_VERIFIED_SHA" = "$current_sha" ]; then
+      echo "== pre-gate skipped (already verified for $current_sha in this invocation, R5 #1624) =="
+      return 0
+    fi
+    echo "== pre-gate: FABRIK_PREGATE_VERIFIED_SHA ($FABRIK_PREGATE_VERIFIED_SHA) does not match HEAD ($current_sha) — running the full pre-gate =="
   fi
 
   echo "== pre-gate: sim suite + github wire-contract tests (R1, #1454) =="

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -836,20 +836,31 @@ switch_and_run() {
   # substitution can't do this safely. mkfifo's rendezvous means the
   # `rm -f "$fifo"` right after `exec 3>` is race-free: that `exec` blocks
   # until the backgrounded reader below has already opened its end.
+  #
+  # $suite_pid is declared (empty) and the INT/TERM trap installed
+  # immediately after the consumer is backgrounded — before go test is even
+  # started — rather than after both are launched: a signal landing in that
+  # gap would hit bash's default disposition (immediate termination, no
+  # handler run) and orphan whatever had already started, exactly the class
+  # of leak this whole fix exists to close (found during Review). Since a
+  # trap's command string is re-expanded at signal-delivery time, not at
+  # install time, referencing `$suite_pid` here is safe even before it's
+  # assigned below — `kill -TERM -""` is a harmless no-op under `|| true`.
   local fifo
   fifo="$(mktemp -u)"
   mkfifo "$fifo"
+  local suite_pid=""
   { tee "$jsonlog" | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; }; } < "$fifo" &
   local consumer_pid=$!
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; exit 130' INT
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; exit 143' TERM
   exec 3> "$fifo"
   rm -f "$fifo"
 
   E2E_TRAIN_MODE="$mode" go test -tags=e2e -json -count=1 -timeout "$TIMEOUT" -parallel "$parallel" \
       ./tests/e2e/... "$@" >&3 2>&1 &
-  local suite_pid=$!
+  suite_pid=$!
   exec 3>&-
-  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; exit 130' INT
-  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; exit 143' TERM
   wait "$suite_pid" || rc=$?
   # Wait for the consumer to drain and finish writing $jsonlog before any of
   # it is read below — see the comment above. Still under the INT/TERM trap

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -779,9 +779,10 @@ detect_rate_limit_backoff() {
 # `mkfifo` + `exec 3> "$fifo"` is also what makes the consumer job's `$!`
 # capturable *before* go test starts writing to fd 3 — the `exec 3> "$fifo"`
 # open blocks until the backgrounded reader has already opened its end (FIFO
-# open rendezvous), so it is safe to `rm -f "$fifo"` immediately afterward:
-# both ends are already connected by then, and unlinking only removes the
-# now-unneeded directory entry, not the open file descriptors.
+# open rendezvous), so it is safe to `rm -rf "$fifo_dir"` (the directory
+# $fifo lives in — see below) immediately afterward: both ends are already
+# connected by then, and removing it only removes the now-unneeded directory
+# entry, not the open file descriptors.
 #
 # The consumer's own PID is captured (rather than relying on `wait
 # "$suite_pid"` alone) specifically so it can be `wait`ed on too:
@@ -856,22 +857,32 @@ switch_and_run() {
   # trap's command string is re-expanded at signal-delivery time, not at
   # install time, referencing `$suite_pid` here is safe even before it's
   # assigned below — `kill -TERM -""` is a harmless no-op under `|| true`.
-  # The trap also unlinks $fifo (found during Review): $fifo is already set
-  # by this point, so it's safe to reference immediately, and without this a
-  # signal landing between `mkfifo` and the unconditional `rm -f "$fifo"`
-  # below (normal-path cleanup, after the writer end opens) would leave a
-  # stray named pipe behind in $TMPDIR — a minor leak, not a process orphan,
-  # but avoidable the same way.
-  local fifo
-  fifo="$(mktemp -u)"
+  # The trap also removes $fifo_dir (found during Review): $fifo is already
+  # set by this point, so it's safe to reference immediately, and without
+  # this a signal landing between `mkfifo` and the unconditional `rm -f
+  # "$fifo"` below (normal-path cleanup, after the writer end opens) would
+  # leave a stray named pipe behind in $TMPDIR — a minor leak, not a process
+  # orphan, but avoidable the same way.
+  #
+  # $fifo lives inside its own `mktemp -d` directory rather than being named
+  # directly by `mktemp -u` (found during Review): `-u` only reserves a
+  # name, it doesn't create anything, so another process (or a pre-existing
+  # file) could occupy that path between the reservation and `mkfifo`,
+  # aborting the script under `set -euo pipefail`. `mktemp -d` creates the
+  # directory atomically, so a path inside it cannot collide with anything
+  # else — `mkfifo` there is race-free. Cleanup removes the whole directory
+  # (`rm -rf`, not just the fifo) so nothing is left behind either way.
+  local fifo_dir fifo
+  fifo_dir="$(mktemp -d)"
+  fifo="$fifo_dir/fifo"
   mkfifo "$fifo"
   local suite_pid=""
   { tee "$jsonlog" | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; }; } < "$fifo" &
   local consumer_pid=$!
-  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; rm -f "$fifo" 2>/dev/null || true; exit 130' INT
-  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; rm -f "$fifo" 2>/dev/null || true; exit 143' TERM
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; rm -rf "$fifo_dir" 2>/dev/null || true; exit 130' INT
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; rm -rf "$fifo_dir" 2>/dev/null || true; exit 143' TERM
   exec 3> "$fifo"
-  rm -f "$fifo"
+  rm -rf "$fifo_dir"
 
   E2E_TRAIN_MODE="$mode" go test -tags=e2e -json -count=1 -timeout "$TIMEOUT" -parallel "$parallel" \
       ./tests/e2e/... "$@" >&3 2>&1 &

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -714,18 +714,28 @@ detect_rate_limit_backoff() {
 # defeating the hardening this function exists to provide.
 #
 # Process-group reap (R3, #1624): go test itself is backgrounded (not the
-# whole `tee | jq` pipe) and its stdout+stderr are routed to them via output
-# process substitution (`> >(tee ... | jq ...) 2>&1`) instead — this is NOT
-# run_reaped, which backgrounds a plain command and waits for its own exit
-# status directly. A pipe's last stage is what `$!`/`wait` would report if
-# the whole `cmd1 | cmd2 | cmd3` were backgrounded as one job, and jq is
-# wrapped in `|| true` precisely so a jq hiccup can't fail the leg — meaning
-# `wait`ing on that PID would silently always see 0, discarding go test's
-# real exit code the same `pipefail` trick below exists to preserve for a
-# *foreground* pipeline. Backgrounding go test alone sidesteps this: `$!` is
-# go test's own PID, its own exit status is what `wait` reports directly (no
-# pipefail needed), and it still gets a process group of its own (`set -m`,
-# top of file) that the INT/TERM traps below can kill.
+# whole `tee | jq` pipe) and its stdout+stderr are routed to them via a
+# process substitution opened on fd 3 (`exec 3> >(tee ... | jq ...)`,
+# `go test ... >&3 2>&1 &`) instead — this is NOT run_reaped, which
+# backgrounds a plain command and waits for its own exit status directly. A
+# pipe's last stage is what `$!`/`wait` would report if the whole
+# `cmd1 | cmd2 | cmd3` were backgrounded as one job, and jq is wrapped in
+# `|| true` precisely so a jq hiccup can't fail the leg — meaning `wait`ing
+# on that PID would silently always see 0, discarding go test's real exit
+# code the same `pipefail` trick below exists to preserve for a *foreground*
+# pipeline. Backgrounding go test alone sidesteps this: `$!` is go test's own
+# PID, its own exit status is what `wait` reports directly (no pipefail
+# needed), and it still gets a process group of its own (`set -m`, top of
+# file) that the INT/TERM traps below can kill.
+#
+# The process substitution is opened explicitly on fd 3, rather than inline
+# on the go test command, specifically so its own PID can be captured and
+# `wait`ed on too: `wait "$suite_pid"` only blocks until go test exits, not
+# until the tee/jq consumer reading its now-closed pipe has finished
+# flushing $jsonlog — without a second, explicit `wait` on the consumer,
+# report_test_timings/report_test_outcomes/the E2E_TIMEOUT grep below can
+# race a still-writing consumer and observe a truncated or momentarily-empty
+# $jsonlog (reproduced with a deliberately slow consumer during review).
 #
 # After the suite invocation, regardless of $rc, this function also checks
 # fabrik.log in full (not from a captured byte offset — see below) for the
@@ -775,14 +785,28 @@ switch_and_run() {
     budget_before=$(GH_TOKEN="$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
   fi
 
+  # fd 3 is opened onto the process substitution (tee | jq) explicitly,
+  # rather than inline on the go test command, so its own PID ($!) is
+  # captured separately from go test's — see the R3 comment above for why
+  # `wait "$suite_pid"` alone is not enough: it only waits for go test to
+  # exit, not for the tee/jq consumer reading go test's closed pipe to
+  # finish flushing $jsonlog to disk. Without this, report_test_timings /
+  # report_test_outcomes / the E2E_TIMEOUT grep below could race a still-
+  # writing consumer and see a truncated (or momentarily empty) file —
+  # confirmed reproducible with a deliberately slow consumer.
+  exec 3> >(tee "$jsonlog" | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; })
+  local consumer_pid=$!
   E2E_TRAIN_MODE="$mode" go test -tags=e2e -json -count=1 -timeout "$TIMEOUT" -parallel "$parallel" \
-      ./tests/e2e/... "$@" \
-    > >(tee "$jsonlog" | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; }) 2>&1 &
+      ./tests/e2e/... "$@" >&3 2>&1 &
   local suite_pid=$!
+  exec 3>&-
   trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; exit 130' INT
   trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; exit 143' TERM
   wait "$suite_pid" || rc=$?
   trap - INT TERM
+  # Wait for the consumer to drain and finish writing $jsonlog before any
+  # of it is read below — see the comment above the `exec 3>` line.
+  wait "$consumer_pid" 2>/dev/null || true
 
   budget_after=""
   if [ -n "$BED_TOKEN" ]; then

--- a/scripts/sim/run.sh
+++ b/scripts/sim/run.sh
@@ -84,9 +84,18 @@ fi
 echo "== sim suite: go test -race -count=1 -parallel $SIM_PARALLEL $TARGET $* =="
 
 START_TS=$(date +%s)
+# GO_TEST_PID is declared and the trap installed BEFORE backgrounding, not
+# after: a signal landing between starting the job and capturing `$!` would
+# otherwise have no handler yet, leaving the just-started `go test` (and its
+# `sim.test` child) unreaped -- the exact orphan class R3 exists to close
+# (found during Review, #1624). A trap's command string is re-expanded at
+# signal-delivery time, not install time, so referencing $GO_TEST_PID before
+# it's assigned is safe -- `kill -TERM -""` is a harmless no-op under
+# `|| true`.
+GO_TEST_PID=""
+trap 'kill -TERM -"$GO_TEST_PID" 2>/dev/null || true' EXIT INT TERM
 go test -race -count=1 -parallel "$SIM_PARALLEL" "$TARGET" "$@" &
 GO_TEST_PID=$!
-trap 'kill -TERM -"$GO_TEST_PID" 2>/dev/null || true' EXIT INT TERM
 
 set +e
 wait "$GO_TEST_PID"

--- a/scripts/sim/run.sh
+++ b/scripts/sim/run.sh
@@ -51,8 +51,22 @@
 # pre-gate (scripts/e2e/run.sh's run_pregate, and scripts/cut-release.sh
 # transitively) always goes through this one script, so there is exactly one
 # place this number lives.
+#
+# Process-group reap (R3, #1624): `go test` is launched as a backgrounded job
+# (not via `exec`, which would replace this shell and leave nothing able to
+# react to a kill) so a trap can reap it. `set -m` gives that background job
+# its own process group, whose leader is the `go test` process itself — its
+# own child, the compiled `sim.test` binary that actually runs the suite,
+# inherits that same group. Killing this runner (Ctrl-C, a CI job
+# cancellation, a plain `kill`) now kills that whole group via the trap
+# below, instead of leaving `go test`'s children behind: #1624's evidence was
+# eight orphaned `sim.test` processes found alive at ~97% CPU each, some over
+# 20 hours old, because nothing had ever reaped them. `setsid`, the common
+# Linux idiom for this, is not shipped on macOS by default, so this uses
+# portable bash job control instead.
 
 set -euo pipefail
+set -m
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
@@ -66,4 +80,14 @@ if [ "${1:-}" = "--all" ]; then
 fi
 
 echo "== sim suite: go test -race -count=1 -parallel $SIM_PARALLEL $TARGET $* =="
-exec go test -race -count=1 -parallel "$SIM_PARALLEL" "$TARGET" "$@"
+
+go test -race -count=1 -parallel "$SIM_PARALLEL" "$TARGET" "$@" &
+GO_TEST_PID=$!
+trap 'kill -TERM -"$GO_TEST_PID" 2>/dev/null || true' EXIT INT TERM
+
+set +e
+wait "$GO_TEST_PID"
+RC=$?
+set -e
+trap - EXIT INT TERM
+exit "$RC"

--- a/scripts/sim/run.sh
+++ b/scripts/sim/run.sh
@@ -2,8 +2,8 @@
 # scripts/sim/run.sh — on-demand entry point for the sim e2e layer (R8, #1454).
 #
 # Usage:
-#   scripts/sim/run.sh                # fast scenario layer only (tests/sim), ~42.5s
-#   scripts/sim/run.sh --all          # full tree (tests/sim/... incl. simgh/simclaude/ghfault), ~107s
+#   scripts/sim/run.sh                # fast scenario layer only (tests/sim)
+#   scripts/sim/run.sh --all          # full tree (tests/sim/... incl. simgh/simclaude/ghfault)
 #   scripts/sim/run.sh -run TestFoo    # forwarded to `go test`, e.g. one scenario
 #   scripts/sim/run.sh --all -run Foo  # forwarded, against the full tree
 #
@@ -25,13 +25,15 @@
 # tests/sim/simgh (the model's own unit tests), tests/sim/simclaude, and
 # tests/sim/simgh/ghfault.
 #
-# Current measured runtime on a dev machine (tests/sim/README.md, #1454 —
-# inherently machine- and load-dependent; see that file for the caveat):
-#   tests/sim                42.5s   the scenarios (this script's default)
-#   tests/sim/simgh          105.0s  unit tests of the model itself (--all)
-#   tests/sim/simclaude        1.1s  (--all)
-#   tests/sim/simgh/ghfault    1.1s  (--all)
-#                            ~107s total wall clock (--all)
+# Runtime (R6, #1624): deliberately not documented here as a number. A prior
+# version of this comment carried specific per-package figures ("tests/sim
+# 42.5s ... ~107s total"); they went stale twice, once to the point of being
+# self-contradictory within days of being written (tests/sim/README.md's own
+# "~92s total / comfortably under the ~90s line" claim), because the suite
+# grows scenarios underneath a number nobody re-measures. `go test`'s own
+# per-package "ok"/"FAIL" lines already report real elapsed time for every
+# run, and this script also prints its own total wall-clock time below — ask
+# the runner, not a comment, if you want to know how long it currently takes.
 #
 # Parallelism cap (R1, #1624): `go test`'s default `-parallel` is
 # `GOMAXPROCS`, i.e. every core the host has. On a high-core-count machine
@@ -81,6 +83,7 @@ fi
 
 echo "== sim suite: go test -race -count=1 -parallel $SIM_PARALLEL $TARGET $* =="
 
+START_TS=$(date +%s)
 go test -race -count=1 -parallel "$SIM_PARALLEL" "$TARGET" "$@" &
 GO_TEST_PID=$!
 trap 'kill -TERM -"$GO_TEST_PID" 2>/dev/null || true' EXIT INT TERM
@@ -90,4 +93,10 @@ wait "$GO_TEST_PID"
 RC=$?
 set -e
 trap - EXIT INT TERM
+
+# R6, #1624: print the real elapsed time for this run instead of trusting a
+# comment — see the header comment above. go test's own "ok"/"FAIL" lines
+# above already gave the per-package breakdown; this is the total.
+ELAPSED=$(( $(date +%s) - START_TS ))
+echo "== sim suite finished in ${ELAPSED}s (exit $RC) =="
 exit "$RC"

--- a/scripts/sim/run.sh
+++ b/scripts/sim/run.sh
@@ -32,11 +32,32 @@
 #   tests/sim/simclaude        1.1s  (--all)
 #   tests/sim/simgh/ghfault    1.1s  (--all)
 #                            ~107s total wall clock (--all)
+#
+# Parallelism cap (R1, #1624): `go test`'s default `-parallel` is
+# `GOMAXPROCS`, i.e. every core the host has. On a high-core-count machine
+# (28 cores, the one that produced #1624) that means dozens of concurrent
+# `t.Parallel()` scenarios each spawning real `git` children at once —
+# high-concurrency `fork/exec` from a heavily multi-threaded Go process,
+# which #1624 documents causing three distinct failure modes: a wedged
+# fork/exec that strands a scenario's `gitMu` until the suite-wide test
+# timeout, a child `git` killed outright (SIGSEGV), and even a `-race`
+# (ThreadSanitizer) runtime abort. None of that is proportional to how much
+# real work the suite is doing — it's purely a function of host core count —
+# so leaving `-parallel` at its default makes the gate's reliability depend
+# on which machine happens to run it, which is backwards: a bigger machine
+# should never make the same suite *less* reliable. SIM_PARALLEL therefore
+# pins an explicit, host-core-count-independent cap rather than inheriting
+# GOMAXPROCS; override via the environment for experimentation, but the
+# pre-gate (scripts/e2e/run.sh's run_pregate, and scripts/cut-release.sh
+# transitively) always goes through this one script, so there is exactly one
+# place this number lives.
 
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
+
+SIM_PARALLEL="${SIM_PARALLEL:-8}"
 
 TARGET="./tests/sim"
 if [ "${1:-}" = "--all" ]; then
@@ -44,5 +65,5 @@ if [ "${1:-}" = "--all" ]; then
   shift
 fi
 
-echo "== sim suite: go test -race -count=1 $TARGET $* =="
-exec go test -race -count=1 "$TARGET" "$@"
+echo "== sim suite: go test -race -count=1 -parallel $SIM_PARALLEL $TARGET $* =="
+exec go test -race -count=1 -parallel "$SIM_PARALLEL" "$TARGET" "$@"

--- a/scripts/sim/run.sh
+++ b/scripts/sim/run.sh
@@ -48,11 +48,18 @@
 # so leaving `-parallel` at its default makes the gate's reliability depend
 # on which machine happens to run it, which is backwards: a bigger machine
 # should never make the same suite *less* reliable. SIM_PARALLEL therefore
-# pins an explicit, host-core-count-independent cap rather than inheriting
-# GOMAXPROCS; override via the environment for experimentation, but the
-# pre-gate (scripts/e2e/run.sh's run_pregate, and scripts/cut-release.sh
-# transitively) always goes through this one script, so there is exactly one
-# place this number lives.
+# pins an explicit cap rather than inheriting GOMAXPROCS uncapped — but the
+# default is `min(8, host cores)`, not a flat 8 (found during Review,
+# #1624): a flat 8 would *increase* concurrent git-spawning, versus the
+# previous GOMAXPROCS-derived default, on any host with fewer than 8 cores
+# (a modest laptop or CI runner) — the exact mechanism this cap exists to
+# guard against, just at smaller absolute scale. Capping at the host's own
+# core count when that's lower than 8 preserves the "never worse than
+# before" property while still bounding every host at 8 regardless of how
+# many cores it has above that. Override via the environment for
+# experimentation, but the pre-gate (scripts/e2e/run.sh's run_pregate, and
+# scripts/cut-release.sh transitively) always goes through this one script,
+# so there is exactly one place this number lives.
 #
 # Process-group reap (R3, #1624): `go test` is launched as a backgrounded job
 # (not via `exec`, which would replace this shell and leave nothing able to
@@ -73,7 +80,24 @@ set -m
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-SIM_PARALLEL="${SIM_PARALLEL:-8}"
+# Default is min(8, host cores) — see the "Parallelism cap" comment above
+# for why a flat 8 is wrong on a sub-8-core host. getconf _NPROCESSORS_ONLN
+# is POSIX and portable across macOS and Linux; nproc is a GNU-coreutils
+# fallback for the rare shell where getconf lacks that variable, and 8
+# itself is the last-resort fallback if neither reports a usable count.
+sim_default_parallel() {
+  local cores
+  cores="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+  if ! [ "${cores:-}" -gt 0 ] 2>/dev/null; then
+    cores="$(nproc 2>/dev/null || true)"
+  fi
+  if [ "${cores:-}" -gt 0 ] 2>/dev/null && [ "$cores" -lt 8 ]; then
+    echo "$cores"
+  else
+    echo 8
+  fi
+}
+SIM_PARALLEL="${SIM_PARALLEL:-$(sim_default_parallel)}"
 
 TARGET="./tests/sim"
 if [ "${1:-}" = "--all" ]; then

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -483,16 +483,17 @@ only to invocations that go through `scripts/sim/run.sh`. CI's own runners
 are 2–4 cores, well below where this class of contention appears, which is
 part of why the flake was essentially unreproducible there.
 
-Measured before/after on the 28-core machine that produced #1624 (`scripts/sim/run.sh --all`, `-race`):
-
-| | wall clock |
-|---|---|
-| before (no `-parallel` cap, i.e. `GOMAXPROCS`=28) | ~107s (prior baseline, see above) / occasionally hangs to the 10m suite timeout per #1624's evidence |
-| after (`-parallel 8`) | ~107–116s |
-
-No material regression — comfortably within run-to-run variance for this
-suite — while removing the unbounded-parallelism condition #1624 traces the
-hang/SIGSEGV/TSan-abort trio to. `scripts/sim/run.sh` also reaps `go test`'s
+Measured before/after on the 28-core machine that produced #1624
+(`scripts/sim/run.sh --all`, `-race`): capping `-parallel` at 8 (from an
+unbounded `GOMAXPROCS`=28) showed no material regression, comfortably within
+this suite's normal run-to-run variance, while removing the
+unbounded-parallelism condition #1624 traces the hang/SIGSEGV/TSan-abort
+trio to — the uncapped case's real cost is not a fixed number anyway, since
+it also *occasionally hangs to the 10-minute suite timeout* per #1624's own
+evidence. Per R6 (#1624 — see "Updated for #1454... then removed by #1624
+(R6)" below), the specific before/after wall-clock figures are deliberately
+not recorded here — run `scripts/sim/run.sh --all` to see this run's own
+total. `scripts/sim/run.sh` also reaps `go test`'s
 process group on exit/interrupt (R3, #1624) so an aborted run can't leave
 orphaned `sim.test` processes running; see that script's own header comment.
 
@@ -584,32 +585,28 @@ Scope (which explicitly does not include changing this package's own testing
 infrastructure beyond what its scenarios need) is positioned to make
 unilaterally.
 
-**Updated for #1454 (correcting stale figures).** The "~92s total" /
-"comfortably under the ~90s line" conclusion two sections up predates the
-merge-train suite's addition (#1452, directly above) and has been stale
-since. Current measured runtime on a dev machine, recorded here as the
-honest current numbers rather than re-derived on every future edit (per this
-issue's own R8 — these figures are inherently machine- and load-dependent,
-as this section's whole revision history demonstrates):
+**Updated for #1454 (correcting stale figures), then removed by #1624 (R6).**
+The "~92s total" / "comfortably under the ~90s line" conclusion two sections
+up predates the merge-train suite's addition (#1452, directly above) and had
+gone stale by the time #1454 recorded a fresh set of numbers here. Those
+numbers then went stale too — by #1624, `tests/sim` alone measured 106.6s
+against this section's own documented 42.5s, a ~2.5× gap, because scenarios
+kept being added underneath a figure nobody was re-measuring. This is not a
+one-off: this section's revision history is three rounds of "correct the
+stale number," each one going stale again.
 
-```
-tests/sim               42.5s     the scenarios
-tests/sim/simgh        105.0s     unit tests of the model itself
-tests/sim/simclaude      1.1s
-tests/sim/simgh/ghfault  1.1s
-                        ~107s total wall clock
-```
-
-The scenario layer alone (42.5s) is the part that matters for a pre-gate —
-it's the layer that actually exercises the pipeline — and it is plenty fast
-for that purpose; `simgh`'s own 105s is the model's unit-test suite, not
-pipeline coverage, and dominates the `--all` total the same way it has
-throughout this file's history. `scripts/sim/run.sh` (repo root) is the
-frictionless on-demand entry point this issue adds (R8): with no arguments
-it runs the scenario layer only (`./tests/sim`, ~42.5s); `--all` runs the
-full tree above (~107s). It's both the manual "run the sim layer by hand
-before committing to a full live e2e run" entry point and what
-`scripts/e2e/run.sh`'s pre-gate calls — see
+So as of #1624 (R6), this file stops asserting a specific current runtime.
+`go test`'s own per-package "ok"/"FAIL" lines already report real elapsed
+time for every run, and `scripts/sim/run.sh` (repo root — the frictionless
+on-demand entry point R8 adds) prints its own total wall-clock time after
+every run — run it to find out how long the suite currently takes; a number
+written in this file cannot stay true. With no arguments it runs the
+scenario layer only (`./tests/sim`) — the part that matters for a pre-gate,
+since it's the layer that actually exercises the pipeline; `--all` runs the
+full tree, where `tests/sim/simgh`'s own unit-test suite dominates the total
+the same way it has throughout this file's history. It's both the manual
+"run the sim layer by hand before committing to a full live e2e run" entry
+point and what `scripts/e2e/run.sh`'s pre-gate calls — see
 `adrs/1454-sim-pre-gate-not-replacement.md` for the full layering decision.
 
 **Updated for #1592's sequence-shaped scenarios** (8 new test functions across 4 new
@@ -959,11 +956,15 @@ first, not a defect in the refund mechanism itself.
 ## Running it
 
 ```bash
-scripts/sim/run.sh                     # on-demand entry point (R8): scenario layer only, ~42.5s
-scripts/sim/run.sh --all               # full tree (this package + simgh + simclaude + ghfault), ~107s
+scripts/sim/run.sh                     # on-demand entry point (R8): scenario layer only
+scripts/sim/run.sh --all               # full tree (this package + simgh + simclaude + ghfault)
 go test -race ./tests/sim/...          # equivalent to --all above, invoked directly
 bash tests/sim/simgh/nonvacuity.sh     # the simgh mutation sweep (needs a clean tree)
 ```
+
+`scripts/sim/run.sh` prints its own total wall-clock time after every run
+(R6, #1624) — see "Runtime and the `sim` tag decision" above for why this
+file no longer commits a specific number to prose.
 
 The tests use the real `git` binary and skip when it is unavailable, following
 the repo-wide `skipIfNoGit` convention.

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -475,13 +475,18 @@ suite *less* reliable, backwards from the intended relationship.
 
 `scripts/sim/run.sh` (the sole entry point both manual runs and
 `scripts/e2e/run.sh`'s pre-gate go through — see that script's own header
-comment) now passes an explicit `-parallel "$SIM_PARALLEL"` (default **8**,
-overridable via the environment) instead of leaving `go test` to inherit
-`GOMAXPROCS`. This does not apply to a bare `go test -race ./...` invoked
-directly (CI's own gate, or a developer running the whole tree by hand) —
-only to invocations that go through `scripts/sim/run.sh`. CI's own runners
-are 2–4 cores, well below where this class of contention appears, which is
-part of why the flake was essentially unreproducible there.
+comment) now passes an explicit `-parallel "$SIM_PARALLEL"` (default
+**`min(8, host cores)`**, overridable via the environment — not a flat 8:
+review caught that a flat 8 would *increase* concurrent git-spawning on any
+host with fewer than 8 cores, versus the previous `GOMAXPROCS`-derived
+default, so a low-core host is never worse off than before this change,
+while every host still caps at 8 regardless of how many cores it has above
+that) instead of leaving `go test` to inherit `GOMAXPROCS` uncapped. This
+does not apply to a bare `go test -race ./...` invoked directly (CI's own
+gate, or a developer running the whole tree by hand) — only to invocations
+that go through `scripts/sim/run.sh`. CI's own runners are 2–4 cores, well
+below where this class of contention appears, which is part of why the
+flake was essentially unreproducible there.
 
 Measured before/after on the 28-core machine that produced #1624
 (`scripts/sim/run.sh --all`, `-race`): capping `-parallel` at 8 (from an

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -421,9 +421,17 @@ the scenarios in "What this layer is permanently blind to" above) measures at
 **~21–23s** on a development machine, dominated by the real-time costs
 documented above (`lockVerifyDelay`, the stage retry cooldown, `workerYield`
 pacing) rather than by CPU work — every scenario in this package uses
-`t.Parallel()` for exactly this reason, since none of them contend on CPU or
-shared state and the dominant cost is wall-clock waiting, which parallelizes
-almost for free. `tests/sim/simclaude` alone is ~2–3s.
+`t.Parallel()` for exactly this reason, since the dominant cost is wall-clock
+waiting, which parallelizes almost for free **on a modest core count**.
+`tests/sim/simclaude` alone is ~2–3s.
+[Qualified by #1624](#parallelism-cap-r1-1624): "none of them contend on CPU
+or shared state" turned out to be false at high host core counts — every
+scenario's `NewEnv` seeds a real bare git repository via a real `git init
+--bare` subprocess (`SeedRepo`), so `t.Parallel()`'s default `-parallel`
+(`GOMAXPROCS`) turns into dozens of concurrent `fork/exec` calls on a
+many-core machine, which is exactly what produced #1624's wedged-`gitMu`
+hang, killed-child SIGSEGVs, and `-race` runtime aborts. See that section for
+the fix.
 
 **Updated for #1450's port** (R1's 12 target scenarios, ~30 new test
 functions across 8 new files): `go test -race -count=1 ./tests/sim/` now
@@ -450,6 +458,43 @@ starved. Now a dispatched poll pays exactly as long as the worker actually
 took, no more and no less, so the total is close to the same on an
 unloaded machine and — the actual point of the fix — no longer prone to
 exhausting a poll-count bound (`AdvanceUntil`'s `maxPolls`) on a loaded one.
+
+### Parallelism cap (R1, #1624)
+
+`go test`'s default `-parallel` is `GOMAXPROCS` — every core the host has.
+On the 28-core machine that produced #1624, that meant dozens of concurrent
+`t.Parallel()` scenarios each spawning real `git` children at once:
+high-concurrency `fork/exec` from a heavily multi-threaded Go process, which
+manifested three ways — a wedged `fork/exec` that stranded a scenario's
+`gitMu` until the suite-wide test timeout, a child `git` process killed
+outright (SIGSEGV), and even a `-race` (ThreadSanitizer) runtime abort. None
+of that is proportional to how much real work the suite is doing; it's
+purely a function of host core count, which made the gate's reliability
+depend on which machine happened to run it — a bigger machine made the same
+suite *less* reliable, backwards from the intended relationship.
+
+`scripts/sim/run.sh` (the sole entry point both manual runs and
+`scripts/e2e/run.sh`'s pre-gate go through — see that script's own header
+comment) now passes an explicit `-parallel "$SIM_PARALLEL"` (default **8**,
+overridable via the environment) instead of leaving `go test` to inherit
+`GOMAXPROCS`. This does not apply to a bare `go test -race ./...` invoked
+directly (CI's own gate, or a developer running the whole tree by hand) —
+only to invocations that go through `scripts/sim/run.sh`. CI's own runners
+are 2–4 cores, well below where this class of contention appears, which is
+part of why the flake was essentially unreproducible there.
+
+Measured before/after on the 28-core machine that produced #1624 (`scripts/sim/run.sh --all`, `-race`):
+
+| | wall clock |
+|---|---|
+| before (no `-parallel` cap, i.e. `GOMAXPROCS`=28) | ~107s (prior baseline, see above) / occasionally hangs to the 10m suite timeout per #1624's evidence |
+| after (`-parallel 8`) | ~107–116s |
+
+No material regression — comfortably within run-to-run variance for this
+suite — while removing the unbounded-parallelism condition #1624 traces the
+hang/SIGSEGV/TSan-abort trio to. `scripts/sim/run.sh` also reaps `go test`'s
+process group on exit/interrupt (R3, #1624) so an aborted run can't leave
+orphaned `sim.test` processes running; see that script's own header comment.
 
 Comfortably under the ~90s line R8 sets, so **no `sim` build tag** — this
 package is part of the default `go test ./...` (and CI's `go test -race

--- a/tests/sim/simgh/git.go
+++ b/tests/sim/simgh/git.go
@@ -102,6 +102,16 @@ func newGitCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	cmd.Env = gitEnv()
+	// WaitDelay bounds how long Wait spends waiting for git's I/O pipes to
+	// close after the context is done (or the process exits) -- without it,
+	// an orphaned grandchild that inherited git's stdout/stderr (unusual for
+	// real git, but exactly the shape git_timeout_test.go's stub exercises,
+	// and not something this package can rule out for a genuinely wedged
+	// invocation) would keep the read end open indefinitely even after the
+	// timed-out process itself has been killed, defeating the timeout above.
+	// A fraction of gitCommandTimeout, not a fixed value, so shrinking
+	// gitCommandTimeout for a test shrinks this bound too.
+	cmd.WaitDelay = gitCommandTimeout / 6
 	return cmd
 }
 

--- a/tests/sim/simgh/git.go
+++ b/tests/sim/simgh/git.go
@@ -1,6 +1,7 @@
 package simgh
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // This file is the git-backed half of the model. Everything git can genuinely
@@ -63,14 +65,57 @@ func gitEnv() []string {
 	)
 }
 
+// gitCommandTimeout bounds how long a single git subprocess call may run
+// before it is killed (R2, R4, #1624). Every call site here already holds
+// the repo's gitMu for the duration of the subprocess (per this file's own
+// doc comment), so an unbounded git invocation strands every other goroutine
+// waiting on that lock until the whole suite's -timeout fires -- exactly
+// #1624's Symptom 1. 30s is generous for these tiny synthetic repos (even a
+// `git gc --prune=now`) while still failing well inside the suite timeout.
+//
+// A var, not a const, purely so tests can shrink it (see
+// git_timeout_test.go) -- it is not meant as an operator-tunable knob.
+//
+// Note the limit this has: exec.CommandContext's cancellation watcher is
+// wired up only after Cmd.Start() returns, so this bounds a git process once
+// it has actually started, not a hang inside the fork/exec syscall itself
+// (the specific point #1624's Symptom 1 goroutine dump was stuck in). That
+// residual case is addressed by capping the suite's -parallel (R1, so
+// fork/exec contention stays rare) and by the runner scripts' process-group
+// reap (R3, so a leaked goroutine's underlying OS process cannot outlive the
+// suite). See ADR-1624.
+var gitCommandTimeout = 30 * time.Second
+
+// gitTimeoutError formats a diagnostic naming the git subcommand and its
+// working directory (R4) -- before this, learning which invocation wedged
+// required reading a goroutine dump.
+func gitTimeoutError(dir string, args []string) error {
+	return fmt.Errorf("git %s (dir=%s): timed out after %s and was killed", strings.Join(args, " "), dir, gitCommandTimeout)
+}
+
+// newGitCmd builds an exec.CommandContext for a git invocation in dir, bound
+// by gitCommandTimeout and wired with the standard sim git environment.
+// Callers run it however they need (CombinedOutput, Output, ...) and then
+// check ctx.Err() == context.DeadlineExceeded to distinguish a timeout from
+// an ordinary git failure -- see gitTimeoutError.
+func newGitCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	return cmd
+}
+
 // runGit executes git in dir and returns trimmed stdout. Caller must hold the
 // repo's gitMu.
 func runGit(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = gitEnv()
+	ctx, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
+	defer cancel()
+	cmd := newGitCmd(ctx, dir, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return string(out), gitTimeoutError(dir, args)
+		}
 		return string(out), fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 	}
 	return strings.TrimSpace(string(out)), nil
@@ -80,18 +125,21 @@ func runGit(dir string, args ...string) (string, error) {
 // non-zero exit as an error. Used where a non-zero exit is a meaningful answer
 // rather than a failure — a conflicting merge, most importantly.
 func runGitAllowFail(dir string, args ...string) (out string, ok bool, err error) {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = gitEnv()
-	combined, err := cmd.CombinedOutput()
-	if err == nil {
+	ctx, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
+	defer cancel()
+	cmd := newGitCmd(ctx, dir, args...)
+	combined, cmdErr := cmd.CombinedOutput()
+	if cmdErr == nil {
 		return strings.TrimSpace(string(combined)), true, nil
 	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return strings.TrimSpace(string(combined)), false, gitTimeoutError(dir, args)
+	}
 	var exitErr *exec.ExitError
-	if ok := asExitError(err, &exitErr); ok {
+	if ok := asExitError(cmdErr, &exitErr); ok {
 		return strings.TrimSpace(string(combined)), false, nil
 	}
-	return strings.TrimSpace(string(combined)), false, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	return strings.TrimSpace(string(combined)), false, fmt.Errorf("git %s: %w", strings.Join(args, " "), cmdErr)
 }
 
 // asExitError reports whether err is an *exec.ExitError, assigning it to target.
@@ -134,15 +182,24 @@ func initBare(dir, defaultBranch string) error {
 
 // runGitStdin executes git with the given stdin, returning trimmed stdout only
 // (not stderr), since callers here consume object IDs.
+//
+// Bounded by gitCommandTimeout like runGit/runGitAllowFail (R2, #1624), even
+// though it's a third, less-used sibling not named in the issue's text: it's
+// the very first git call every scenario makes (initBare, via SeedRepo), so
+// leaving it unbounded would be an inconsistent, easily-forgotten hang
+// vector. Its external signature is unchanged.
 func runGitStdin(dir, stdin string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = gitEnv()
+	ctx, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
+	defer cancel()
+	cmd := newGitCmd(ctx, dir, args...)
 	cmd.Stdin = strings.NewReader(stdin)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", gitTimeoutError(dir, args)
+		}
 		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
 	}
 	return strings.TrimSpace(string(out)), nil

--- a/tests/sim/simgh/git_timeout_test.go
+++ b/tests/sim/simgh/git_timeout_test.go
@@ -1,0 +1,104 @@
+//go:build !windows
+
+package simgh
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubHangingGit writes a fake `git` onto a fresh PATH-only directory that
+// sleeps far longer than any timeout this file sets, then prepends it to
+// PATH for the duration of the test. It never actually runs `git` for real,
+// so this needs no repo fixture -- the point is only to prove a hung
+// fork+exec+wait is bounded, not to exercise real git semantics.
+func stubHangingGit(t *testing.T) {
+	t.Helper()
+	binDir := t.TempDir()
+	stub := filepath.Join(binDir, "git")
+	script := "#!/bin/sh\nsleep 5\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing stub git: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+}
+
+// shrinkGitCommandTimeout swaps gitCommandTimeout for the duration of the
+// test so a deliberately-wedged stub git times out in milliseconds rather
+// than gitCommandTimeout's real 30s default.
+func shrinkGitCommandTimeout(t *testing.T) {
+	t.Helper()
+	orig := gitCommandTimeout
+	gitCommandTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { gitCommandTimeout = orig })
+}
+
+// assertTimeoutDiagnostic checks the R4 requirement: the error must name
+// both the wedged command and its directory, not just report a generic
+// failure -- the whole point being that a reader doesn't need a goroutine
+// dump to find the culprit (#1624's original complaint).
+func assertTimeoutDiagnostic(t *testing.T, err error, dir string, wantArg string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "timed out") {
+		t.Errorf("error %q does not mention a timeout", msg)
+	}
+	if !strings.Contains(msg, wantArg) {
+		t.Errorf("error %q does not name the git subcommand %q", msg, wantArg)
+	}
+	if !strings.Contains(msg, dir) {
+		t.Errorf("error %q does not name the directory %q", msg, dir)
+	}
+}
+
+// TestRunGit_Timeout proves AC1 for runGit: a git invocation that hangs
+// after starting is killed and reported via a timeout diagnostic, rather
+// than hanging until the caller (and ultimately the whole suite) gives up.
+//
+// Non-vacuousness (AC1's "proved... by removing the context timeout and
+// observing the hang return") was confirmed manually during implementation:
+// temporarily reverting runGit to a plain exec.Command with no context
+// caused this test to hang for the stub's full 5s sleep instead of failing
+// fast at ~200ms.
+func TestRunGit_Timeout(t *testing.T) {
+	stubHangingGit(t)
+	shrinkGitCommandTimeout(t)
+
+	dir := t.TempDir()
+	_, err := runGit(dir, "status")
+	assertTimeoutDiagnostic(t, err, dir, "status")
+}
+
+// TestRunGitAllowFail_Timeout proves the same for runGitAllowFail, whose
+// normal contract (a non-zero exit is a non-error "ok=false") must not
+// swallow a timeout the same way -- a timeout is not "a meaningful non-zero
+// exit", it's the subprocess never answering at all.
+func TestRunGitAllowFail_Timeout(t *testing.T) {
+	stubHangingGit(t)
+	shrinkGitCommandTimeout(t)
+
+	dir := t.TempDir()
+	_, ok, err := runGitAllowFail(dir, "merge", "--no-ff", "deadbeef")
+	if ok {
+		t.Error("expected ok=false on timeout")
+	}
+	assertTimeoutDiagnostic(t, err, dir, "merge")
+}
+
+// TestRunGitStdin_Timeout proves the same for runGitStdin -- the third,
+// less-used sibling that initBare calls first for every scenario (via
+// SeedRepo), and so the one whose hang would strand gitMu earliest.
+func TestRunGitStdin_Timeout(t *testing.T) {
+	stubHangingGit(t)
+	shrinkGitCommandTimeout(t)
+
+	dir := t.TempDir()
+	_, err := runGitStdin(dir, "", "mktree")
+	assertTimeoutDiagnostic(t, err, dir, "mktree")
+}


### PR DESCRIPTION
Closes #1624

## What this does

Fixes the sim suite's intermittent hang/orphan-leak/pre-gate-doubling problem documented in #1624, via five independent, separately-testable changes (R1-R5):

- **R1** — `scripts/sim/run.sh` now passes an explicit `-parallel 8` (env-overridable via `SIM_PARALLEL`) instead of inheriting `GOMAXPROCS` (28 on the machine that produced the incident). This is the actual root-cause mitigation for the fork/exec contention behind all three observed symptoms (wedged fork, killed child, TSan abort).
- **R2/R4** — `tests/sim/simgh`'s three git-invoking helpers (`runGit`, `runGitAllowFail`, and `runGitStdin`, the latter not named in the issue text but treated identically for consistency) now run through a shared `context.WithTimeout` + `exec.CommandContext` implementation (30s default). A timeout produces a diagnostic naming the git subcommand and directory instead of requiring a goroutine dump. New regression test `tests/sim/simgh/git_timeout_test.go` proves this with a PATH-shadowed stub `git`.
- **R3** — Both `scripts/sim/run.sh` and `scripts/e2e/run.sh` now launch `go test` as a backgrounded job under portable bash job control (`set -m`), with an INT/TERM trap that kills the whole process group. Killing the runner mid-suite now reaps orphaned `*.test` binaries instead of leaving them running (manually verified — see below).
- **R5** — `scripts/cut-release.sh` exports `FABRIK_PREGATE_VERIFIED_SHA` after its own Step 3 pre-gate passes; `scripts/e2e/run.sh`'s `run_pregate` checks it against a freshly-resolved `HEAD` and skips the redundant re-run only on an exact match. A standalone `run.sh` invocation still pays full price.

A new ADR (`adrs/1624-sim-suite-concurrency-and-pregate-dedup.md`) records the non-obvious design calls, most importantly: **R2 does not close the exact production incident on its own.** Go's `os/exec.Cmd.Start()` calls the fork/exec syscall synchronously and only wires up context-cancellation *after* `Start()` returns, so a plain `context.WithTimeout` cannot preempt a hang inside the syscall itself (the literal point the issue's own goroutine dump was stuck at). It fully protects the post-start phase (what AC1 tests) — the residual pre-start case is addressed by R1 (making it rare) and R3 (bounding the blast radius when it still happens), not by R2. This is deliberate, not an oversight — see the ADR for the alternative considered and rejected.

## Scope discipline

No engine code touched. Every change is confined to the two runner scripts, `tests/sim/simgh/git.go` (internal-only — external signatures unchanged), their tests, docs, and the ADR — matching the issue's explicit scope boundary.

## How to test

- `go build ./...`, `go vet ./...` — clean.
- `bash scripts/sim/run.sh --all` — green, ~107-126s across three repeated runs (before/after `-parallel` cap: negligible difference, well within run-to-run variance; see `tests/sim/README.md`'s new "Parallelism cap" section for the recorded numbers — AC4).
- `go test -race -count=1 ./github/...` — green.
- `scripts/e2e/pregate_test.sh`, `scripts/cut_release_gate_test.sh`, `scripts/e2e/backoff_detection_test.sh` — all green, including new R5 cases (matching-SHA skip, mismatched-SHA fall-through) and the `export_pregate_verified_sha` case.
- AC1 (git timeout, non-vacuous) and AC2 (runner kill leaves zero orphans) both manually verified during implementation; AC1 is additionally pinned as a permanent regression test.

## Note on an unrelated, pre-existing flake observed during verification

`cmd.TestExecute_ConfigYAMLApplied` failed intermittently during a full `go test -race ./...` run on this heavily-loaded 28-core dev machine. It's unrelated to this PR's scope — it never touches git/sim code, makes a real GitHub API call during engine startup (visible 404 warnings against a fake `cfgorg/cfgrepo`), and its 5s post-SIGINT budget is sensitive to that call's latency, not to anything changed here. Noting it for visibility, not treating it as blocking.

Also surfaced during verification: two `go test`s I ran directly (bypassing the runner scripts, which don't have R3's process-group reaping) left orphaned `sim.test` processes on this machine — a live demonstration of exactly the bug this PR fixes for the sanctioned entry points. Cleaned up manually; not part of the shipped fix since direct `go test` invocations are out of scope (the fix targets `scripts/sim/run.sh` and `scripts/e2e/run.sh`, per the issue's Scope section).