### PR TITLE
notes: findings from running the spec-authoring plugin on its first real project

### DIFF
--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -28,7 +28,7 @@ v2.0.0    1        after three more specifications
 Every drop came from a specification being written. None came from further work on the
 architecture document. That is the headline, and several findings below follow from it.
 
-**Ten findings and three smaller ones.** Nothing here is a defect in the method as written —
+**Eleven findings and three smaller ones.** Nothing here is a defect in the method as written —
 these are things it does not currently say. Findings 3 through 5 all follow from one fact the
 method never states: the reader of these documents is an agent.
 
@@ -46,10 +46,11 @@ Some will bounce back. There will be judgement calls in flight. That is true of 
 is not a failure of the specifications. What matters is that a team of people and a team of
 agents fail differently, in three specific ways:
 
-**No memory across issues.** A human team accumulates shared understanding — a decision made in
-one ticket is in everyone's head for the next one. Every Fabrik worker starts fresh. A
-judgement call made while implementing issue 12 is invisible to issue 40, and the two may
-decide the same question differently without either noticing.
+**Memory exists, but in a different artifact than entwurf writes to.** I assumed workers had no
+memory across issues and that is wrong — see finding 10. Fabrik agents write ADRs, and on
+`~/dev/fantasy` they have written 204 of them, 182 citing another ADR and 187 citing an issue,
+with supersession marked in line. The gap is not amnesia; it is that entwurf's register and
+Fabrik's ADRs are two halves of one job and neither tool writes to the other's half.
 
 **Asking is cheap for people and expensive for agents.** An engineer leans over and asks; it
 costs seconds, and the answer is absorbed by everyone in earshot. A worker either blocks the
@@ -382,37 +383,76 @@ two domains rather than routing the whole thing to one.
 
 ---
 
-## 10. Escalation is normal, and the pipeline has nowhere to put the answer
+## 10. The register and the ADR log are two halves of one job, and each tool uses only its own
 
-`FABRIK_BLOCKED_ON_INPUT` exists, so a worker can stop and ask. Three things around it are
-missing, and each maps onto one of the deficits above.
+**I had this wrong and the evidence corrected it.** My first draft claimed Fabrik workers carry
+no memory between issues. They do. On `~/dev/fantasy` — Fabrik without entwurf, one human, the
+full six-stage pipeline — agents have written **204 ADRs**. 182 of them cite another ADR, 187
+cite an issue, and supersession is marked in line (*"Superseded by ADR-109"*). A recent one
+reasons about a review bot's diff limit, quotes its own measurements, and links two prior
+decisions. That is a working institutional memory, written by agents, for agents.
+
+Now put the two projects side by side:
+
+| | `~/dev/fantasy` — Fabrik alone | 86ED — entwurf then Fabrik |
+|---|---|---|
+| ADRs | **204** | **1** |
+| Decision register | none | **87 rows** |
+| Specs | 538, one per issue | 15, one per feature |
+
+Each tool produced its own artifact and ignored the other's entirely.
+
+**Both artifacts are load-bearing and they are not substitutes.** `CONVENTIONS.md` already says
+why:
+
+> ADRs record individual decisions and their reasoning. They do not tell you which decision is
+> still in force.
+
+Fantasy's in-line supersession softens that — you *can* find what is current — but only by
+scanning every ADR touching a topic and checking each status. That is a search, not a lookup,
+and it gets worse at 204 and worse again at 500. And the register carries classes ADRs do not:
+working assumptions, exploratory ideas, technical suggestions binding on nobody, and unresolved
+markers naming who resolves them. Fantasy has no place for *"we are proceeding on this but
+nobody has confirmed it"*.
+
+Meanwhile 86ED has one ADR and 87 register rows — the mirror failure. Several of those rows are
+implementation-shaped decisions with real reasoning that deserved an ADR and got a table cell.
+
+**Proposed change.** State the division of labour and make each tool write to both:
+
+- **An ADR is the reasoning**; a register row is **what is currently true**. A decision worth an
+  ADR is worth a register row pointing at it. A register row whose reasoning would not fit in a
+  cell wants an ADR.
+- **Fabrik's stage skills should append a register row** when they make a decision that outlives
+  their issue — with an honest Class, which is the column that keeps an agent's judgement call
+  visibly distinct from a product owner's ruling.
+- **entwurf should write ADRs**, not only register rows, for its own architecture decisions.
+  Topic 3 already says to write one for a reclassified commitment; that instruction should be
+  general.
+
+## 11. Escalation is normal, and the answer has nowhere reusable to land
+
+`FABRIK_BLOCKED_ON_INPUT` exists, so a worker can stop and ask. Two things around it are
+missing.
 
 **The block is role-blind.** A worker can say it is blocked; it cannot say *on whom*. The
-baseline already carries the vocabulary — 86ED's open questions are grouped as *addressed to
-the product owner*, *to the architect*, *to the experience lead*, and that grouping is what
-made them actionable. A block that names its audience lands in the right person's lane. A block
-that does not becomes a notification somebody has to triage.
-
-**The answer goes nowhere reusable.** When the block clears, the answer lives in an issue
-comment. The decision register — *what is currently true, and who decided it* — is the artifact
-built precisely for this, and no worker writes to it. **That register is the shared memory a
-team has and a pipeline does not.** A Plan agent that settles a CSV format should append a row
-with an honest Class, and the next worker should find it there rather than deciding again.
+baseline already carries the vocabulary — 86ED's open questions are grouped as *addressed to the
+product owner*, *to the architect*, *to the experience lead*, and that grouping is what made
+them actionable. A block that names its audience lands in the right lane; one that does not
+becomes something a human has to triage.
 
 **A worker's escalation is evidence about the corpus, not just about that issue.** Plan's skill
-currently frames an open question as an upstream failure — *"if there are, something was missed
-upstream."* True, and the useful response is not only to flag it but to treat it as a **stage-3
-re-run trigger**. The existing triggers are "a new specification introduces an entity, a state
-or an authority". A worker blocking on an ambiguity is at least as strong a signal that the
-corpus has drifted.
+frames an open question as an upstream failure — *"if there are, something was missed
+upstream."* True, and the useful response is also to treat it as a **stage-3 re-run trigger**.
+The existing triggers are "a new specification introduces an entity, a state or an authority";
+a worker blocking on an ambiguity is at least as strong a signal that the corpus has drifted.
 
 **And this reframes finding 4.** The 27 deferrals are not wrong. A real team receives
-specifications with open ends and resolves them in a standup. The problem is not that the
-decisions are deferred — it is that the asking is cheap for that team and expensive for this
-one. So the fix is both halves: **name the consumer, and make sure a route to them exists.**
-86ED built that route — an outer-loop board, one issue per question, a skill that briefs the
-person on what is waiting for them. It was built for entwurf's findings. It is equally the
-escalation channel the inner loop needs, and neither plugin knows it exists.
+specifications with open ends and settles them in a standup. The problem is that asking is cheap
+for that team and expensive for this one — so the fix is both halves: **name the consumer, and
+make sure a route to them exists.** 86ED built that route: an outer-loop board, one issue per
+question, a skill that briefs the person on what is waiting. It was built for entwurf's
+findings, it is equally the inner loop's escalation channel, and neither plugin knows it exists.
 
 ---
 

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -28,7 +28,9 @@ v2.0.0    1        after three more specifications
 Every drop came from a specification being written. None came from further work on the
 architecture document. That is the headline, and several findings below follow from it.
 
-Nothing here is a defect in the method as written. These are things it does not currently say.
+**Nine findings and three smaller ones.** Nothing here is a defect in the method as written —
+these are things it does not currently say. Findings 3 through 5 all follow from one fact the
+method never states: the reader of these documents is an agent.
 
 ---
 
@@ -98,7 +100,7 @@ specification change is listed as owed until the specification reflects it.*
 
 ---
 
-## 3. entwurf produces specifications; Fabrik consumes them. The method says so nowhere.
+## 3. entwurf produces specifications, a baseline and a register; Fabrik consumes all three — and neither plugin says so
 
 The two plugins ship from the same repository, are used together by design, and **do not
 reference each other**. entwurf's output is `specs/NNN-name/spec.md`. Fabrik's Specify stage
@@ -125,7 +127,7 @@ solution is in the plugin, so every project meets the seam cold.
 - **Specify must never rewrite an authored specification.** Stock behaviour destroys it.
 - entwurf's README should say what happens next; Fabrik's should say what it expects to find.
 
-### 3a. The PLANNED per-feature paths already have a producer
+### 3a — the PLANNED per-feature paths already have a producer
 
 `CONVENTIONS.md` describes `specs/NNN-name/technical.md` as PLANNED with no producer:
 
@@ -135,7 +137,7 @@ solution is in the plugin, so every project meets the seam cold.
 derived from the spec — and posts it as a stage comment rather than writing the file. The
 producer exists; the two halves have never been introduced.
 
-### 3b. Stage 5's outputs are Fabrik configuration, not advice
+### 3b — stage 5's outputs are Fabrik configuration, not advice
 
 - **Build order** is the board's dependency graph. 86ED's own orientation already says *"build
   order is a stage-5 output — do not hand-wire issue dependencies before then,"* which is a
@@ -146,7 +148,7 @@ producer exists; the two halves have never been introduced.
 - **Pipeline readiness** is a board rule: a specification whose referenced entities are unowned
   does not get an issue yet.
 
-### 3c. The outer and inner loops
+### 3c — the outer and inner loops
 
 The two plugins are two loops and the projects using them will invent the distinction anyway.
 86ED did, on day two, and it clarified everything downstream:
@@ -163,9 +165,9 @@ than rediscovering.
 
 ---
 
-## 3d. Because agents implement, "an implementation detail" is now a defect class
+## 4. Because agents implement, "an implementation detail" is now a defect class
 
-**This is the finding I would rank first.**
+**Of everything here, this is the one I would fix first.**
 
 The corpus contains **27 deliberate deferrals** — ten phrased as "an implementation detail",
 seventeen as "outside this spec's scope" — spread across **9 of its 15 specifications**. Every
@@ -200,7 +202,7 @@ consumer**, in the same way `[NEEDS LOOKUP]` requires a named fetcher:
 
 That is a small change to a checklist item and it would have caught all 27.
 
-## 3e. Precedence was written for humans reading documents. Agents read them now.
+## 5. Precedence was written for humans reading documents. Agents read them now
 
 Fabrik's workers consume the specifications, `.specify/memory/architecture.md` and
 `.specify/memory/decisions.md`. Three of the method's rules become load-bearing in a way they
@@ -255,7 +257,7 @@ and nothing currently carries them from the baseline to the stage that would enf
 
 ---
 
-## 4. A clean checklist does not mean a consistent corpus
+## 6. A clean checklist does not mean a consistent corpus
 
 **What happened.** A specification came back **16/16 with no clarification markers while
 directly contradicting an existing specification** — it permitted configuration to cross a
@@ -282,7 +284,7 @@ nobody declared; nothing currently tells the architect to find things two specs 
 
 ---
 
-## 5. The gate decays silently, and nothing says when to re-run it
+## 7. The gate decays silently, and nothing says when to re-run it
 
 **What happened.** The baseline moved through four version bumps without its checklist being
 re-evaluated. It sat claiming a spec range and a set of counts that were two constitution
@@ -304,7 +306,7 @@ new specifications, not for amendments to the baseline itself.
 
 ---
 
-## 6. There is a third disposition, and it is neither owned nor unowned
+## 8. There is a third disposition, and it is neither owned nor unowned
 
 **What happened.** Twice a field marked "no feature exists that could own it" was reclassified
 rather than closed. One was deliberately unspecified because the constitution treats that class
@@ -323,7 +325,7 @@ as writing "the platform owns it."
 
 ---
 
-## 7. Three smaller findings
+## 9. Three smaller findings
 
 **entwurf produces AI-assisted documents and says nothing about labelling them.** This project
 independently wrote rules into three of its own specifications requiring AI-assisted content to

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -28,7 +28,8 @@ v2.0.0    1        after three more specifications
 Every drop came from a specification being written. None came from further work on the
 architecture document. That is the headline, and several findings below follow from it.
 
-**Fourteen findings and three smaller ones.** Nothing here is a defect in the method as written —
+**Fourteen findings and three smaller ones.** One is settled — the ADR `Level` field in finding
+13, agreed 2026-08-22. The rest are proposals. Nothing here is a defect in the method as written —
 these are things it does not currently say. Findings 3 through 5 all follow from one fact the
 method never states: the reader of these documents is an agent.
 
@@ -594,8 +595,10 @@ almost all in the second group, which suggests the split is real rather than inv
 
 ### What to actually take
 
-**Require a level on every ADR.** Not the altitude prefix I proposed above — a named field, with
-C4's vocabulary where it applies:
+**Require a level on every ADR.** **Agreed by the maintainer, 2026-08-22** — the only finding in
+this note settled rather than proposed. It takes effect when 86ED's architecture phase begins,
+which is the first moment either tool writes an ADR in anger. Not the altitude prefix I proposed
+above — a named field, with C4's vocabulary where it applies:
 
 > `**Level**: Context | Container | Component | Code | Domain`
 

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -28,7 +28,7 @@ v2.0.0    1        after three more specifications
 Every drop came from a specification being written. None came from further work on the
 architecture document. That is the headline, and several findings below follow from it.
 
-**Twelve findings and three smaller ones.** Nothing here is a defect in the method as written —
+**Thirteen findings and three smaller ones.** Nothing here is a defect in the method as written —
 these are things it does not currently say. Findings 3 through 5 all follow from one fact the
 method never states: the reader of these documents is an agent.
 
@@ -546,6 +546,67 @@ and a narrowing of stage 5:
 > promise and belongs here. A mechanism is a means, and the moment before anything is built is
 > the moment you know least about it. Name it, state what it must achieve and how a violation
 > would show, and let the ADR that chooses it be written when the constraint is real.
+
+---
+
+## 13. What C4 offers: declare the level, and notice which one is missing
+
+The altitude confusion in finding 10 is the problem C4 was built for. Its lasting contribution
+is not the four names but the discipline behind them: **most architecture disagreements are two
+people zoomed to different levels, and neither has said so.** C4 makes the level a required
+part of the statement.
+
+### The taxonomy only half fits, and the half that misses matters
+
+| C4 level | Who covers it here |
+|---|---|
+| **Context** — the system, its users, the systems it touches | entwurf: Constraints, existing systems, obligations |
+| **Container** — deployable and runnable units | **nobody, currently** |
+| **Component** — groupings within a container | entwurf: interface contracts. Fabrik: `validator-dependency-injection`, `kind-registry-module-singleton` |
+| **Code** | Fabrik, occasionally. C4 says rarely draw this, and it is right |
+
+**C4 has no level for the domain model**, which is most of what entwurf's stage 3 produces —
+which entity exists, which feature owns each field, who may do what. That is not structure and
+C4 does not claim to cover it. So the taxonomy should be borrowed for the structural altitudes
+and not stretched over the rest.
+
+### The Container level is the actual gap between the two tools
+
+This is the useful finding. On 86ED, Container is **explicitly deferred** — the whole stack
+table moved to stage 5 when the platform commitment was reclassified, so there is currently no
+statement anywhere about deployable units.
+
+On fantasy, Fabrik filled that level by itself, issue by issue: `pnpm-workspaces`,
+`electron-vite`, `ipc-contextbridge`, `event-log-storage`. Nobody framed it; the pipeline
+decided it while building, and the decisions are sound.
+
+So the seam between entwurf and Fabrik sits **exactly at Container**, and neither tool claims
+it. Combined with finding 12 — that stage 5 should frame mechanisms rather than choose them —
+the open question sharpens usefully:
+
+> **Which Container decisions must stage 5 make, and which may Fabrik make?**
+
+A defensible split: stage 5 owns Container decisions that a specification depends on or that
+are expensive to reverse — is there a mobile client at all, is there one datastore or several,
+does anything run offline. Fabrik owns those that are cheap to change and only knowable while
+building — which bundler, which test runner, how a package is laid out. Fantasy's ADRs are
+almost all in the second group, which suggests the split is real rather than invented.
+
+### What to actually take
+
+**Require a level on every ADR.** Not the altitude prefix I proposed above — a named field, with
+C4's vocabulary where it applies:
+
+> `**Level**: Context | Container | Component | Code | Domain`
+
+That solves the numbering collision without a second directory, makes the ten decisions that
+shape the system findable among the two hundred that shape a module, and forces the writer to
+place their own decision — which is where C4's value actually lives. An author who cannot say
+which level they are at usually has not decided.
+
+**And use change rate as the test for what belongs where.** Context changes rarely, Code changes
+constantly. A slow-changing commitment buried in a stream of fast-changing ones is functionally
+lost. That is the argument for separation, independent of tooling.
 
 ---
 

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -4,6 +4,11 @@
 existed when entwurf's stage 3 first ran; four more specifications and two constitution
 amendments followed over four days, driven by what stage 3 found.
 
+**The pairing**: entwurf and Fabrik ship from the same repository and are intended to be used
+together. entwurf produces the specifications, the architecture baseline and the decision
+register; **Fabrik's agents consume all three**. Several findings below
+follow from that, and the two plugins currently do not reference each other at all.
+
 **Why this is worth reading**: `CONVENTIONS.md` cites this project as the motivating case for
 making stage 3 a living document — *"eleven specifications written over days drifted, because
 each new feature changed the meaning of earlier ones and nothing owned the shared entities."*
@@ -81,35 +86,172 @@ reads as settled while the specifications still say the old thing.
 **What we built.** A `## Spec amendments owed` section: spec, amendment, and the finding it
 came from. It became the most operationally important part of the document.
 
+**And it matters more than "untidy" because agents read both documents.** An unapplied
+amendment does not leave a gap in a worker's context — it leaves a **contradiction**. The
+baseline says the roster supplies facts; the specification says the roster derives authority.
+Both are in front of the agent. It will pick one, silently, and there is nothing in either
+document telling it which wins.
+
 **Proposed change.** Add it to the `architecture.md` template between `## Deferred to the
 baseline` and `## Open questions`, with a line in the gate: *every decision requiring a
 specification change is listed as owed until the specification reflects it.*
 
 ---
 
-## 3. Topic 4 should ask *how* it will be built, not only who by
+## 3. entwurf produces specifications; Fabrik consumes them. The method says so nowhere.
 
-**What happened.** Topic 4 was answered late: the build team is one person plus an agent
-pipeline that drives coding agents through a specification-to-merge lifecycle. That single fact
-changed the completeness bar for everything before it.
+The two plugins ship from the same repository, are used together by design, and **do not
+reference each other**. entwurf's output is `specs/NNN-name/spec.md`. Fabrik's Specify stage
+opens with:
 
-An engineer who encounters "what is a Matter?" asks someone. **An agent invents one** —
-plausibly, self-consistently, and differently in each of the four specifications that reference
-it. The inconsistency surfaces at integration.
+> Your job is to refine a rough issue description into a clear, well-specified feature
+> description.
 
-So the twenty-four unowned fields stopped being a documentation gap and became a delivery risk,
-and a build-order rule fell out of it:
+and Plan states plainly: *"The issue body is the spec, owned by Specify."* So Fabrik's model is
+issue-first — a rough issue becomes a spec — while entwurf's is file-first. Where entwurf has
+run, **Specify's authoring job is already done, and doing it again would overwrite an authored
+specification with a generated one.**
 
-> A specification is pipeline-ready when everything it references is owned — not when its own
-> checklist passes.
+86ED discovered this per-project and recorded it as a local gotcha. `~/dev/fantasy` solved the
+opposite direction — the issue body is the spec and Specify projects it to a file. Neither
+solution is in the plugin, so every project meets the seam cold.
 
-**What the method says today.** Topic 4 asks who builds it, how many, what they know, how long
-there is. All useful. It does not ask **how** — and agent-built and human-built projects have
-materially different definitions of a finished specification.
+**Proposed change.** State the pairing in both plugins, and define the entwurf-first direction:
 
-**Proposed change.** Extend topic 4 with the build model, and note the consequence: where
-specifications are the direct input to automated implementation, every unowned field and every
-unapplied amendment is a defect waiting to be built rather than a question waiting to be asked.
+- **Where a `specs/NNN-*/spec.md` exists, the issue references it rather than containing it**,
+  and Specify becomes a *reading and consistency* stage rather than an authoring one. Its
+  existing "check consistency with existing features" work is the valuable half and should
+  read `.specify/memory/architecture.md` and `decisions.md`, not only `CLAUDE.md`.
+- **Specify must never rewrite an authored specification.** Stock behaviour destroys it.
+- entwurf's README should say what happens next; Fabrik's should say what it expects to find.
+
+### 3a. The PLANNED per-feature paths already have a producer
+
+`CONVENTIONS.md` describes `specs/NNN-name/technical.md` as PLANNED with no producer:
+
+> The baselines are written to be inherited by per-feature documents that do not exist yet.
+
+**Fabrik's Plan stage produces exactly that document** — a per-feature implementation design
+derived from the spec — and posts it as a stage comment rather than writing the file. The
+producer exists; the two halves have never been introduced.
+
+### 3b. Stage 5's outputs are Fabrik configuration, not advice
+
+- **Build order** is the board's dependency graph. 86ED's own orientation already says *"build
+  order is a stage-5 output — do not hand-wire issue dependencies before then,"* which is a
+  project reinventing the rule.
+- **Fitness functions** are what Validate gates on. Stage 5 currently describes them
+  abstractly; paired with Fabrik they have a concrete home, and "the check is owed to stage 5"
+  becomes "the check is owed to Validate."
+- **Pipeline readiness** is a board rule: a specification whose referenced entities are unowned
+  does not get an issue yet.
+
+### 3c. The outer and inner loops
+
+The two plugins are two loops and the projects using them will invent the distinction anyway.
+86ED did, on day two, and it clarified everything downstream:
+
+| | Outer loop — entwurf | Inner loop — Fabrik |
+|---|---|---|
+| Cycle | product | code |
+| Worked by | people | agents |
+| Output | specifications, decisions, ADRs | pull requests |
+
+The seam between them is human-gated: an outer-loop task settles a specification, and only then
+does an inner-loop issue exist for it. Nothing crosses automatically. Worth shipping rather
+than rediscovering.
+
+---
+
+## 3d. Because agents implement, "an implementation detail" is now a defect class
+
+**This is the finding I would rank first.**
+
+The corpus contains **27 deliberate deferrals** — ten phrased as "an implementation detail",
+seventeen as "outside this spec's scope" — spread across **9 of its 15 specifications**. Every
+one of them is well-judged by the standards of specification writing. Examples:
+
+- *the specific CSV file format is an implementation detail outside this spec's scope*
+- *the exact matching criteria for a stable source identifier are an implementation detail*
+- *the specific mechanism for detecting similar names worth flagging is an implementation detail*
+
+With a human engineer these are correct. Over-specifying is a real failure and the specs avoid
+it. **With an agent implementation they are invention points** — and unlike an unowned entity,
+which stage 3 surfaces, a deferral is *invisible to every check in the method*. It reads as
+good practice. It passes 16/16.
+
+The risk is not that the decision is undeferred. It is that the chain runs:
+
+```
+spec defers → Research or Plan agent decides → nobody sees it until Review
+```
+
+The decision still gets made — by an agent, silently, differently in each specification that
+defers the same thing, with the first human sight of it at Review.
+
+**Proposed change.** `write-spec` and `clarify` should treat a deferral as requiring a **named
+consumer**, in the same way `[NEEDS LOOKUP]` requires a named fetcher:
+
+> Deferring a decision is legitimate. Deferring it to nobody is not. Every "this is an
+> implementation detail" must name who decides it and when — a human at Plan, the architect at
+> stage 5, or the build team. Where implementation is automated, a deferral with no named
+> consumer is a decision an agent will make silently, and the same deferral appearing in two
+> specifications is two agents making it differently.
+
+That is a small change to a checklist item and it would have caught all 27.
+
+## 3e. Precedence was written for humans reading documents. Agents read them now.
+
+Fabrik's workers consume the specifications, `.specify/memory/architecture.md` and
+`.specify/memory/decisions.md`. Three of the method's rules become load-bearing in a way they
+were not when a person was doing the reading.
+
+**"Draft" means advisory, and the build may deviate.** `CONVENTIONS.md`:
+
+> **Draft** — advisory. The build may deviate, but must say where and why.
+
+Stage 3 stays Draft by design until stage 5. So for most of a project's life, **the architecture
+baseline is advisory to the build** — and an agent has to know both that it is permitted to
+deviate and that it is obliged to say so. Neither is discoverable from the document, which
+carries `**Status**: Draft` in a footer and explains nowhere what that obliges a reader to do.
+
+**The Class column is now a parsing rule, not a nuance.**
+
+> A row whose class is anything other than **Decided** is not a commitment and must never be
+> quoted downstream as though it were.
+
+Downstream is an agent. It will read `Working assumption` and `Recommended and accepted` and
+`Technical suggestion` rows in the same table as `Decided` ones, and nothing in its context
+tells it these bind differently. On 86ED the register carries all six classes and several
+architect's-own-defaults deliberately flagged as guesses — exactly the rows an agent should
+not build against without asking.
+
+**Precedence needs to be machine-legible.** The ordering exists and is good:
+
+> 1. The constitution outranks every baseline · 2. A ratified baseline outranks a draft ·
+> 3. An earlier stage's decision stands until the earlier role amends it · 4. Constraints
+> recorded at stage 3 bind stage 4 regardless of document status
+
+Rule 3 is the one that resolves the contradiction above — the specification wins until amended,
+and the baseline's decision is inert until applied. That is the right answer and **no worker
+will ever find it**, because it lives in the plugin's shared rulebook rather than anywhere a
+Fabrik agent reads.
+
+**Proposed change.** A short precedence block, written for a worker rather than a role, carried
+where workers actually look — the project's orientation file, or better, a Fabrik stage-skill
+section:
+
+> The specification is what you build. The architecture baseline constrains how. Where they
+> disagree, the specification wins and you flag the disagreement rather than resolving it — a
+> baseline decision that the specification has not absorbed is not yet in force. Anything in
+> the decision register whose Class is not "Decided" is not a commitment; treat it as context
+> and ask. A Draft baseline is advisory: you may deviate, and you must say where and why.
+
+**And the non-negotiables need to reach the worker at all.** 86ED's baseline carries four —
+one central authority decision point, insert-only audit at the storage layer, no status
+collapsed into one column, sensitive material in a separate tier rather than a filtered view.
+Each records how a violation would be detected. Those are precisely Review and Validate gates,
+and nothing currently carries them from the baseline to the stage that would enforce them.
 
 ---
 

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -28,9 +28,41 @@ v2.0.0    1        after three more specifications
 Every drop came from a specification being written. None came from further work on the
 architecture document. That is the headline, and several findings below follow from it.
 
-**Nine findings and three smaller ones.** Nothing here is a defect in the method as written —
+**Ten findings and three smaller ones.** Nothing here is a defect in the method as written —
 these are things it does not currently say. Findings 3 through 5 all follow from one fact the
 method never states: the reader of these documents is an agent.
+
+---
+
+---
+
+## The frame these findings sit in
+
+**Fabrik is an entire engineering team.** That is the useful way to read everything below.
+entwurf's job is to hand that team a body of work resolved well enough that contradictions do
+not keep bouncing back to the product owner, the experience lead and the architect.
+
+Some will bounce back. There will be judgement calls in flight. That is true of any team and it
+is not a failure of the specifications. What matters is that a team of people and a team of
+agents fail differently, in three specific ways:
+
+**No memory across issues.** A human team accumulates shared understanding — a decision made in
+one ticket is in everyone's head for the next one. Every Fabrik worker starts fresh. A
+judgement call made while implementing issue 12 is invisible to issue 40, and the two may
+decide the same question differently without either noticing.
+
+**Asking is cheap for people and expensive for agents.** An engineer leans over and asks; it
+costs seconds, and the answer is absorbed by everyone in earshot. A worker either blocks the
+issue or decides silently. The cost asymmetry inverts the incentive exactly where you least
+want it inverted.
+
+**No "that can't be right."** The most valuable thing a team does with a fresh specification set
+is read it and disbelieve parts of it. That function exists in this method — it is stage 3 —
+but it runs periodically rather than continuously, and nothing routes a worker's disbelief back
+into it.
+
+So the target is not *no escalation*. It is **escalation that is cheap, correctly addressed, and
+recorded where the next worker will see it.** Several findings below are versions of that.
 
 ---
 
@@ -347,6 +379,40 @@ correctly refused it: the product half had already been answered in a clarificat
 months earlier, and only the storage half was his. Interview rules already say to route
 neighbouring-domain claims to their owner; they could also say to *split* a question that spans
 two domains rather than routing the whole thing to one.
+
+---
+
+## 10. Escalation is normal, and the pipeline has nowhere to put the answer
+
+`FABRIK_BLOCKED_ON_INPUT` exists, so a worker can stop and ask. Three things around it are
+missing, and each maps onto one of the deficits above.
+
+**The block is role-blind.** A worker can say it is blocked; it cannot say *on whom*. The
+baseline already carries the vocabulary — 86ED's open questions are grouped as *addressed to
+the product owner*, *to the architect*, *to the experience lead*, and that grouping is what
+made them actionable. A block that names its audience lands in the right person's lane. A block
+that does not becomes a notification somebody has to triage.
+
+**The answer goes nowhere reusable.** When the block clears, the answer lives in an issue
+comment. The decision register — *what is currently true, and who decided it* — is the artifact
+built precisely for this, and no worker writes to it. **That register is the shared memory a
+team has and a pipeline does not.** A Plan agent that settles a CSV format should append a row
+with an honest Class, and the next worker should find it there rather than deciding again.
+
+**A worker's escalation is evidence about the corpus, not just about that issue.** Plan's skill
+currently frames an open question as an upstream failure — *"if there are, something was missed
+upstream."* True, and the useful response is not only to flag it but to treat it as a **stage-3
+re-run trigger**. The existing triggers are "a new specification introduces an entity, a state
+or an authority". A worker blocking on an ambiguity is at least as strong a signal that the
+corpus has drifted.
+
+**And this reframes finding 4.** The 27 deferrals are not wrong. A real team receives
+specifications with open ends and resolves them in a standup. The problem is not that the
+decisions are deferred — it is that the asking is cheap for that team and expensive for this
+one. So the fix is both halves: **name the consumer, and make sure a route to them exists.**
+86ED built that route — an outer-loop board, one issue per question, a skill that briefs the
+person on what is waiting for them. It was built for entwurf's findings. It is equally the
+escalation channel the inner loop needs, and neither plugin knows it exists.
 
 ---
 

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -28,7 +28,7 @@ v2.0.0    1        after three more specifications
 Every drop came from a specification being written. None came from further work on the
 architecture document. That is the headline, and several findings below follow from it.
 
-**Thirteen findings and three smaller ones.** Nothing here is a defect in the method as written —
+**Fourteen findings and three smaller ones.** Nothing here is a defect in the method as written —
 these are things it does not currently say. Findings 3 through 5 all follow from one fact the
 method never states: the reader of these documents is an agent.
 
@@ -607,6 +607,51 @@ which level they are at usually has not decided.
 **And use change rate as the test for what belongs where.** Context changes rarely, Code changes
 constantly. A slow-changing commitment buried in a stream of fast-changing ones is functionally
 lost. That is the argument for separation, independent of tooling.
+
+---
+
+## 14. The method apologises four times for where it puts things
+
+`.specify/` is a hidden directory holding the most-read human documents in the project — the
+constitution, the architecture baseline, the decision register, the gates. Four skills carry the
+same closing instruction:
+
+> **Where it was saved**, and that `.specify` is hidden by the operating system.
+
+`write-spec` goes further and tells the author to warn the reader in plain words. **A method
+that instructs its authors to apologise for its output location, in four places, is telling you
+something.**
+
+The split is arbitrary on its own terms. Spec Kit puts per-feature specifications in a visible
+`specs/` and project-level memory in a hidden `.specify/`. Both are human-readable prose written
+for people to read. There is no principle separating them, only history.
+
+**What is genuinely at stake.** The name is not entwurf's — `CONVENTIONS.md` protects it
+deliberately:
+
+> `.specify/` and `specs/NNN-name/` are GitHub Spec Kit's own names — never rename them to match
+> a skill, and never invent variants.
+
+That restraint is right in spirit: a method should not fork someone else's convention for taste.
+But on 86ED the dependency appears **conventional rather than functional**. `.specify/` holds
+`memory/` and a one-line `feature.json` pointer that entwurf's own `write-spec` writes. No Spec
+Kit tooling is running. What breaks on a rename is recognisability to someone who knows Spec
+Kit, not anything that executes.
+
+**Options, in increasing cost:**
+
+1. **Leave it and keep apologising.** Defensible, and the current position.
+2. **A visible entry point.** A top-level document that links into `.specify/memory/`, so a
+   human or an agent exploring the repository finds the constitution without knowing to look for
+   a dotfile. Cheapest, preserves interop, costs a second path to the same documents.
+3. **Rename.** Fixes it properly and forks the convention. Worth doing only with a clear view of
+   what actually consumes the path.
+4. **Raise it upstream.** The complaint is about Spec Kit's choice, and it is a reasonable one to
+   make there.
+
+Worth noting that the discoverability problem is sharper with agents than with people. A person
+told once where to look remembers. A fresh Fabrik worker explores the repository, and `ls` does
+not show it the constitution.
 
 ---
 

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -1,0 +1,224 @@
+# entwurf — findings from the first real project
+
+**Project**: 86ED, a restaurant operations product. Eleven specifications and a constitution
+existed when entwurf's stage 3 first ran; four more specifications and two constitution
+amendments followed over four days, driven by what stage 3 found.
+
+**Why this is worth reading**: `CONVENTIONS.md` cites this project as the motivating case for
+making stage 3 a living document — *"eleven specifications written over days drifted, because
+each new feature changed the meaning of earlier ones and nothing owned the shared entities."*
+This is what happened when the stage it never got was finally run against it.
+
+**Outcome, as a number.** Fields in the shared domain model with no feature that could own them:
+
+```
+v1.0.0   25        first run
+v1.2.0   25        constitution amendment — went UP by 2, closed 0
+v1.3.0   16        after one new specification
+v1.5.0   13
+v1.6.0   10        three architect decisions, no new specs
+v2.0.0    1        after three more specifications
+```
+
+Every drop came from a specification being written. None came from further work on the
+architecture document. That is the headline, and several findings below follow from it.
+
+Nothing here is a defect in the method as written. These are things it does not currently say.
+
+---
+
+## 1. Stage 3 finds missing specifications, and there is no route back to stage 2
+
+**What happened.** The largest single output of the first run was 24 fields no feature could
+own, which resolved to five missing specifications — tenancy and scoping, matter lifecycle,
+user accounts, acknowledgment, and one more. Four specifications were subsequently written and
+stage 3 re-ran after each.
+
+**What the method says today.** `architecture-foundations`, topic 6:
+
+> A shared entity used everywhere and defined nowhere is a missing specification, and saying
+> so is a finding addressed to the product owner.
+
+That is exactly right and it stops there. There is no described route for the finding to reach
+the product owner, no statement that they should write the specification, and no instruction to
+re-run stage 3 afterwards — even though the re-run trigger ("a new specification introduces an
+entity, a state or an authority") describes precisely what a spec written to close such a
+finding will do.
+
+**What we built instead.** A GitHub Project distinct from the delivery board, one issue per
+finding, and a pair of project-scoped skills — one that briefs the product owner on what is
+assigned to them and one that drafts a well-formed issue. Every project would reinvent this.
+
+**Proposed change.** Describe the loop in `CONVENTIONS.md` as a first-class part of the method,
+alongside the revision beat which it resembles:
+
+> **The specification beat.** Stage 3 routinely discovers that a shared entity has no owning
+> specification. That finding returns to stage 2, the product owner writes the specification,
+> and stage 3 re-runs — its own trigger guarantees it must. Expect several cycles. On this
+> project three cycles took 25 unowned fields to 1, and no amount of further work on the
+> architecture document would have closed a single one.
+
+Setting that expectation matters. A reader of the current text could reasonably believe stage 3
+is a single pass that ends with a list of complaints.
+
+---
+
+## 2. "Spec amendments owed" earned a place in the template
+
+**What happened.** Stage 3 makes decisions that specifications must reflect — an entity owner,
+a corrected derivation, a duplicated definition collapsed to one. At peak this project carried
+**twenty** such decisions that no specification had absorbed.
+
+**What the method says today.** Precedence, rule 3:
+
+> An earlier stage's decision stands until the later stage returns it as an open question and
+> the earlier role amends it.
+
+Correct, and there is no mechanism. Open questions are for things unresolved; these are
+resolved and unapplied, which is a different state and a more dangerous one — the baseline
+reads as settled while the specifications still say the old thing.
+
+**What we built.** A `## Spec amendments owed` section: spec, amendment, and the finding it
+came from. It became the most operationally important part of the document.
+
+**Proposed change.** Add it to the `architecture.md` template between `## Deferred to the
+baseline` and `## Open questions`, with a line in the gate: *every decision requiring a
+specification change is listed as owed until the specification reflects it.*
+
+---
+
+## 3. Topic 4 should ask *how* it will be built, not only who by
+
+**What happened.** Topic 4 was answered late: the build team is one person plus an agent
+pipeline that drives coding agents through a specification-to-merge lifecycle. That single fact
+changed the completeness bar for everything before it.
+
+An engineer who encounters "what is a Matter?" asks someone. **An agent invents one** —
+plausibly, self-consistently, and differently in each of the four specifications that reference
+it. The inconsistency surfaces at integration.
+
+So the twenty-four unowned fields stopped being a documentation gap and became a delivery risk,
+and a build-order rule fell out of it:
+
+> A specification is pipeline-ready when everything it references is owned — not when its own
+> checklist passes.
+
+**What the method says today.** Topic 4 asks who builds it, how many, what they know, how long
+there is. All useful. It does not ask **how** — and agent-built and human-built projects have
+materially different definitions of a finished specification.
+
+**Proposed change.** Extend topic 4 with the build model, and note the consequence: where
+specifications are the direct input to automated implementation, every unowned field and every
+unapplied amendment is a defect waiting to be built rather than a question waiting to be asked.
+
+---
+
+## 4. A clean checklist does not mean a consistent corpus
+
+**What happened.** A specification came back **16/16 with no clarification markers while
+directly contradicting an existing specification** — it permitted configuration to cross a
+boundary that another spec forbade crossing. It surfaced only because the architect read it
+against the corpus.
+
+**Why it is not a `write-spec` defect.** `write-spec` validates a document against itself,
+which is all a per-document checklist can do. But the product owner reasonably read 16/16 as
+"nothing left to resolve," and said so.
+
+**Proposed change.** Two small ones.
+
+`write-spec`'s checklist gains a closing note stating what it does not check:
+
+> This checklist validates this specification against itself. It cannot detect a conflict with
+> another specification — that check happens at stage 3, which reads the corpus as a whole.
+> A clean result here means this document is internally sound, not that it agrees with the
+> others.
+
+And `architecture-foundations` gains an explicit instruction to look for cross-spec
+contradiction, not only for undeclared and contested entities. Passes 2 and 3 find things
+nobody declared; nothing currently tells the architect to find things two specs declare
+*differently*.
+
+---
+
+## 5. The gate decays silently, and nothing says when to re-run it
+
+**What happened.** The baseline moved through four version bumps without its checklist being
+re-evaluated. It sat claiming a spec range and a set of counts that were two constitution
+versions and two specifications out of date, understating progress by twelve fields.
+
+**What the method says today.** `CONVENTIONS.md` is strong on preserving previous evaluations
+and on the checkbox state being durable:
+
+> later skills compare it before and after their own run, and the build reads it as a gate
+
+It says nothing about **when** a re-evaluation is required. The re-run trigger is defined for
+new specifications, not for amendments to the baseline itself.
+
+**Proposed change.** One sentence in Gates:
+
+> A version bump requires a gate evaluation. If the amendment is small enough not to warrant
+> one, say so in the checklist header — an unexplained gap between the document's version and
+> its gate's is indistinguishable from a gate nobody ran.
+
+---
+
+## 6. There is a third disposition, and it is neither owned nor unowned
+
+**What happened.** Twice a field marked "no feature exists that could own it" was reclassified
+rather than closed. One was deliberately unspecified because the constitution treats that class
+of logic as proprietary and restricted. The other was deferred — the capability does not ship
+in the pilot at all, and the principle governing it was reworded to describe a boundary rather
+than assert that something exists.
+
+Neither is a gap. Both had been sitting in the model inviting someone to fill them.
+
+**What the method says today.** Topic 6 names three dispositions: owned by a feature; owned by
+nobody but with a candidate; no feature exists that could own it.
+
+**Proposed change.** Add a fourth: **deliberately out of scope** — restricted, deferred, or
+excluded, with the decision recorded. It is not a gap, and labelling it as one is as misleading
+as writing "the platform owns it."
+
+---
+
+## 7. Three smaller findings
+
+**entwurf produces AI-assisted documents and says nothing about labelling them.** This project
+independently wrote rules into three of its own specifications requiring AI-assisted content to
+carry a visible provenance label until a human verifies it — and then merged an unlabelled
+244-line design document produced with AI assistance. The method's own outputs are in the same
+category. Worth a line in `CONVENTIONS.md`: a baseline produced through these interviews is
+AI-assisted, and where a project sets its own provenance rules, its baselines are subject to
+them.
+
+**A scope exclusion should record why, so the reason can be checked for expiry.** A finding was
+deliberately excluded from a task on the grounds that it needed an engineer's judgement and the
+project had none. Two days later the build team was answered and the exclusion had to be
+reversed. Exclusions written as bare "out of scope" cannot be audited for staleness; written as
+"out of scope *because*" they can.
+
+**Split a question before asking it when it has a product half and an architecture half.** One
+question — where a particular authority lives — was put to the architect as a single fork. He
+correctly refused it: the product half had already been answered in a clarification session
+months earlier, and only the storage half was his. Interview rules already say to route
+neighbouring-domain claims to their owner; they could also say to *split* a question that spans
+two domains rather than routing the whole thing to one.
+
+---
+
+## What worked, and should not be changed
+
+- **The three dispositions for a field, and the instruction not to resolve a gap by assigning
+  it to the nearest feature.** This is what produced the missing-specification findings at all.
+  A weaker method would have let the architect quietly assign Venue to whichever spec mentioned
+  it most.
+- **Counts in the gate rather than claims.** "25 → 16 → 13 → 1" told the story better than any
+  prose, and made it obvious that architecture work was not what closed the gap.
+- **Preserving previous evaluations verbatim.** Reading the v1.0.0 evaluation next to the
+  current one shows a failure that was fixed and one that was silently dropped as different
+  things, exactly as intended.
+- **Stage 3 staying Draft until stage 5.** It was amended nine times in four days. Anything
+  ratified would have been re-ratified nine times or quietly lied about.
+- **The register's Class column.** Distinguishing "Decided" from "Recommended and accepted"
+  from "Working assumption" mattered constantly, particularly for keeping the architect's own
+  defaults visibly separate from the product owner's decisions.

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -28,7 +28,7 @@ v2.0.0    1        after three more specifications
 Every drop came from a specification being written. None came from further work on the
 architecture document. That is the headline, and several findings below follow from it.
 
-**Fourteen findings and three smaller ones.** One is settled — the ADR `Level` field in finding
+**Fifteen findings and three smaller ones.** One is settled — the ADR `Level` field in finding
 13, agreed 2026-08-22. The rest are proposals. Nothing here is a defect in the method as written —
 these are things it does not currently say. Findings 3 through 5 all follow from one fact the
 method never states: the reader of these documents is an agent.
@@ -331,6 +331,8 @@ and on the checkbox state being durable:
 
 It says nothing about **when** a re-evaluation is required. The re-run trigger is defined for
 new specifications, not for amendments to the baseline itself.
+
+**This is one instance of a wider pattern — see finding 15.**
 
 **Proposed change.** One sentence in Gates:
 
@@ -655,6 +657,63 @@ Kit, not anything that executes.
 Worth noting that the discoverability problem is sharper with agents than with people. A person
 told once where to look remembers. A fresh Fabrik worker explores the repository, and `ls` does
 not show it the constitution.
+
+---
+
+## 15. Every list in the baseline decays in the same direction, and nothing sweeps them
+
+Finding 7 recorded the gate going four versions stale. That was not an isolated slip — it is one
+instance of a pattern, and the second instance was worse.
+
+**What happened.** A stage-3 re-run took the domain model to zero unowned fields, updated the
+gate, and never touched `## Open questions`. The document then sat claiming **fourteen questions
+addressed to the product owner when thirteen had already been answered by his own work** over the
+preceding three days. He could reasonably have answered them again.
+
+**The pattern.** The baseline holds several sections that are lists, and every one of them is
+appended to freely and pruned only deliberately:
+
+| Section | Decays by |
+|---|---|
+| `## Open questions` | questions answered elsewhere and never struck |
+| `## Spec amendments owed` | amendments applied and never removed |
+| `## Deliberately deferred` | parked markers whose fetcher delivered |
+| the gate's counts | any amendment at all |
+| `Last reviewed against specs` / `Against constitution` | a spec or a constitution version landing |
+
+Appending is cheap and feels safe. Pruning requires re-reading the whole section against
+everything that has happened since. So they all rot in the **same direction — over-reporting
+open work** — and that direction feels conservative, which is exactly why nobody catches it.
+
+**Why over-reporting is not the safe error.** A document claiming fourteen open questions when
+one is real trains its readers to discount it, and the one real question goes with the rest. And
+where the reader is an agent, it is worse than discounting: an agent does not discount. It will
+treat a resolved question as open, and on a project with an escalation channel it will spend
+that channel asking something already answered.
+
+**The mechanism is already in the repository.** The decision register is the authority on what is
+currently true — that is its entire purpose. Every stale open question on 86ED had a matching
+`Current` row in the register answering it. So the sweep is not a judgement call, it is a join:
+
+> **For each open question, is there a `Current` register row that answers it? If so it is not
+> open.** Same for an amendment owed, and for a parked marker whose fetcher has delivered.
+
+**Proposed change.** A closing step in every baseline skill, before the gate is written:
+
+> **Sweep before you evaluate.** Re-read `## Open questions`, `## Spec amendments owed` and
+> `## Deliberately deferred` against the decision register. Anything the register now answers is
+> closed — strike it, record the number as retired rather than reusing it, and say in the gate
+> how many closed this run. These sections only ever grow unless a run deliberately shrinks
+> them, and they decay toward over-reporting, which reads as caution and behaves as noise.
+
+And a gate item to make it checkable:
+
+> - [ ] Every open question, owed amendment and parked marker was re-read against the register
+>       this run, and the number closed is recorded
+
+**This is the finding I would rank second**, after the deferral one. Both are the same species:
+something that reads as careful practice — deferring a decision, leaving a question open —
+quietly accumulating into a document nobody can act on.
 
 ---
 

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -28,7 +28,7 @@ v2.0.0    1        after three more specifications
 Every drop came from a specification being written. None came from further work on the
 architecture document. That is the headline, and several findings below follow from it.
 
-**Eleven findings and three smaller ones.** Nothing here is a defect in the method as written —
+**Twelve findings and three smaller ones.** Nothing here is a defect in the method as written —
 these are things it does not currently say. Findings 3 through 5 all follow from one fact the
 method never states: the reader of these documents is an agent.
 
@@ -392,6 +392,10 @@ cite an issue, and supersession is marked in line (*"Superseded by ADR-109"*). A
 reasons about a review bot's diff limit, quotes its own measurements, and links two prior
 decisions. That is a working institutional memory, written by agents, for agents.
 
+**And they were written as the implementation proceeded, issue by issue** — not up front, not by
+an architect. The log is a byproduct of building rather than a precondition for it. That timing
+turns out to matter more than the artifact does; see finding 12.
+
 Now put the two projects side by side:
 
 | | `~/dev/fantasy` — Fabrik alone | 86ED — entwurf then Fabrik |
@@ -453,6 +457,76 @@ for that team and expensive for this one — so the fix is both halves: **name t
 make sure a route to them exists.** 86ED built that route: an outer-loop board, one issue per
 question, a skill that briefs the person on what is waiting. It was built for entwurf's
 findings, it is equally the inner loop's escalation channel, and neither plugin knows it exists.
+
+---
+
+## 12. Two projects, two philosophies — and entwurf should say which one it is for
+
+The comparison is more instructive than any single finding, because the two projects did the
+opposite thing and both worked.
+
+**`~/dev/fantasy` discovered its architecture.** 538 issues, 204 ADRs written as each issue was
+worked, no architecture baseline at all. Every decision is grounded in something real that came
+up while building — ADR-160 exists because a review bot has a 500 KB diff limit, which is not a
+fact anybody could have written down in advance.
+
+**86ED is deciding its architecture first.** Fifteen specifications and a baseline before a line
+of code, on the maintainer's explicit position: *we must fully spec this system before we
+build.*
+
+Both are legitimate. What each buys is different, and entwurf currently says nothing about
+which situation it is for.
+
+### What the up-front baseline buys that emergent ADRs cannot
+
+**Cross-corpus findings.** An ADR written while implementing issue 12 optimises for issue 12.
+Nobody was checking whether it contradicts issue 40, because issue 40 does not exist yet. The
+findings stage 3 produced on 86ED were all of this kind: *Venue is used by eleven specifications
+and defined by none*; *two specifications derive the same authority by different mechanisms*;
+*the same field set is defined twice, identically*. **No per-issue process finds those**, because
+no single issue can see them.
+
+That is also why 86ED needed entwurf and fantasy did not. 86ED arrived with eleven
+specifications written over days that had already drifted — the exact condition `CONVENTIONS.md`
+describes. Fantasy never had that problem because it never had a large up-front corpus to drift.
+
+### What emergent ADRs buy that an up-front baseline cannot
+
+**Facts you cannot know yet.** A diff limit. A native binding that behaves badly. A prompt that
+costs more than expected. Fantasy's ADRs are grounded because the ground existed when they were
+written. An up-front decision about the same thing would have been a guess with a confident
+tone.
+
+### The consequence for stage 5
+
+This is the part worth acting on. Stage 5 currently owns two kinds of thing:
+
+- **Budgets and fitness functions** — targets, converted from user-facing guarantees. Legitimately
+  up front. You cannot discover what you promised.
+- **Cross-cutting mechanisms chosen for a quality** — synchronisation, notification delivery,
+  storage tiering. **These are exactly what fantasy's ADRs are made of**, and deciding them
+  before anything is built is deciding them at the moment you know least.
+
+`CONVENTIONS.md` defers a mechanism to stage 5 when it is *"chosen for a quality — performance,
+cost, scale, resilience — because those trade against the experience."* The trade-off reasoning
+is right. The conclusion may be a step too far: stage 5 should **frame** such a mechanism —
+name it, say what it must achieve, say how a violation would be detected — and leave the choice
+to an ADR written when the constraint is real.
+
+**Proposed change.** A short section in `CONVENTIONS.md` on when this method is worth running,
+and a narrowing of stage 5:
+
+> **When to run this.** These stages exist for a corpus that must be coherent before it is
+> built — many features specified in parallel, several people writing them, or a domain where
+> the cost of discovering a contradiction late is high. A project that can grow one issue at a
+> time, with decisions recorded as they are made, may need only a constitution and an ADR log.
+> Stage 3 exists to find what no single feature can see. If nothing spans your features, it has
+> nothing to find.
+
+> **Stage 5 sets targets and frames mechanisms; it does not choose them.** A budget is a
+> promise and belongs here. A mechanism is a means, and the moment before anything is built is
+> the moment you know least about it. Name it, state what it must achieve and how a violation
+> would show, and let the ADR that chooses it be written when the constraint is real.
 
 ---
 

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -37,6 +37,78 @@ method never states: the reader of these documents is an agent.
 
 ---
 
+## Handoff — read this first
+
+*Written for whoever implements this, in a session that was not there when it was written.*
+
+**Status.** Fifteen findings and three smaller ones. **One is settled** — the ADR `Level` field
+in finding 13, agreed by the maintainer on 2026-08-22 and already applied to 86ED as an example
+in `adrs/001`. Everything else is a proposal. Nothing in `CONVENTIONS.md` or any skill has been
+changed.
+
+### Trust calibration — four of these claims were wrong first
+
+This note was corrected repeatedly by the maintainer while being written, and a reader should
+know where the soft ground is. I claimed, and was wrong about:
+
+- **that agent-implementation was a variable to discover at topic 4.** It is the premise —
+  entwurf and Fabrik are designed to be used together.
+- **that Fabrik consumes only specifications.** It consumes the baseline and the decision
+  register too, which turns an unapplied amendment from an omission into a contradiction.
+- **that Fabrik workers carry no memory between issues.** They write ADRs; `~/dev/fantasy` has
+  204 of them, densely cross-referenced.
+- **that entwurf's and Fabrik's decision artifacts are two halves of one job.** They are three
+  altitudes that barely overlap.
+
+**Verify before trusting.** Every claim here is checkable against two repositories:
+`~/dev/86ed` (entwurf then Fabrik, mid-flight) and `~/dev/fantasy` (Fabrik alone, 538 issues,
+204 ADRs, no baseline). Where a number appears — 27 deferrals, 204 ADRs, 25 unowned fields —
+it was measured, and the command that measured it is worth re-running rather than believing.
+
+### Suggested order, and what each touches
+
+Roughly dependency order. Effort is rough and assumes reading the surrounding text first.
+
+| # | Finding | Touches | Effort |
+|---|---|---|---|
+| 13 | ADR `Level` field — **settled** | `CONVENTIONS.md` § Decision records; Fabrik stage skills | small |
+| 3 | Name the pairing; Specify must not overwrite an authored spec | both plugins' READMEs; `fabrik-specify` | small, high value |
+| 5 | Precedence written for a worker, not a role | `CONVENTIONS.md` § Precedence; a Fabrik stage skill | small |
+| 7 + 15 | Gate re-evaluation rule and the list sweep — **do these together, they are one family** | `CONVENTIONS.md` § Gates; all three baseline skills' closing steps | medium |
+| 4 | A deferral must name its consumer | `write-spec` and `clarify` checklists | small, **ranked first for value** |
+| 6 | Fourth field disposition — deliberately out of scope | `architecture-foundations` topic 6 | small |
+| 1 | The specification beat — stage 3 → stage 2 → stage 3 | `CONVENTIONS.md` § The stages | medium |
+| 2 | `## Spec amendments owed` in the template | `architecture-foundations` template + gate | small |
+| 10 | Register and ADRs are three altitudes | `CONVENTIONS.md` §§ Decision register, Decision records | medium |
+| 11 | Escalation: role-addressed blocks, and a re-run trigger | Fabrik stage skills; `architecture-foundations` re-run triggers | medium |
+| 12 | Stage 5 frames mechanisms rather than choosing them; and when to run the method at all | `CONVENTIONS.md` § The stages; `architecture-baseline` | **large — a real change of position** |
+| 14 | `.specify/` is hidden | four skills' closing reports, or a rename | **decision first, then small** |
+| 9 | Three smaller ones | scattered | small |
+
+### Two that are not like the others
+
+**Finding 12** proposes that stage 5 *frame* cross-cutting mechanisms rather than choose them,
+on the evidence that fantasy's best ADRs could only have been written once the constraint was
+real. That is a change of position on what stage 5 is for, not a clarification. Read the whole
+finding before touching `architecture-baseline`.
+
+**Finding 14** is a decision, not an implementation. `.specify/` is Spec Kit's name and
+`CONVENTIONS.md` deliberately protects it. The note lays out four options and recommends none.
+
+### What this would do to 86ED
+
+86ED is the evidence for most of this and would be the first project on the new shape. Its
+stage 3 is complete — 89 of 89 fields owned, nothing contested, no amendments owed — so the
+earlier concern about disturbing work in flight has largely lapsed. Two cautions remain:
+
+- **A `.specify/` rename or a domain-model split would move paths** that `CLAUDE.md`, the
+  hiring brief and several issue bodies reference by name.
+- **86ED has one ADR and has not run stage 5.** Any finding about ADR volume or altitude mixing
+  is theoretical there and observed on fantasy. Do not test it against 86ED and conclude the
+  problem is small.
+
+---
+
 ## The frame these findings sit in
 
 **Fabrik is an entire engineering team.** That is the useful way to read everything below.

--- a/notes/entwurf-findings-86ed-2026-08-22.md
+++ b/notes/entwurf-findings-86ed-2026-08-22.md
@@ -396,15 +396,22 @@ decisions. That is a working institutional memory, written by agents, for agents
 an architect. The log is a byproduct of building rather than a precondition for it. That timing
 turns out to matter more than the artifact does; see finding 12.
 
-Now put the two projects side by side:
+**They are not two halves of one job. They are three altitudes, and only two of them share a
+directory.**
 
-| | `~/dev/fantasy` — Fabrik alone | 86ED — entwurf then Fabrik |
+| Altitude | Artifact | Example |
 |---|---|---|
-| ADRs | **204** | **1** |
-| Decision register | none | **87 rows** |
-| Specs | 538, one per issue | 15, one per feature |
+| Domain, product, authority — *what is currently true* | register row | *"Routing does not branch on severity; severity determines safeguards, type determines destination"* |
+| High-level architecture — *a commitment a reasonable person would question later* | ADR, written by entwurf | *"Platform commitment reclassified from constraint to reversible decision"* |
+| Implementation — *module structure, library choice, pattern* | ADR, written by a Fabrik worker | *"Validator dependency injection"*, *"Kind registry module singleton"*, *"pnpm workspaces"* |
 
-Each tool produced its own artifact and ignored the other's entirely.
+Fantasy's 204 ADRs are almost entirely the third kind. 86ED's register rows are almost entirely
+the first. **They barely overlap at all** — which is why neither project noticed it was missing
+the other's artifact.
+
+*(86ED currently has one ADR against fantasy's 204, and that comparison is not meaningful: 86ED
+has not run stage 5, the phase that produces architecture decisions, and has built nothing. It
+is mid-flight, not deficient.)*
 
 **Both artifacts are load-bearing and they are not substitutes.** `CONVENTIONS.md` already says
 why:
@@ -419,8 +426,15 @@ working assumptions, exploratory ideas, technical suggestions binding on nobody,
 markers naming who resolves them. Fantasy has no place for *"we are proceeding on this but
 nobody has confirmed it"*.
 
-Meanwhile 86ED has one ADR and 87 register rows — the mirror failure. Several of those rows are
-implementation-shaped decisions with real reasoning that deserved an ADR and got a table cell.
+**The collision 86ED will hit the moment Fabrik runs.** `adrs/` is one directory with one
+numbering sequence, and two tools will write into it at different altitudes. 86ED's `adrs/001`
+is a platform reclassification. The first Fabrik worker to make an implementation call will
+write `adrs/002` about a build tool or an injection pattern. They will interleave, numbered as
+peers, and a reader looking for architectural commitments will be reading them alongside
+decisions about which test runner won.
+
+Fantasy never hit this because it only ever had the third altitude. 86ED is the first project
+where both tools write ADRs, and nothing separates them.
 
 **Proposed change.** State the division of labour and make each tool write to both:
 
@@ -430,9 +444,14 @@ implementation-shaped decisions with real reasoning that deserved an ADR and got
 - **Fabrik's stage skills should append a register row** when they make a decision that outlives
   their issue — with an honest Class, which is the column that keeps an agent's judgement call
   visibly distinct from a product owner's ruling.
-- **entwurf should write ADRs**, not only register rows, for its own architecture decisions.
-  Topic 3 already says to write one for a reclassified commitment; that instruction should be
-  general.
+- **Separate the two altitudes in `adrs/`.** A prefix, a subdirectory, or a required
+  `**Altitude**` field — anything that lets a reader find the ten decisions that shape the
+  system without reading the two hundred that shape a module. Whatever the mechanism, it has to
+  exist before both tools write into the same directory, which on 86ED is imminent.
+- **Do not push implementation ADRs into the register.** Two hundred rows about factory patterns
+  would drown eighty-seven about what is currently true in the domain. A Fabrik worker should
+  append a register row only when its decision changes something at the first altitude — which
+  will be rare, and is exactly why the Class column matters when it happens.
 
 ## 11. Escalation is normal, and the answer has nowhere reusable to land
 


### PR DESCRIPTION
## Summary

86ED is the project `CONVENTIONS.md` already cites as the motivating case for stage 3 being a living document — *"eleven specifications written over days drifted, because each new feature changed the meaning of earlier ones and nothing owned the shared entities."* This records what happened when that stage was finally run against it.

Four days, nine baseline versions, four new specifications, two constitution amendments. Fields with no feature that could own them went **25 → 1**, and every drop came from a specification being written rather than from further work on the architecture document.

Six substantial findings and three smaller ones. Each has what happened, what the method says today, and a proposed change. **Nothing here is a defect in the method as written** — they are things it does not currently say.

## The findings

1. **Stage 3 finds missing specifications and there is no route back to stage 2.** 24 of the 25 unowned fields were missing specs. The method says saying so is "a finding addressed to the product owner" and stops. Proposes describing the loop as a first-class beat, alongside the revision beat it resembles.
2. **"Spec amendments owed" earned a template slot.** Resolved-but-unapplied is a distinct state from unresolved, and a more dangerous one — the baseline reads as settled while the specs still say the old thing. This project carried twenty at peak.
3. **Topic 4 should ask *how* it will be built.** Answering "one human plus an agent pipeline" changed the completeness bar for everything: an engineer asks, an agent invents. Agent-built and human-built projects have different definitions of a finished spec.
4. **A clean checklist does not mean a consistent corpus.** A spec came back 16/16 with no markers while contradicting another spec. Not a `write-spec` defect — it validates a document against itself — but the product owner reasonably read 16/16 as "done".
5. **The gate decays silently.** Four version bumps without re-evaluation. The conventions say when to *preserve* an evaluation, never when to *run* one.
6. **A fourth field disposition.** Deliberately out of scope — restricted, deferred or excluded — is neither owned nor a gap, and labelling it a gap invites someone to fill it.

Plus: the method produces AI-assisted documents and says nothing about labelling them, while projects routinely write exactly that rule for themselves; exclusions should record *why* so they can be audited for staleness; and a question spanning two domains should be split before it is asked.

## What this does not do

No changes to `CONVENTIONS.md` or any skill. Several of these bind three other projects, so they should be read as proposals before they become rules.

The note closes with what worked and should not be changed, which is most of it — the three dispositions, counts over claims, preserved evaluations, stage 3 staying Draft, and the register's Class column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)