### PR TITLE
Bump every marketplace-listed plugin at release, not just plugin/fabrik

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2462,14 +2462,14 @@ The `fabrik:yolo` label means Fabrik will pick it up automatically and run it th
 
 Claude Code's `/plugin update` detects a new plugin release by comparing the cached `plugin.json` `version` field against the version at `ref: main` in `marketplace.json` — same version number means no refresh fires, even if the plugin's source changed. To prevent users from getting stuck on stale cached content, `cut-release.sh` may commit a version bump to `plugin/fabrik/.claude-plugin/plugin.json` before it tags the release:
 
-- **When it fires**: after the release-notes commit is pushed and before the tag is created, the script diffs `plugin/fabrik` (excluding the manifest itself) against the previous release tag. If anything changed, it patch-bumps `plugin.json`'s `version` field (e.g. `0.2.0` → `0.2.1`) and commits it as `@arbeithand`, in a separate commit alongside an appended changelog line in that release's `release-notes/<version>.md`, e.g.:
+- **When it fires**: after the release-notes commit is pushed and before the tag is created, the script diffs each plugin listed in `marketplace.json` (excluding its own manifest) against the previous release tag. For each one that changed, it patch-bumps that `plugin.json`'s `version` field (e.g. `0.2.0` → `0.2.1`) and commits it as `@arbeithand`, in a separate commit alongside an appended changelog line in that release's `release-notes/<version>.md`, e.g.:
 
   ```
   - Auto-bumped fabrik plugin to 0.2.1 (source changed since v0.0.75)
   ```
 
 - **When it doesn't fire**: if `plugin/fabrik`'s source is unchanged since the previous tag, or there is no previous tag (first-ever release), no extra commit is made and nothing is appended to the release notes.
-- **Scope**: only `plugin/fabrik` (the one plugin listed in `marketplace.json`) is bumped. `plugin/fabrik-workflows` is embedded directly into the Fabrik binary and distributed via `fabrik init`/`fabrik upgrade`; it uses independent content-hash-based change detection and is not affected by the `/plugin update` staleness issue this bump exists to fix.
+- **Scope**: every plugin listed in `marketplace.json` with a `git-subdir` source is bumped — the list is derived from that file rather than hardcoded, so listing a plugin is all that is needed to include it. All bumped manifests land in one commit, each with its own changelog line. `plugin/fabrik-workflows` is out of scope: it is embedded directly into the Fabrik binary and distributed via `fabrik init`/`fabrik upgrade`, uses independent content-hash-based change detection, and is not affected by the `/plugin update` staleness issue this bump exists to fix.
 - **Bump type**: patch-only. Minor/major version bumps for `plugin/fabrik` remain a manual responsibility.
 - **Escape hatch**: pass `--no-plugin-bump` to skip this step entirely, e.g. for a hotfix release where you don't want the extra commit:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2460,14 +2460,14 @@ The `fabrik:yolo` label means Fabrik will pick it up automatically and run it th
 
 Claude Code's `/plugin update` detects a new plugin release by comparing the cached `plugin.json` `version` field against the version at `ref: main` in `marketplace.json` — same version number means no refresh fires, even if the plugin's source changed. To prevent users from getting stuck on stale cached content, `cut-release.sh` may commit a version bump to `plugin/fabrik/.claude-plugin/plugin.json` before it tags the release:
 
-- **When it fires**: after the release-notes commit is pushed and before the tag is created, the script diffs `plugin/fabrik` (excluding the manifest itself) against the previous release tag. If anything changed, it patch-bumps `plugin.json`'s `version` field (e.g. `0.2.0` → `0.2.1`) and commits it as `@arbeithand`, in a separate commit alongside an appended changelog line in that release's `release-notes/<version>.md`, e.g.:
+- **When it fires**: after the release-notes commit is pushed and before the tag is created, the script diffs each plugin listed in `marketplace.json` (excluding its own manifest) against the previous release tag. For each one that changed, it patch-bumps that `plugin.json`'s `version` field (e.g. `0.2.0` → `0.2.1`) and commits it as `@arbeithand`, in a separate commit alongside an appended changelog line in that release's `release-notes/<version>.md`, e.g.:
 
   ```
   - Auto-bumped fabrik plugin to 0.2.1 (source changed since v0.0.75)
   ```
 
 - **When it doesn't fire**: if `plugin/fabrik`'s source is unchanged since the previous tag, or there is no previous tag (first-ever release), no extra commit is made and nothing is appended to the release notes.
-- **Scope**: only `plugin/fabrik` (the one plugin listed in `marketplace.json`) is bumped. `plugin/fabrik-workflows` is embedded directly into the Fabrik binary and distributed via `fabrik init`/`fabrik upgrade`; it uses independent content-hash-based change detection and is not affected by the `/plugin update` staleness issue this bump exists to fix.
+- **Scope**: every plugin listed in `marketplace.json` with a `git-subdir` source is bumped — the list is derived from that file rather than hardcoded, so listing a plugin is all that is needed to include it. All bumped manifests land in one commit, each with its own changelog line. `plugin/fabrik-workflows` is out of scope: it is embedded directly into the Fabrik binary and distributed via `fabrik init`/`fabrik upgrade`, uses independent content-hash-based change detection, and is not affected by the `/plugin update` staleness issue this bump exists to fix.
 - **Bump type**: patch-only. Minor/major version bumps for `plugin/fabrik` remain a manual responsibility.
 - **Escape hatch**: pass `--no-plugin-bump` to skip this step entirely, e.g. for a hotfix release where you don't want the extra commit:
 

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -5,7 +5,7 @@
 #   scripts/cut-release.sh v0.0.67
 #   scripts/cut-release.sh v0.0.67 --skip-tests       # skip race-tested suite (last-resort)
 #   scripts/cut-release.sh v0.0.67 --no-doc-issue     # skip filing the doc-update issue
-#   scripts/cut-release.sh v0.0.67 --no-plugin-bump   # skip the plugin/fabrik version auto-bump
+#   scripts/cut-release.sh v0.0.67 --no-plugin-bump   # skip the marketplace plugin version auto-bumps
 #   scripts/cut-release.sh v0.0.67 --skip-integration=<reason>
 #       # Skip the mandatory live e2e integration gate (step 5 below). This is
 #       # a LOUD, RECORDED escape hatch, not a quiet default — see step 5's own
@@ -36,9 +36,9 @@
 #      "Fidelity-drift policy" section). This is a release-checklist step, not
 #      something left to memory.
 #   6. Commit release-notes.md (if dirty) as arbeithand
-#   6b. If plugin/fabrik's source changed since the previous tag, patch-bump
-#       plugin/fabrik/.claude-plugin/plugin.json and commit as arbeithand
-#       (skippable with --no-plugin-bump)
+#   6b. For each plugin listed in .claude-plugin/marketplace.json whose source
+#       changed since the previous tag, patch-bump its .claude-plugin/plugin.json
+#       and commit them together as arbeithand (skippable with --no-plugin-bump)
 #   7. Tag, push tag with credential helpers nuked + PAT-in-URL
 #   8. Watch the release workflow run; fail loudly on non-success
 #   9. Verify the published release author and discussion author are both arbeithand
@@ -422,42 +422,78 @@ else
   ok "release-notes commit pushed"
 fi
 
-# ─── 6b. auto-bump plugin/fabrik version if source changed ───────────────────
+# ─── 6b. auto-bump marketplace plugin versions if source changed ─────────────
 # Claude Code's /plugin update compares plugin.json's version field against
-# marketplace.json@main; same version number means no refresh fires even if
-# the plugin's source changed. Patch-bump plugin/fabrik's manifest whenever
-# its source changed since the previous tag, so users always get fresh
-# content. plugin/fabrik-workflows is out of scope — it's not listed in
-# marketplace.json and has its own content-hash-based change detection.
+# marketplace.json@main; same version number means no refresh fires even if the
+# plugin's source changed. Patch-bump the manifest of every plugin whose source
+# changed since the previous tag, so users always get fresh content.
+#
+# The plugin list is derived from marketplace.json rather than hardcoded: a
+# plugin listed there is bumpable from that moment on, with no matching edit
+# here. That coupling is deliberate — marketplace.json membership is exactly
+# what makes /plugin update's version comparison apply to a plugin, so the two
+# cannot drift apart. plugin/fabrik-workflows is out of scope for the same
+# reason: it isn't listed, isn't served by /plugin update, and has its own
+# content-hash-based change detection.
 step "Plugin version bump"
-PLUGIN_MANIFEST="plugin/fabrik/.claude-plugin/plugin.json"
 if [ "$NO_PLUGIN_BUMP" -eq 1 ]; then
-  warn "--no-plugin-bump was passed; skipping plugin/fabrik version bump"
+  warn "--no-plugin-bump was passed; skipping plugin version bumps"
 elif [ -z "$PREV_TAG" ]; then
-  warn "no previous release tag found — skipping plugin/fabrik version bump (first release?)"
+  warn "no previous release tag found — skipping plugin version bumps (first release?)"
 else
-  if ! BUMP_OUTPUT="$(go run ./tools/bump-plugin-version/ plugin/fabrik "$PLUGIN_MANIFEST" "$PREV_TAG")"; then
-    die "bump-plugin-version failed for plugin/fabrik (prev tag: $PREV_TAG)"
+  MARKETPLACE_JSON=".claude-plugin/marketplace.json"
+  [ -f "$MARKETPLACE_JSON" ] || die "$MARKETPLACE_JSON not found"
+
+  # Only git-subdir entries carry a source.path pointing at a directory in this
+  # repo; any other source type is distributed from elsewhere and is not ours to
+  # bump. Enumerated by a Go helper rather than jq, so the release path depends
+  # on nothing the repo doesn't already require.
+  if ! PLUGIN_DIRS="$(go run ./tools/list-marketplace-plugins/ "$MARKETPLACE_JSON")"; then
+    die "failed to enumerate plugins from $MARKETPLACE_JSON"
   fi
-  if [ -z "$BUMP_OUTPUT" ]; then
-    ok "plugin/fabrik unchanged since $PREV_TAG — no bump needed"
-  else
+
+  BUMPED_MANIFESTS=""
+  BUMPED_SUMMARY=""
+
+  for PLUGIN_DIR in $PLUGIN_DIRS; do
+    PLUGIN_MANIFEST="$PLUGIN_DIR/.claude-plugin/plugin.json"
+    [ -f "$PLUGIN_MANIFEST" ] \
+      || die "$PLUGIN_MANIFEST not found (listed in $MARKETPLACE_JSON)"
+
+    if ! BUMP_OUTPUT="$(go run ./tools/bump-plugin-version/ "$PLUGIN_DIR" "$PLUGIN_MANIFEST" "$PREV_TAG")"; then
+      die "bump-plugin-version failed for $PLUGIN_DIR (prev tag: $PREV_TAG)"
+    fi
+    if [ -z "$BUMP_OUTPUT" ]; then
+      ok "$PLUGIN_DIR unchanged since $PREV_TAG — no bump needed"
+      continue
+    fi
+
     OLD_PLUGIN_VER="$(printf '%s' "$BUMP_OUTPUT" | cut -d' ' -f1)"
     NEW_PLUGIN_VER="$(printf '%s' "$BUMP_OUTPUT" | cut -d' ' -f2)"
-    ok "bumped plugin/fabrik $OLD_PLUGIN_VER -> $NEW_PLUGIN_VER (source changed since $PREV_TAG)"
+    PLUGIN_NAME="$(basename "$PLUGIN_DIR")"
+    ok "bumped $PLUGIN_DIR $OLD_PLUGIN_VER -> $NEW_PLUGIN_VER (source changed since $PREV_TAG)"
 
-    # Append a changelog line so the version bump is visible in the GitHub
-    # Release notes. release-notes/<version>.md was already committed and
-    # pushed above, so this lands in a second commit alongside the manifest
-    # bump rather than amending the already-pushed one.
-    insert_notes_line "$NOTES_FILE" "- Auto-bumped fabrik plugin to $NEW_PLUGIN_VER (source changed since $PREV_TAG)"
+    BUMPED_MANIFESTS="$BUMPED_MANIFESTS $PLUGIN_MANIFEST"
+    BUMPED_SUMMARY="$BUMPED_SUMMARY $PLUGIN_NAME@$NEW_PLUGIN_VER"
 
-    git add "$PLUGIN_MANIFEST" "$NOTES_FILE"
+    # Append a changelog line so each bump is visible in the GitHub Release
+    # notes. release-notes/<version>.md was already committed and pushed above,
+    # so this lands in a later commit alongside the manifest bumps rather than
+    # amending the already-pushed one.
+    insert_notes_line "$NOTES_FILE" "- Auto-bumped $PLUGIN_NAME plugin to $NEW_PLUGIN_VER (source changed since $PREV_TAG)"
+  done
+
+  if [ -z "$BUMPED_MANIFESTS" ]; then
+    ok "no marketplace plugin source changed since $PREV_TAG — nothing to bump"
+  else
+    # Intentionally unquoted: BUMPED_MANIFESTS is a space-separated path list.
+    # Plugin paths come from marketplace.json and contain no spaces.
+    git add $BUMPED_MANIFESTS "$NOTES_FILE"
     GIT_AUTHOR_NAME="$BOT_LOGIN" \
     GIT_AUTHOR_EMAIL="$BOT_EMAIL" \
     GIT_COMMITTER_NAME="$BOT_LOGIN" \
     GIT_COMMITTER_EMAIL="$BOT_EMAIL" \
-    git commit -m "Bump fabrik plugin to $NEW_PLUGIN_VER" --quiet
+    git commit -m "Bump plugin versions:$BUMPED_SUMMARY" --quiet
     COMMIT_AUTHOR="$(git log -1 --pretty=format:'%an <%ae>')"
     [ "$COMMIT_AUTHOR" = "$BOT_LOGIN <$BOT_EMAIL>" ] \
       || die "plugin-bump commit author wrong (got: $COMMIT_AUTHOR)"

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -223,8 +223,11 @@ BRANCH="$(git branch --show-current)"
 ok "on main"
 
 # Allow uncommitted release-notes/<version>.md, plugin/known_embedded_versions.go,
-# and plugin/fabrik/.claude-plugin/plugin.json (all three are updated by this
-# script itself, after the build step and in step 6b).
+# and any plugin/*/.claude-plugin/plugin.json (all are updated by this script
+# itself, after the build step and in step 6b). The manifest pattern is
+# deliberately not pinned to one plugin: step 6b bumps every marketplace-listed
+# plugin, so a run that dies partway through can leave any of them modified but
+# uncommitted, and a retry must not abort on the mess its own predecessor made.
 #
 # Allowlist disposition (reviewed for #1070, extended for #816): all three
 # files are committed by this script's own step 6 / step 6b, *before* the tag
@@ -234,7 +237,7 @@ ok "on main"
 # does not need to be tightened; the built-artifact VCS check lives in
 # .goreleaser.yaml/release.yml instead (see
 # adrs/071-release-artifact-vcs-verification.md).
-DIRTY=$(git status --porcelain | grep -Ev "^\?\? release-notes/${VERSION}\.md$| M release-notes/${VERSION}\.md$|^M  release-notes/${VERSION}\.md$| M plugin/known_embedded_versions\.go$|^M  plugin/known_embedded_versions\.go$| M plugin/fabrik/\.claude-plugin/plugin\.json$|^M  plugin/fabrik/\.claude-plugin/plugin\.json$" || true)
+DIRTY=$(git status --porcelain | grep -Ev "^\?\? release-notes/${VERSION}\.md$| M release-notes/${VERSION}\.md$|^M  release-notes/${VERSION}\.md$| M plugin/known_embedded_versions\.go$|^M  plugin/known_embedded_versions\.go$| M plugin/[^/]+/\.claude-plugin/plugin\.json$|^M  plugin/[^/]+/\.claude-plugin/plugin\.json$" || true)
 [ -z "$DIRTY" ] || die "working tree dirty:
 $DIRTY"
 ok "working tree acceptable"

--- a/tools/list-marketplace-plugins/main.go
+++ b/tools/list-marketplace-plugins/main.go
@@ -1,0 +1,89 @@
+// list-marketplace-plugins prints the repo-relative directory of every plugin
+// distributed from this repository via .claude-plugin/marketplace.json, one
+// per line.
+//
+// Only entries whose source.source is "git-subdir" are listed: those carry a
+// source.path pointing at a directory in this repo and are therefore ours to
+// version-bump at release time. Any other source type is distributed from
+// somewhere else and must be left alone.
+//
+// This exists so scripts/cut-release.sh can derive its plugin-bump list from
+// marketplace.json instead of hardcoding it — marketplace.json membership is
+// exactly what makes /plugin update's version comparison apply to a plugin, so
+// deriving the list keeps the two from drifting apart. It is a Go program
+// rather than a jq one-liner to avoid adding a jq dependency to the release
+// path; the release script already requires the Go toolchain.
+//
+// Usage: go run ./tools/list-marketplace-plugins/ [marketplace-json-path]
+//
+// Defaults to .claude-plugin/marketplace.json relative to the working
+// directory. Exits non-zero if the file is missing, malformed, or lists no
+// git-subdir plugins at all — each of which means the release script's
+// assumptions no longer hold and a silent empty list would skip every bump.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const defaultManifest = ".claude-plugin/marketplace.json"
+
+type marketplace struct {
+	Plugins []struct {
+		Name   string `json:"name"`
+		Source struct {
+			Source string `json:"source"`
+			Path   string `json:"path"`
+		} `json:"source"`
+	} `json:"plugins"`
+}
+
+func main() {
+	path := defaultManifest
+	if len(os.Args) > 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s [marketplace-json-path]\n", os.Args[0])
+		os.Exit(2)
+	}
+	if len(os.Args) == 2 {
+		path = os.Args[1]
+	}
+
+	dirs, err := gitSubdirPluginDirs(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "list-marketplace-plugins: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(strings.Join(dirs, "\n"))
+}
+
+// gitSubdirPluginDirs returns the source.path of every git-subdir plugin
+// listed in the marketplace manifest at path, in file order.
+func gitSubdirPluginDirs(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var m marketplace
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	var dirs []string
+	for _, p := range m.Plugins {
+		if p.Source.Source != "git-subdir" {
+			continue
+		}
+		if p.Source.Path == "" {
+			return nil, fmt.Errorf("%s: plugin %q is git-subdir but has no source.path", path, p.Name)
+		}
+		dirs = append(dirs, p.Source.Path)
+	}
+	if len(dirs) == 0 {
+		return nil, fmt.Errorf("%s: no git-subdir plugins listed", path)
+	}
+	return dirs, nil
+}

--- a/tools/list-marketplace-plugins/main.go
+++ b/tools/list-marketplace-plugins/main.go
@@ -80,6 +80,15 @@ func gitSubdirPluginDirs(path string) ([]string, error) {
 		if p.Source.Path == "" {
 			return nil, fmt.Errorf("%s: plugin %q is git-subdir but has no source.path", path, p.Name)
 		}
+		// The release script consumes this output with shell word-splitting
+		// (for dir in $PLUGIN_DIRS). A path containing whitespace would split
+		// into two nonexistent paths and fail with a confusing missing-file
+		// error several steps later. Reject it here, where the message can say
+		// what is actually wrong.
+		if strings.ContainsAny(p.Source.Path, " \t\n") {
+			return nil, fmt.Errorf("%s: plugin %q has whitespace in source.path (%q); "+
+				"the release script splits this list on whitespace", path, p.Name, p.Source.Path)
+		}
 		dirs = append(dirs, p.Source.Path)
 	}
 	if len(dirs) == 0 {

--- a/tools/list-marketplace-plugins/main_test.go
+++ b/tools/list-marketplace-plugins/main_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeManifest writes content to a temp file and returns its path.
+func writeManifest(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "marketplace.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+	return path
+}
+
+func TestGitSubdirPluginDirs(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name: "returns git-subdir paths in file order",
+			content: `{"plugins":[
+				{"name":"a","source":{"source":"git-subdir","path":"plugin/a"}},
+				{"name":"b","source":{"source":"git-subdir","path":"plugin/b"}}
+			]}`,
+			want: []string{"plugin/a", "plugin/b"},
+		},
+		{
+			name: "skips non-git-subdir sources",
+			content: `{"plugins":[
+				{"name":"a","source":{"source":"git-subdir","path":"plugin/a"}},
+				{"name":"remote","source":{"source":"github","path":"ignored"}}
+			]}`,
+			want: []string{"plugin/a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := gitSubdirPluginDirs(writeManifest(t, tt.content))
+			if err != nil {
+				t.Fatalf("gitSubdirPluginDirs() error = %v", err)
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("gitSubdirPluginDirs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitSubdirPluginDirsErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantSub string
+	}{
+		{
+			name:    "no git-subdir plugins is an error, not an empty list",
+			content: `{"plugins":[{"name":"remote","source":{"source":"github"}}]}`,
+			wantSub: "no git-subdir plugins listed",
+		},
+		{
+			name:    "git-subdir without a path is an error",
+			content: `{"plugins":[{"name":"a","source":{"source":"git-subdir"}}]}`,
+			wantSub: "has no source.path",
+		},
+		{
+			name:    "malformed JSON is an error",
+			content: `{"plugins":[`,
+			wantSub: "parsing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := gitSubdirPluginDirs(writeManifest(t, tt.content))
+			if err == nil {
+				t.Fatal("gitSubdirPluginDirs() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error = %q, want it to contain %q", err, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestGitSubdirPluginDirsMissingFile(t *testing.T) {
+	_, err := gitSubdirPluginDirs(filepath.Join(t.TempDir(), "absent.json"))
+	if err == nil {
+		t.Fatal("gitSubdirPluginDirs() error = nil, want error for a missing file")
+	}
+	if !strings.Contains(err.Error(), "reading") {
+		t.Errorf("error = %q, want it to mention reading the file", err)
+	}
+}
+
+// TestRealMarketplaceManifest guards the actual file the release script reads:
+// if it stops listing git-subdir plugins, or gains a malformed entry, the
+// plugin-bump step would silently skip every plugin.
+func TestRealMarketplaceManifest(t *testing.T) {
+	got, err := gitSubdirPluginDirs("../../.claude-plugin/marketplace.json")
+	if err != nil {
+		t.Fatalf("gitSubdirPluginDirs() on the real manifest: %v", err)
+	}
+	for _, dir := range got {
+		manifest := filepath.Join("../..", dir, ".claude-plugin", "plugin.json")
+		if _, err := os.Stat(manifest); err != nil {
+			t.Errorf("plugin %q is listed in marketplace.json but %s is missing: %v", dir, manifest, err)
+		}
+	}
+}

--- a/tools/list-marketplace-plugins/main_test.go
+++ b/tools/list-marketplace-plugins/main_test.go
@@ -71,6 +71,11 @@ func TestGitSubdirPluginDirsErrors(t *testing.T) {
 			wantSub: "has no source.path",
 		},
 		{
+			name:    "whitespace in source.path is an error",
+			content: `{"plugins":[{"name":"a","source":{"source":"git-subdir","path":"plugin/my plugin"}}]}`,
+			wantSub: "whitespace in source.path",
+		},
+		{
 			name:    "malformed JSON is an error",
 			content: `{"plugins":[`,
 			wantSub: "parsing",


### PR DESCRIPTION
`/plugin update` only refreshes a user's cached copy when the version in `plugin.json` changes. The release script hardcoded `plugin/fabrik`, so **any second marketplace plugin is installable and then permanently un-updatable** — users keep whatever they first installed, no matter what lands on `main`.

That was hypothetical when the block was written. It isn't now: `marketplace.json` lists two plugins.

The block's own comment scoped bumping to *"plugins listed in marketplace.json"* — a rationale that silently stopped covering the file as soon as a second one was listed.

## The fix

Derive the list from `marketplace.json` instead of hardcoding it, so listing a plugin is sufficient and the two can't drift apart again. Only `git-subdir` entries are considered — any other source type is distributed from elsewhere and isn't ours to bump. All bumped manifests land in one commit, each contributing its own changelog line through the existing `insert_notes_line` helper.

Because the list is derived, it also picks up a **renamed** plugin directory with no edit here — which matters immediately, since #1634 renames one.

## Why a Go helper rather than jq

The script already runs `go run ./tools/bump-plugin-version/` on the very next line, so the Go toolchain is a dependency this step cannot avoid. `jq` would have been a new one on a release-critical path.

`tools/list-marketplace-plugins` fails loudly rather than returning an empty list when the manifest is missing, malformed, lists no `git-subdir` plugins, or has a `git-subdir` entry with no path. An empty list would silently skip every bump — precisely the failure this mechanism exists to prevent.

## Scope

`fabrik-workflows` stays out of scope for the reason the original comment gave: it isn't listed in `marketplace.json`, isn't served by `/plugin update`, and has its own content-hash change detection.

## Test plan

- [x] `bash -n scripts/cut-release.sh`
- [x] `go build ./...`; `go test ./tools/list-marketplace-plugins/` — covers missing file, malformed JSON, no git-subdir entries, and a git-subdir entry with no path, plus a guard asserting every plugin `marketplace.json` lists has a manifest on disk
- [x] The helper enumerates both currently-listed plugins
- [ ] Exercised end to end at the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEECnu53jBenQA7yxu3jS8