### PR TITLE
feat(pruefer): derive the watched repo set from App installations instead of a hand-maintained list

### DIFF
--- a/adrs/1233-pruefer-multi-installation-auth.md
+++ b/adrs/1233-pruefer-multi-installation-auth.md
@@ -1,8 +1,58 @@
 # ADR 1233: Pruefer Multi-Installation Auth Derived from `watched_repos`
 
 **Date**: 2026-07-28
-**Status**: Accepted
+**Status**: Accepted (Decision 1's security framing superseded — see Amendment below)
 **Issue**: #1233 — derive App installations from `watched_repos` (multi-org, one daemon)
+
+## Amendment (2026-08-27, #1641)
+
+Decision 1's core claim — **"this is also the whole security control": the set of
+installations Pruefer ever tokenizes equals exactly the set of owners in
+`watched_repos`, nothing more** — is superseded. #1253 replaced the shared,
+publicly-installable App (`handarbeit-pruefer`) this ADR was written against with a
+per-operator dedicated App, bootstrapped via manifest flow
+(`internal/githubauth.Reconciler`); `pruefer/auth.go`'s `BootstrapMulti`/`AuthSet`
+(the code this ADR describes) no longer exists. #1641 then inverted discovery
+direction entirely: `internal/githubauth.Reconciler.Derive` now discovers and mints
+**every** installation of the operator's own App unconditionally, regardless of
+whether `watched_repos` names its owner — the opposite of Decision 1's "only ever
+mints a token for an owner that appears in `watched_repos`."
+
+This is safe, not a regression, because the *reason* Decision 1's allowlist existed
+— a stranger installing the same shared App must never enlist this operator's daemon
+— is now satisfied structurally by App identity instead: `GET /app/installations` is
+JWT-scoped to the calling App, so it is physically incapable of returning another
+App's installations. Once every operator runs their own dedicated App, "installed on
+it" and "mine to review" are the same statement, and an owner-derived-from-`watched_repos`
+allowlist adds no additional protection — see
+[adrs/1641-pruefer-installation-derived-repo-discovery.md](1641-pruefer-installation-derived-repo-discovery.md)
+for the full rationale and `internal/githubauth`'s own containment regression test
+(`TestDerive_Containment_NeverContactsOtherAppsInstallations`).
+
+`watched_repos` is not removed — it becomes an optional, operator-preference
+narrowing filter over the installation-derived set (never a widening, never the
+containment boundary) — see ADR-1641's R3.
+
+What this amendment does **not** touch, because #1253/#1641 retained and reused it
+rather than replacing it:
+- **Decision 2** (one `*github.Client`/`*Auth` per owner, not a token-provider inside
+  `github/client.go`) — the owner-scoped client-map shape is unchanged; `Reconciler.clients`
+  is exactly this pattern under a new name.
+- **Decision 3** (`RunRefreshLoop` per distinct `*Auth`) — `Reconciler.RunRefreshLoops`
+  is the direct successor, same dedup-by-pointer-identity mechanism.
+- **Decision 4** (`github_app_installation_id` as a legacy pin/escape hatch) — preserved
+  byte-for-byte; ADR-1641 confirms this pinned path is fully exempt from the R1
+  discovery inversion, exactly as it was exempt from Decision 1's `watched_repos`-driven
+  discovery here.
+- **Decision 6** (pagination gap in `FetchAppInstallations`/`FetchInstallationRepositories`,
+  deferred at the time) — now addressed: both functions paginate for real as of #1641,
+  since installation enumeration became the *primary* discovery path rather than a
+  verification check against a short list, making silent under-enumeration a
+  materially worse failure mode. See ADR-1641.
+
+Decision 5 (`repository_selection: selected` handled via `FetchInstallationRepositories`)
+is subsumed by `Derive`, which now calls that same endpoint unconditionally for every
+installation regardless of mode — see ADR-1641.
 
 ## Context
 

--- a/adrs/1253-github-app-manifest-auth-reconciler.md
+++ b/adrs/1253-github-app-manifest-auth-reconciler.md
@@ -110,8 +110,13 @@ mint/commit or detach/drain sequence itself.
 Concretely, `handleReload` (`pruefer/execute.go`) no longer calls `MintOwnerAuth`,
 `CommitOwnerAuth`, or `RemoveOwners` at all — those three methods remain on `Reconciler`,
 still correct, but are now exercised only via `Derive`'s own internal use of
-`CommitOwnerAuth`/`RemoveOwners` (for the genuinely new installation-driven trigger, not
-a config-driven one). `MintOwnerAuth` and `internal/githubauth/installations.go`'s
+`RemoveOwners` (for the genuinely new installation-driven trigger, not a config-driven
+one). `Derive` does **not** call `CommitOwnerAuth` for a newly-discovered owner —
+it registers the new `Auth` via a lower-level `registerOwnerAuth` helper instead, and
+starts its refresh loop itself only when appropriate (see ADR-1641 Decision 1's
+`startLoopsForNewOwners` note: `Reconcile`'s own first call defers loop-starting to its
+caller's subsequent `RunRefreshLoops`, to avoid starting the same installation's refresh
+loop twice). `MintOwnerAuth` and `internal/githubauth/installations.go`'s
 `verifyRepoAccess` have no remaining caller in the non-test code path as of this change;
 they are deliberately left in place (not deleted) as a scoped, explicitly-noted
 deferral — see ADR-1641's own trade-offs section for why immediate removal was not

--- a/adrs/1253-github-app-manifest-auth-reconciler.md
+++ b/adrs/1253-github-app-manifest-auth-reconciler.md
@@ -77,6 +77,8 @@ ADR-1233 Decision 5's `checkSelectedRepos` hard-errored bootstrap entirely when 
 
 The reconciler reports progress via a plain `func(format string, args ...any)` callback (`Options.Logf`), matching every other package's `logf` convention in this codebase, which `pruefer/execute.go` wires to Pruefer's existing console/structured logging. Piping progress into `pruefer/tui`'s `ptui.Event` channel instead would require `internal/githubauth` to import `pruefer/tui`, inverting the intended dependency direction (Decision 1) for a one-time startup sequence the TUI doesn't otherwise model. The issue's own example output (`✓ handarbeit/fabrik authorized` / `! shadoworg has no installation → ...`) is console-shaped, not a TUI mockup — flagged as a reasonable follow-up, not required here.
 
+**Narrow exception (2026-08-27, #1641):** the reconciliation-*progress* boundary above is unchanged — `internal/githubauth` still never imports `pruefer/tui`. But #1641's R4 ("make the derived set observable... in the log and the TUI") requires the *result* of reconciliation/derivation — which repos, from which installation — to reach the TUI, not just its progress log lines. That data crosses the boundary the same way every other daemon-observable fact already does: `pruefer/daemon.go` (which already imports both `internal/githubauth` and `pruefer/tui`) reads `githubauth.DerivedRepoSet` after a `Derive` call and re-expresses it as a plain `ptui.DerivedRepoSetEvent`/`ptui.DerivedInstallationSummary`/`ptui.DerivedRepoEntry` — the identical "re-express as a dependency-free plain type" pattern `ReviewCompletedEvent.Reason` already established for `pruefer.SkipReason`. `internal/githubauth` itself remains fully unaware the TUI exists.
+
 ### Addendum (2026-08-26): SIGHUP reload ported onto the Reconciler
 
 ADR-1640 (#1640) landed SIGHUP-triggered config reload on `main` while this branch had already deleted the `pruefer/auth.go`/`AuthSet` model that ADR-1640's original implementation was built against — a genuine modify/delete collision at merge time, not a stylistic conflict. Rather than pick a side (either would have silently dropped working functionality — reload support, or this issue's reconciler), the reload behavior was **ported** onto `internal/githubauth.Reconciler`, since the enabling fact that made this tractable is narrow: of `pruefer.Config`'s fields, only `WatchedRepos` and a couple of poll/reconciliation-interval fields are `reload:"live"` (see ADR-1640); `AppID`/`AppPrivateKeyPath`/`AppInstallationID` are all `reload:"restart"`. A reload therefore never needs to re-run manifest bootstrap or re-validate the App's identity against GitHub — it only ever needs to dynamically mint or detach per-*owner* `Auth`s under the App identity `Reconcile` already resolved once at startup.
@@ -88,6 +90,32 @@ ADR-1640 (#1640) landed SIGHUP-triggered config reload on `main` while this bran
 - `RemoveOwners(removed []string) []DetachedAuth` — detaches a removed owner's `Auth` from `Reconciler` state without stopping its refresh loop; the caller (`Daemon.drainThenStopAuth`) defers the actual stop until no review is in flight for that owner, matching ADR-1640's drain-before-cancel requirement.
 
 `pruefer/daemon.go` gained a `cfgMu sync.RWMutex` guarding `Config`/`Clients`/the concurrency semaphore together, `config()`/`client()` read accessors, and `ApplyReload` — the same shape ADR-1640 specifies, just reading through `Reconciler`'s new methods instead of `AuthSet`'s. This closes Decision 1's and Decision 5's original "no live trigger, no live-reload capability" premise: `daemon.go`'s poll loop is no longer untouched by config reload, though the *manifest/bootstrap/discovery* portions of `Reconcile` genuinely are — reload never re-enters them, by construction, since none of the fields that would require it are `reload:"live"`.
+
+### Addendum (2026-08-27, #1641): SIGHUP `watched_repos` reload no longer mints or removes owner auth
+
+#1641 inverted `Reconcile`'s discovery direction (see
+[adrs/1641-pruefer-installation-derived-repo-discovery.md](1641-pruefer-installation-derived-repo-discovery.md)):
+every installation of the operator's own App is now minted unconditionally by the new
+`Reconciler.Derive`, regardless of whether `watched_repos` names its owner. This makes
+the addendum above's premise — that a SIGHUP `watched_repos` edit needs `MintOwnerAuth`/
+`CommitOwnerAuth`/`RemoveOwners` to add or drop an owner's `Auth` — no longer true: by
+the time any reload runs, every owner the operator could possibly add to `watched_repos`
+already has a client if their installation exists at all (`Derive` doesn't consult
+`watched_repos` to decide *whom* to mint). A `watched_repos` change now only needs to
+re-intersect the (unwidened) filter against the installation grant — `pruefer/daemon.go`'s
+`triggerRederivation` calls `Derive` again (which is safe and cheap to repeat — see
+ADR-1641), rather than `handleReload` computing an owner diff and driving the two-phase
+mint/commit or detach/drain sequence itself.
+
+Concretely, `handleReload` (`pruefer/execute.go`) no longer calls `MintOwnerAuth`,
+`CommitOwnerAuth`, or `RemoveOwners` at all — those three methods remain on `Reconciler`,
+still correct, but are now exercised only via `Derive`'s own internal use of
+`CommitOwnerAuth`/`RemoveOwners` (for the genuinely new installation-driven trigger, not
+a config-driven one). `MintOwnerAuth` and `internal/githubauth/installations.go`'s
+`verifyRepoAccess` have no remaining caller in the non-test code path as of this change;
+they are deliberately left in place (not deleted) as a scoped, explicitly-noted
+deferral — see ADR-1641's own trade-offs section for why immediate removal was not
+worth the additional churn in this same change.
 
 ## Consequences
 
@@ -108,6 +136,7 @@ ADR-1640 (#1640) landed SIGHUP-triggered config reload on `main` while this bran
 - ADR-1233 (`adrs/1233-pruefer-multi-installation-auth.md`) — the owner-derived multi-installation routing (`AuthSet`/`BootstrapMulti`) this ADR's reconciler subsumes; Decisions 4 (pinned-installation compat) and 5 (`selected`-mode check, now generalized to a soft status per Decision 7 above) both carry forward.
 - ADR-1196 (`adrs/1196-extract-self-upgrade-package.md`) — the `internal/selfupgrade` engine-independence precedent `internal/githubauth`'s package boundary mirrors.
 - ADR-1640 (`adrs/1640-pruefer-config-reload.md`, #1640) — SIGHUP config reload; landed on `main` against the pre-reconciler `AuthSet` model, ported onto `internal/githubauth.Reconciler` on 2026-08-26 (see the addendum after Decision 8 above). That ADR's design rationale (the `reload:"live"|"restart"|"skip"` tag scheme, the drain-before-cancel requirement, the all-or-nothing multi-owner reload batch) is unchanged by the port — only which package implements the per-owner mint/detach primitives changed.
+- ADR-1641 (`adrs/1641-pruefer-installation-derived-repo-discovery.md`, #1641) — inverts `Reconcile`'s discovery direction (installations are now the desired state, `watched_repos` an optional filter) via the new `Reconciler.Derive`; supersedes the 2026-08-26 SIGHUP addendum's mint/remove behavior (see the 2026-08-27 addendum above) and adds the narrow TUI exception noted after Decision 8.
 - `cmd/pruefer/README.md` — Setup section rewritten in the same change to document the manifest flow as the default first-run path, with the manual registration flow kept as documented compat mode, plus new config reference rows for `github_app_state_path`/`no_browser`.
 
 **References:** [cmd/pruefer/README.md](../cmd/pruefer/README.md)

--- a/adrs/1641-pruefer-installation-derived-repo-discovery.md
+++ b/adrs/1641-pruefer-installation-derived-repo-discovery.md
@@ -38,10 +38,29 @@ former owner-scoped discovery loop (which only ever iterated owners already pres
 1. Calls `gh.FetchAppInstallations` with **no owner list as input** — every installation
    of the operator's own App, discovered unconditionally.
 2. For each installation not already known (by lower-cased account), mints a token
-   (`mintAuth`) and commits it via the existing `CommitOwnerAuth` (starting its refresh
-   loop). An *already*-known owner's existing client/`Auth` is reused unchanged — no
-   re-mint — so a repo gained or lost under an already-known installation never
-   disturbs that installation's running refresh loop.
+   (`mintAuth`) and registers it via `registerOwnerAuth` (a helper factored out of
+   `CommitOwnerAuth`'s registration bookkeeping — see below for why `Derive` doesn't
+   call `CommitOwnerAuth` itself). An *already*-known owner's existing client/`Auth`
+   is reused unchanged — no re-mint — so a repo gained or lost under an already-known
+   installation never disturbs that installation's running refresh loop.
+   Whether the newly-registered `Auth`'s refresh loop starts immediately depends on
+   an unexported `startLoopsForNewOwners` parameter: true for every public `Derive`
+   call (an installation webhook event, the periodic ticker, or a SIGHUP
+   `watched_repos` edit — nothing else will ever start a loop for an owner one of
+   those newly discovers), but false specifically for `Reconcile`'s own first,
+   internal call. That distinction exists because `Reconcile`'s caller
+   (`pruefer/execute.go`) always calls `Reconciler.RunRefreshLoops` itself immediately
+   after `Reconcile` returns, to start every discovered owner's refresh loop as one
+   batch — if `Derive` had also started a loop right away (via `CommitOwnerAuth`, as
+   an earlier revision of this change did), every installation would get **two**
+   independent refresh-loop goroutines: `Auth.startRefreshLoop`'s `cancel` field holds
+   only the most recent loop's cancel func, so the second start silently orphans the
+   first — un-stoppable by `Auth.Stop`/`drainThenStopAuth`/`RemoveOwners` short of a
+   process restart — while also doubling every installation's token-mint API traffic.
+   Caught by a data race in the existing test suite (two independently-running,
+   `context.Background()`-rooted refresh loops touching shared test state) and fixed
+   during this issue's own review; see
+   `TestReconcile_InitialDiscovery_DoesNotDoubleStartRefreshLoops`.
 3. Calls `gh.FetchInstallationRepositories` for **every** installation, regardless of
    `repository_selection` — that endpoint already returns the full accessible set for
    `"all"`-mode installations too; the pre-#1641 code only called it for `"selected"`

--- a/adrs/1641-pruefer-installation-derived-repo-discovery.md
+++ b/adrs/1641-pruefer-installation-derived-repo-discovery.md
@@ -1,0 +1,270 @@
+# ADR 1641: Installation-Derived Repo Discovery
+
+**Date**: 2026-08-27
+**Status**: Accepted
+**Issue**: #1641 — derive the watched repo set from App installations instead of a hand-maintained list
+
+## Context
+
+Which repos Pruefer reviews was decided by a hand-maintained list, `watched_repos` in
+`.pruefer/config.yaml`. That list had to be kept in sync by hand with a second source
+of truth — where the GitHub App is actually installed — and the two drifted silently:
+installing the App on a new repo did nothing until an operator remembered to edit the
+config and restart or reload.
+
+Until #1253 merged, `watched_repos` was not merely a convenience list — it was the
+**containment boundary**. Pruefer's GitHub App was, at the time, shared and public
+(`handarbeit-pruefer`, installable by anyone); ADR-1233 made the set of installations
+Pruefer ever tokenized equal exactly the set of owners named in `watched_repos`,
+structurally, so a stranger installing the public App on their own account was never
+contacted — their owner never appeared in this operator's config. Inverting the model
+(install-derived discovery) would have removed that protection by construction: a
+stranger's installation would have enlisted *this operator's* daemon.
+
+#1253 changed the premise: each operator now bootstraps and authenticates as their
+own dedicated App via the manifest flow (`internal/githubauth.Reconciler`), superseding
+the shared-App model entirely. "Installed on it" and "mine to review" became the same
+statement for every operator, unblocking this issue.
+
+## Decisions
+
+### 1. `Reconciler.Derive` becomes the single source of truth for "which repos does Pruefer review"
+
+`internal/githubauth/derive.go` (new) adds `Reconciler.Derive(ctx, filter []string,
+maxRepos int, logf) (DerivedRepoSet, []DetachedAuth, error)`, replacing `Reconcile`'s
+former owner-scoped discovery loop (which only ever iterated owners already present in
+`watched_repos`). `Derive` instead:
+
+1. Calls `gh.FetchAppInstallations` with **no owner list as input** — every installation
+   of the operator's own App, discovered unconditionally.
+2. For each installation not already known (by lower-cased account), mints a token
+   (`mintAuth`) and commits it via the existing `CommitOwnerAuth` (starting its refresh
+   loop). An *already*-known owner's existing client/`Auth` is reused unchanged — no
+   re-mint — so a repo gained or lost under an already-known installation never
+   disturbs that installation's running refresh loop.
+3. Calls `gh.FetchInstallationRepositories` for **every** installation, regardless of
+   `repository_selection` — that endpoint already returns the full accessible set for
+   `"all"`-mode installations too; the pre-#1641 code only called it for `"selected"`
+   mode because it only ever needed a watched-repo verification, not full enumeration.
+   Calling it unconditionally is what makes org-level and account-level derivation
+   (AC2) work with no special-casing, and is also what "future repos become pollable
+   with no restart" (AC2/AC3) requires: this call is never cached, only ever a live
+   re-fetch, on every `Derive` call.
+4. Unions every installation's repos into the **installation grant**.
+5. If `filter` (the caller's `watched_repos`) is non-empty, intersects it in — **never
+   widening** beyond the grant — and reports (via `DerivedRepoSet.FilteredOut`) any
+   filter entry the grant doesn't cover, rather than silently dropping or including it
+   (R3/AC4).
+6. Sorts the result deterministically (lower-cased `owner/repo` ascending) and, if
+   `maxRepos > 0` and the result exceeds it, caps it there (R5) — same repos dropped
+   consistently across calls, not an arbitrary API-order cut.
+7. Detects owners that had a client before this call but no longer have a matching
+   installation, and detaches them via the existing `RemoveOwners` (returned as
+   `[]DetachedAuth` for the caller to drain-then-stop, exactly `RemoveOwners`' existing
+   contract).
+
+`Reconcile`'s own (first-run) call and every later re-derivation trigger (R2) call the
+same `Derive` method — it is safe to call repeatedly specifically because steps 2–3
+above never trust a cache.
+
+**Pinned-installation mode (`AppInstallationID != 0`) is fully exempt** — `Derive`
+short-circuits to `derivedSetForPinned`, building a `DerivedRepoSet` directly from
+`filter` with the pinned installation ID attributed to every entry, preserving
+ADR-1233 Decision 4/ADR-1253 Decision 6's byte-for-byte compat guarantee. There is
+nothing to discover when the operator has already asserted one installation covers
+everything.
+
+### 2. `watched_repos` stays the config key; semantics invert to an optional intersection filter (R3)
+
+Renaming was considered and rejected: the field is deeply threaded through `Config`,
+`yamlConfig`, `reload:"live"` tagging, `TestConfig_AllFieldsClassified`, and the
+README. Keeping the name with redefined, clearly-documented semantics — absent means
+"everything the installations grant"; present means "the intersection, never wider" —
+was judged materially lower-risk than a rename-plus-migration for the same outcome.
+
+### 3. `FetchAppInstallations`/`FetchInstallationRepositories` gain real pagination
+
+Both `github/app.go` functions previously capped at 100 results (GitHub's max
+`per_page`) with only a package-level log line noting the possible truncation —
+adequate when these were a verification check against a short, operator-typed list
+(ADR-1233 Decision 6 explicitly deferred fixing this). Once installation enumeration
+became the *primary* discovery path, silently under-deriving past 100 items became a
+materially worse failure mode: previously a missed entry mis-reported one
+`watched_repos` line as "not authorized" (a visible, per-repo symptom); post-#1641 the
+same gap would have silently omitted repos from the derived set with no watched_repos
+entry ever having flagged the discrepancy.
+
+Both functions now follow real page-number pagination (`?page=N`, not the Link
+header — every caller already builds page-numbered URLs directly) up to a fixed
+50-page ceiling (≈5,000 items) — a sanity bound distinct from R5's own operator-facing
+cap, guarding only against an unbounded loop against a pathological or misbehaving
+server. Both return a `truncated bool` alongside their result, used to warn (not
+silently under-derive) when even that ceiling is hit.
+
+### 4. R5's cap (`max_derived_repos`, default 200) is a separate knob from pagination
+
+Applied last, after the full union and any `watched_repos` filter — over the same
+deterministic sort pagination itself doesn't need but capping does, so the same repos
+are dropped consistently across re-derivations. `<= 0` disables the cap entirely (an
+explicit operator opt-out, not the default). A loud warning is logged
+(`derived N repo(s)... (capped from M by max_derived_repos=200)`) and surfaced via
+`DerivedRepoSetEvent.Capped`/`CapApplied` in the TUI. Raising the cap or narrowing via
+`watched_repos` are both documented as the operator's ways out.
+
+### 5. Derived state lives on `Daemon`, not `Config`
+
+`Daemon.derived githubauth.DerivedRepoSet` (guarded by the existing `cfgMu`, alongside
+`Config`/`Clients`) holds the result of the most recent `rederiveRepos` call — this is
+what `poll()` and `isWatchedRepo` (`eventsink.go`) now read, replacing their direct
+`Config.WatchedRepos` reads. Putting it on `Config` instead would have made
+`applyConfigReload`'s generic per-field reflection loop compare it against
+`LoadConfig`'s always-empty candidate value on every SIGHUP, incorrectly
+reporting/clobbering a field no operator ever sets directly.
+
+`ApplyDerivedRepos(set, clients)` — the write side, mirroring `ApplyReload`'s existing
+concurrency-safety shape — rebuilds `Daemon.Clients` **wholesale** from the newly
+derived installation set, rather than diffing added/removed clients incrementally.
+Installation counts for one operator's own dedicated App are small (their own
+orgs/repos, not a shared-App fleet), so a full rebuild on every re-derivation is cheap
+and removes an entire class of incremental-diff bugs.
+
+### 6. One uniform re-derivation ticker for both poll-mode and event-driven mode (R2)
+
+`Daemon.runRederivationTicker`, driven by `Config.RepoRederivationInterval` (default
+10 minutes), is started unconditionally in `Daemon.Run` — before either
+`runPollOnly` or `runEventDriven` — rather than as a mode-specific mechanism.
+Poll-mode had zero installation-change awareness at all before this issue and needed
+one from scratch; event-driven mode already had `ReconciliationFallbackInterval` as a
+low-frequency PR-listing safety net, but growing that ticker a second, differently-scoped
+responsibility (re-derivation, not just re-polling) was judged more confusing than a
+second, purpose-built ticker.
+
+The `installation`/`installation_repositories` webhook event
+(`pruefer/eventsink.go`'s `installEventTypes`) and the ticker both converge on the
+same `Daemon.triggerRederivation` entry point — a `CompareAndSwap`-guarded coalescing
+wrapper (mirroring `triggerReconciliationPoll`'s existing shape) around
+`rederiveRepos`, which itself chains into `triggerReconciliationPoll` afterward so a
+newly-derived repo becomes pollable in the same cycle (AC3), not only on the next
+fallback tick.
+
+### 7. SIGHUP `watched_repos` changes no longer mint or remove any owner's auth
+
+Since `Derive` now mints every installation unconditionally (Decision 1), a SIGHUP
+`watched_repos` edit (`pruefer/execute.go`'s `handleReload`) no longer needs the
+two-phase `MintOwnerAuth`/`CommitOwnerAuth` mint-then-commit or the
+`RemoveOwners`/`drainThenStopAuth` detach-then-drain sequence ADR-1253's 2026-08-26
+addendum built for exactly this trigger. `handleReload` now only applies the merged
+`Config` (`ApplyReload(merged, nil, nil)`) and, if `watched_repos` or
+`max_derived_repos` changed, calls `daemon.triggerRederivation` — the same
+re-derivation path an installation webhook event or the ticker uses. This does still
+make a live call to re-list each installation's accessible repos (not a purely local
+re-intersection against a cached grant), since `Derive`'s own contract is "always
+re-fetch, never trust a cache" — accepted as a reasonable cost for a rare,
+operator-initiated event, and it reuses the exact same machinery as every other
+re-derivation trigger rather than a bespoke local-only path.
+
+`MintOwnerAuth` and `internal/githubauth/installations.go`'s `verifyRepoAccess` have
+no remaining production caller after this change. They are **deliberately retained**
+rather than deleted in this same change — both still compile, are still exercised by
+their own existing unit tests, and remain a correct, documented (if now-unused)
+mechanism. Full removal was judged a separable cleanup not worth the additional
+churn/review-diff size in a change already touching this much surface area; see
+Consequences below.
+
+### 8. Containment (AC7) is structural, not an added check
+
+`FetchAppInstallations` is JWT-scoped to the calling App's own identity by GitHub's
+own API contract — it is physically incapable of returning another App's
+installations. No owner-allowlist, denylist, or "trusted accounts" list was
+introduced to compensate, per the issue's own explicit instruction not to
+reintroduce the hand-maintained list this issue exists to remove while looking like
+it has been removed. The regression test
+(`TestDerive_Containment_NeverContactsOtherAppsInstallations`,
+`internal/githubauth/derive_test.go`) simulates two distinct App identities against
+one fake server, differentiated by the JWT's `iss` claim, and asserts a `Reconciler`
+built from App A's own key never sees or contacts App B's installations or mints a
+token against them — proving the property structurally rather than by convention.
+
+### 9. R4 observability: log lines plus a TUI `DerivedRepoSetEvent`
+
+Every `Derive` call's result is logged (`logRederivedRepos`, `pruefer/daemon.go`): one
+line per installation found (account, `repository_selection`, repo count), a summary
+line (total repos derived, installation count, capped/truncated warnings), and one
+line per `watched_repos` entry the grant doesn't cover. The same result is re-expressed
+as a TUI event — `ptui.DerivedRepoSetEvent` carrying `[]DerivedRepoEntry{Repo,
+InstallationID}` (per-repo provenance) and `[]DerivedInstallationSummary`
+(per-installation aggregate), kept as plain, dependency-free types so `pruefer/tui`
+never imports `internal/githubauth` (see ADR-1253's Decision 8 amendment). The repos
+pane (`RepoPaneComponent`) re-seeds itself from this event — adding newly-derived
+repos, dropping ones no longer granted, and preserving poll status (last poll time, PR
+count, last error) for every repo still present — rather than a naive full replace,
+which would have discarded in-flight poll state on every re-derivation tick.
+
+## Consequences
+
+**Positive:**
+- Installing the App on a new repo, org, or account is picked up automatically — no
+  config edit, no restart, satisfying AC1/AC2/AC3 directly.
+- `watched_repos` becomes genuinely optional operator preference (R3), no longer a
+  required, hand-maintained, silently-drifting list.
+- The pagination gap flagged as a known, deferred limitation in ADR-1233 Decision 6 is
+  finally addressed, specifically because it became a correctness issue (not just an
+  inert gap) once discovery, not verification, depended on it.
+- R5's cap and R4's observability ship in the same change as the discovery inversion,
+  rather than as follow-ups — directly mitigating the issue's own top-flagged risk (an
+  operator's effective review set silently expanding the moment this ships).
+
+**Negative / Trade-offs:**
+- **Behavior change for existing deployments**: an operator currently relying on
+  `watched_repos` to narrow a broad `"all"`-mode installation sees their effective set
+  *expand* to everything the installation grants the moment this ships, unless they
+  already relied on `watched_repos`' new intersection semantics being correct (they
+  are, and are covered by AC4's own test coverage) — this is the deliberate, accepted
+  outcome of R1, not an oversight; R4's visibility exists specifically so this
+  expansion is never silent.
+- **SIGHUP `watched_repos` reload now makes a live GitHub call** (re-listing every
+  installation's accessible repos via `Derive`) rather than a purely local
+  re-intersection against an already-known grant, as the original Plan for this issue
+  briefly considered. Judged an acceptable cost for a rare, operator-initiated event
+  in exchange for reusing one re-derivation code path everywhere, instead of a second,
+  divergent one for this trigger alone.
+- **`MintOwnerAuth`/`verifyRepoAccess` are dead code as of this change** (see Decision
+  7) — a real, if scoped and explicitly-noted, deviation from immediately deleting
+  now-unused code. A future cleanup issue can remove them (and their dedicated tests)
+  once this change has soaked.
+- **`Derive`'s per-installation enumeration cost scales with installation count**,
+  each re-derivation trigger requiring a `FetchInstallationRepositories` call per
+  known installation (plus a mint for any newly-discovered one). Small for one
+  operator's own dedicated App; a misconfigured `repo_rederivation_interval` set very
+  low could still add unnecessary GitHub API load — documented with its default and
+  rationale in `cmd/pruefer/README.md`.
+- **`ApplyDerivedRepos`'s wholesale `Clients` rebuild** briefly replaces the map under
+  the `cfgMu` write lock rather than diffing it — a reader racing exactly that window
+  sees a fully-swapped map, never a partially-updated one (the same guarantee
+  `ApplyReload` already provides for its own incremental merge), covered by an
+  explicit concurrency test (`TestDaemon_ConcurrentReloadDuringActivePoll`) exercising
+  both write paths against an active poll cycle simultaneously under `-race`.
+
+## Related Work
+
+- ADR-1233 (`adrs/1233-pruefer-multi-installation-auth.md`) — the
+  owner-derived-from-`watched_repos` discovery direction this issue reverses; amended
+  in the same change to mark Decision 1's security framing superseded while noting
+  Decisions 2–4/6 retained and reused.
+- ADR-1253 (`adrs/1253-github-app-manifest-auth-reconciler.md`) — the per-operator App
+  reconciler (`internal/githubauth.Reconciler`) this issue's `Derive` method extends,
+  and the prerequisite (#1253) that made installation-derived discovery safe in the
+  first place; amended in the same change (Decision 8's narrow TUI exception, and a
+  new addendum describing the SIGHUP-reload behavior change).
+- ADR-1640 (`adrs/1640-pruefer-config-reload.md`) — the `cfgMu`/`config()`/`client()`/
+  `ApplyReload` concurrency boundary and "diff at the right granularity, apply
+  atomically, log a summary" discipline this issue's re-derivation machinery reuses
+  (`ApplyDerivedRepos` alongside `ApplyReload`, not replacing it).
+- #1428, #1563 — prior "silent state change with no record" failure modes R4's
+  log-plus-TUI observability convention is modeled on.
+- `cmd/pruefer/README.md` — Setup/config-reference/TUI sections rewritten in the same
+  change to document the inverted model, the new `max_derived_repos`/
+  `repo_rederivation_interval` config keys, and the new per-repo installation
+  provenance the TUI now shows.
+
+**References:** [cmd/pruefer/README.md](../cmd/pruefer/README.md)

--- a/cmd/pruefer/README.md
+++ b/cmd/pruefer/README.md
@@ -27,12 +27,10 @@ Pruefer authenticates as a GitHub App so its reviews are attributed to a genuine
 
 ### First run: automatic setup (recommended)
 
-There's no GitHub App to hand-register up front. Just configure your watched repos and run Pruefer:
+There's no GitHub App to hand-register up front, and no repo list to maintain — which repos Pruefer reviews is decided by where you install the App (see [Installation-derived repo discovery](#installation-derived-repo-discovery) below), not by a config file. A minimal config is enough to get started:
 
 ```yaml
 # .pruefer/config.yaml
-watched_repos:
-  - your-org/repo-one
 poll_interval_seconds: 120
 model: sonnet
 ```
@@ -55,14 +53,13 @@ With no usable local App credentials, Pruefer walks you through GitHub's **App M
    Since `<port>` is only known once Pruefer prints the setup URL, start Pruefer first (with `-no-browser` so it doesn't try to open a browser on the remote host itself), copy the port out of the printed URL, open the SSH tunnel, then open that URL in your local browser.
 2. On GitHub, confirm (or rename) the App and click **Create GitHub App**. GitHub redirects back to Pruefer's local listener with the new App's credentials — the flow expires after about an hour if abandoned; just restart Pruefer to try again, your existing config is never disturbed by an abandoned or expired attempt.
 3. Pruefer saves the private key to `.pruefer/app-private-key.pem` and everything else (App ID, slug, webhook secret, client ID/secret) to `.pruefer/app-state.json` — both gitignored, neither ever committed or logged.
-4. Pruefer then checks every account named in `watched_repos` for an installation of the new App, printing guided-installation progress as it goes:
+4. Pruefer then discovers every installation of the new App — there's nothing to install yet on a genuinely fresh App, so it prints a guided-installation link instead:
 
    ```
-   ✓ your-org/repo-one authorized
-   ! another-org has no installation → opening https://github.com/apps/<your-app-slug>/installations/new …
+   no installations found for this App yet — install it on a repo, org, or account to begin reviewing: https://github.com/apps/<your-app-slug>/installations/new
    ```
 
-   Follow the printed link, install the App on the account, and restart Pruefer — reconciliation re-runs automatically and picks up the new installation. (Adding a repo under a new owner later works the same way: add it to `watched_repos` and restart.)
+   Follow the printed link and install the App on whichever repo, org, or account you want reviewed — no restart needed: Pruefer picks up the new installation on its own within `repo_rederivation_interval` (default 10m), or immediately on the next `installation`/`installation_repositories` webhook event in `event_source: hookdeck` mode. See [Installation-derived repo discovery](#installation-derived-repo-discovery) below for the full model, including how to narrow what gets reviewed with `watched_repos`.
 
 The App this flow creates is **yours** — owned by whichever GitHub account performs the manifest flow, installable only where you choose to install it. This is not a shared, publicly-installable App: each user who sets up their own Pruefer instance this way gets their own dedicated App, with no credential ever shared between instances.
 
@@ -70,7 +67,7 @@ The App this flow creates is **yours** — owned by whichever GitHub account per
 
 Once `.pruefer/app-private-key.pem` and `.pruefer/app-state.json` exist (or a manually-registered `github_app_id` + PEM — see below), every later run finds valid local credentials and skips the manifest flow entirely, going straight to installation/token verification — no prompts, no behavior change to *auth* from run to run.
 
-**One caveat**: `.pruefer/app-state.json` is now written (created if absent) on every run, in every mode — including manual/compat setup and even when `github_app_installation_id` is pinned, not only after the manifest flow. It holds a diagnostics-only cache of which watched repos each installation authorizes (`InstallationRepoCache`), refreshed on each reconciliation pass; it is never read to make an authorization decision — `.pruefer/app-private-key.pem` plus a live GitHub call is always authoritative — and it does not change which repos Pruefer polls. An existing single-App deployment that never had this file before this change will see it appear on the first run after upgrading; nothing else about that deployment's behavior changes.
+**One caveat**: `.pruefer/app-state.json` is now written (created if absent) on every run, in every mode — including manual/compat setup and even when `github_app_installation_id` is pinned, not only after the manifest flow. It holds a diagnostics-only cache of which repos each installation authorizes (`InstallationRepoCache`), refreshed on each re-derivation; it is never read to make an authorization decision — `.pruefer/app-private-key.pem` plus a live GitHub call is always authoritative — and it does not change which repos Pruefer polls. An existing single-App deployment that never had this file before this change will see it appear on the first run after upgrading; nothing else about that deployment's behavior changes.
 
 ### Manual setup (compat mode)
 
@@ -89,7 +86,7 @@ Registering the App yourself is still fully supported — this is also how Pruef
 4. **Where can this GitHub App be installed?**: your choice — "Only on this account" is simplest for a single org.
 5. Click **Create GitHub App**. Note the **App ID** shown on the app's settings page.
 6. Scroll to **Private keys** and click **Generate a private key**. This downloads a `.pem` file — save it somewhere outside version control (Pruefer's default config gitignores `.pruefer/*.pem`).
-7. Click **Install App** (left sidebar) and install it on every account whose repos you list in `watched_repos` — a single App installed on multiple orgs/accounts is exactly the multi-org setup this section leads into.
+7. Click **Install App** (left sidebar) and install it on every repo, org, or account you want reviewed — a single App installed on multiple orgs/accounts is exactly the multi-org setup this section leads into.
 8. Set `github_app_id` in `.pruefer/config.yaml` (or `PRUEFER_GITHUB_APP_ID` / `--github-app-id`) and place the downloaded key per "Place the private key" below.
 
 Once `github_app_id` and the PEM are both in place, the reconciler recognizes them as valid local credentials on the very next run and never attempts the manifest flow.
@@ -103,14 +100,9 @@ Put the private key `.pem` file (however it was produced — manifest flow or ma
 Create `.pruefer/config.yaml` (or use flags/env vars — see Configuration below):
 
 ```yaml
-watched_repos:
-  - your-org/repo-one
-  - your-org/repo-two
-  - another-org/repo-three   # a different owner works too — see below
-
 # github_app_id: 123456                        # only needed for manual/compat setup — see above
 # github_app_private_key_path: .pruefer/app-private-key.pem  # default shown
-# github_app_installation_id: 0  # 0 = derive installations from watched_repos (see below)
+# github_app_installation_id: 0  # 0 = derive from installations (see "Installation-derived repo discovery" below)
 # github_app_state_path: .pruefer/app-state.json  # default shown — reconciler-owned; never hand-edit this file
 # no_browser: false  # true = never attempt to open a local browser during first-run setup
 
@@ -120,22 +112,31 @@ effort: medium
 concurrency_cap: 3
 max_diff_bytes: 500000
 
+# watched_repos:                    # optional narrowing filter — see "Installation-derived repo discovery" below
+#   - your-org/repo-one
+#   - another-org/repo-three        # a different owner works too
+# max_derived_repos: 200            # cap on how many repos a single derivation may yield; <= 0 disables the cap
+# repo_rederivation_interval: 10m   # how often to re-derive the repo set from installations on a timer
+
 # excluded_authors: [dependabot]
 # excluded_labels: [skip-review]
 # excluded_paths: ["testdata/schema/**"]  # a vendored schema or generated fixture directory — filtered per file, applied before max_diff_bytes (see above)
 # request_changes_threshold: high  # low, medium, high, or critical — see below
 ```
 
-### Multi-org installations and the public-App safety property
+### Installation-derived repo discovery
 
-`watched_repos` may list repos across any number of distinct owners. Pruefer groups the list by owner and, for each distinct owner, resolves that owner's App installation and mints it its own token — refreshed independently on its own schedule. A single daemon can therefore cover every org/account the App is installed on, driven entirely by `watched_repos`.
+Which repos Pruefer reviews is decided by where the GitHub App is installed, not by a hand-maintained list. Install the App on a single repo, an entire org (current and future repos), or a whole user account, and Pruefer derives its review set directly from that installation's grant — enumerated fresh on every re-derivation (see below), so a repo created after the install shows up with no config change and no restart. A single daemon covers every installation of its own App, across any number of distinct owners, each with its own independently-refreshed token.
 
-**The set of installations Pruefer ever tokenizes equals exactly the set of owners appearing in `watched_repos` — nothing more.** Pruefer never enumerates "every installation of the App" and acts on all of them; it only ever mints a token for, or contacts, an owner an operator explicitly listed. This is what makes a per-user dedicated App (or, in compat mode, a public App) safe: a stranger who installs it on their own account is structurally untouched, because no `watched_repos` entry names them. There's no separate allowlist to maintain — "only act on my own accounts" falls directly out of what's in the config.
+**`watched_repos` is an optional narrowing filter, not the primary input.** Absent (or empty, the default), Pruefer reviews everything its installations grant. Present, it narrows the derived set to the intersection — it can only ever *exclude* a repo the installation grants, never *include* one it doesn't; a `watched_repos` entry naming a repo no installation covers is reported in the log and TUI, not silently dropped or added. Use it to keep the App installed broadly (e.g. an entire org) while still holding a repo or two out of review, without uninstalling the App from just that repo.
 
-Two consequences:
+**The containment boundary is the operator's own dedicated App identity (see [Setup](#setup) above), not `watched_repos` membership.** Every installation of *your* App is derived and authorized regardless of whether `watched_repos` names it — a stranger installing their own separate App on their own account is structurally never contacted, because `GET /app/installations` is scoped to the calling App's identity by GitHub's own API contract. This is different from Pruefer's original shared-App model (see ADR-1233), where `watched_repos` itself was the containment boundary; since each operator now runs their own dedicated App (ADR-1253), that boundary comes from App identity instead, and `watched_repos` is free to become what it always felt like it should be — operator preference, not safety-critical config.
 
-- If an owner in `watched_repos` has **no** matching App installation, Pruefer keeps running for every other, already-authorized owner and prints a guided installation link for the missing one (see "First run" above) rather than failing to start.
-- `github_app_installation_id` is a **legacy pin/escape hatch**, not a requirement. Leave it at `0` (or unset) to let Pruefer resolve one installation per watched owner automatically — this works cleanly even with several installations, as long as every owner you watch has one. Set it explicitly only to force every watched repo through one specific installation's token regardless of owner (the old single-installation behavior, preserved byte-for-byte for existing single-org deployments).
+**Runtime re-derivation (no restart needed):** installing/uninstalling the App, or changing its repository selection, is picked up automatically — via the `installation`/`installation_repositories` webhook event in `event_source: hookdeck` mode, or on a timer (`repo_rederivation_interval`, default `10m`) in every mode, including plain polling. The daemon logs, and the TUI's Watched Repos pane shows, exactly which repos it derived, from which installation, and any `watched_repos` entry that wasn't covered — see [Terminal UI](#terminal-ui) below.
+
+**Bounding a large installation (`max_derived_repos`, default `200`):** an org-level install on an account with hundreds of repos would otherwise make every one of them pollable at once, multiplying poll cost, GraphQL budget, and `concurrency_cap` contention with no warning. Once the derived set (after any `watched_repos` filter) exceeds this cap, Pruefer sorts it deterministically (`owner/repo` ascending) and keeps only the first `max_derived_repos` — the same repos are dropped consistently across re-derivations, not an arbitrary API-order cut — and logs a loud warning naming the cap. Raise `max_derived_repos`, or narrow with `watched_repos`, to cover the rest. Set it to `0` or a negative value to disable the cap entirely (an explicit, deliberate opt-out — not the default).
+
+`github_app_installation_id` is a **legacy pin/escape hatch**, not a requirement. Leave it at `0` (or unset) to let Pruefer derive from installations automatically. Set it explicitly only to force every review through one specific installation's token regardless of owner (the old single-installation behavior, preserved byte-for-byte for existing single-org deployments) — installation-derived discovery does not apply in this mode; the pinned installation's repos are trusted wholesale.
 
 ### Run it
 
@@ -213,7 +214,7 @@ If you see the drift banner: check that `hookdeck.webhook_secret_env` (and the e
 
 When run with a real terminal attached (both stdin and stdout), Pruefer launches an interactive TUI by default — the same `bubbletea`/`bubbles`/`lipgloss` stack and model/update/view structure as Fabrik's own `tui/` package, so the two feel like the same family of tool. It shows:
 
-- Watched repositories, each with its last poll time, PR count found, and last error (if any).
+- Watched repositories, each with its last poll time, PR count found, last error (if any), and the installation that granted it — plus, when relevant, a warning if the last derivation hit a pagination ceiling or the `max_derived_repos` cap, and a count of `watched_repos` entries not covered by any installation. See [Installation-derived repo discovery](#installation-derived-repo-discovery).
 - PRs currently under review, with elapsed time since the review started.
 - Recently completed reviews (last 200, in-memory — not persisted across restarts): repo, PR, outcome (reviewed / skipped / errored), turns, cost, and duration.
 - Skipped PRs with their reason, covering every skip category Pruefer tracks (draft, self-authored, excluded author/label/path, already reviewed at this head SHA, diff too large).
@@ -251,7 +252,9 @@ Every field is classified as either **live** (applied immediately) or **restart-
 
 | YAML key | Reload |
 |---|---|
-| `watched_repos` | Live. Added repos are polled starting the next cycle; removed repos stop being polled starting the next cycle. A review already in flight for a repo removed mid-reload is allowed to finish — it is never cancelled, and its owner's installation token keeps refreshing until it does, so its remaining GitHub API calls never fail with a stale token either. |
+| `watched_repos` | Live. A changed filter triggers an immediate re-derivation of the reviewed set (see [Installation-derived repo discovery](#installation-derived-repo-discovery)) rather than waiting for the next timer tick — no owner's installation token is minted or removed by this alone, since every installation is already authorized independently of `watched_repos`. A review already in flight for a repo the new filter excludes is allowed to finish — it is never cancelled. |
+| `max_derived_repos` | Live. A lowered or raised cap takes effect on the next re-derivation, triggered immediately by the same change. |
+| `repo_rederivation_interval` | Live, effective starting the next tick. |
 | `poll_interval_seconds` | Live, effective starting the next cycle. |
 | `model` | Live. |
 | `effort` | Live. |
@@ -276,9 +279,7 @@ Every field is classified as either **live** (applied immediately) or **restart-
 
 A restart-only field that changed is always named in the reload's log summary — never silently ignored. A malformed config file leaves the previously running config completely untouched (not partially applied) and logs the parse error; fix the file and send `SIGHUP` again.
 
-**Adding a repo under a new owner** mints that owner's GitHub App installation token as part of the reload. If the owner has no matching installation, the *entire* reload fails with a clear error (not just that one repo) — the running config, including any other change bundled in the same edit, is left untouched. Install the app on the new owner first, then retry the reload.
-
-Every reload — successful or not — logs a diff-style summary to `.pruefer/pruefer.log` (see [Logging](#logging) above): every repo added/removed, every changed field's old → new value, and every restart-only field that was reported but not applied.
+Every reload — successful or not — logs a diff-style summary to `.pruefer/pruefer.log` (see [Logging](#logging) above): every repo added/removed from `watched_repos`, every changed field's old → new value, and every restart-only field that was reported but not applied.
 
 ## On-demand re-review
 
@@ -315,7 +316,9 @@ Precedence, highest to lowest: **flag > environment variable > YAML config file 
 
 | Flag | Env var | YAML key | Default | Notes |
 |---|---|---|---|---|
-| `--repos` | `PRUEFER_REPOS` | `watched_repos` | (none — required) | Comma-separated `owner/repo` list |
+| `--repos` | `PRUEFER_REPOS` | `watched_repos` | (none — optional) | Comma-separated `owner/repo` list; an optional intersection filter over the installation-derived set, never the primary input — see [Installation-derived repo discovery](#installation-derived-repo-discovery) |
+| `--max-derived-repos` | `PRUEFER_MAX_DERIVED_REPOS` | `max_derived_repos` | `200` | Caps a single derivation's result (R5); `<= 0` disables the cap. See [Installation-derived repo discovery](#installation-derived-repo-discovery) |
+| `--repo-rederivation-interval` | `PRUEFER_REPO_REDERIVATION_INTERVAL` | `repo_rederivation_interval` | `10m` | Go duration; how often to re-derive the repo set from installations on a timer, independent of any installation webhook event |
 | `--poll-interval` | `PRUEFER_POLL_INTERVAL` | `poll_interval_seconds` | `120` | Seconds |
 | `--model` | `PRUEFER_MODEL` | `model` | `sonnet` | Claude model |
 | `--effort` | `PRUEFER_EFFORT` | `effort` | `medium` | `low`, `medium`, `high`, or `max` |
@@ -328,7 +331,7 @@ Precedence, highest to lowest: **flag > environment variable > YAML config file 
 | `--request-changes-threshold` | `PRUEFER_REQUEST_CHANGES_THRESHOLD` | `request_changes_threshold` | (none — disabled) | `low`, `medium`, `high`, or `critical`; submits `REQUEST_CHANGES` when a finding's severity meets or exceeds this tier. See [Severity-gated REQUEST_CHANGES](#severity-gated-request_changes). |
 | `--github-app-id` | `PRUEFER_GITHUB_APP_ID` | `github_app_id` | (none) | Only needed for manual/compat setup — omit it to let first-run manifest setup create and track its own App ID in `github_app_state_path` instead |
 | `--github-app-private-key-path` | `PRUEFER_GITHUB_APP_PRIVATE_KEY_PATH` | `github_app_private_key_path` | `.pruefer/app-private-key.pem` | Read from and written to by both manifest and manual setup |
-| `--github-app-installation-id` | `PRUEFER_GITHUB_APP_INSTALLATION_ID` | `github_app_installation_id` | `0` (derive from `watched_repos`) | Legacy pin: set to force every watched repo through one specific installation, regardless of owner |
+| `--github-app-installation-id` | `PRUEFER_GITHUB_APP_INSTALLATION_ID` | `github_app_installation_id` | `0` (derive from installations) | Legacy pin: set to force every review through one specific installation, regardless of owner — installation-derived discovery does not apply in this mode |
 | `--github-app-state-path` | `PRUEFER_GITHUB_APP_STATE_PATH` | `github_app_state_path` | `.pruefer/app-state.json` | Reconciler-owned (App ID once manifest-created, slug, webhook secret, client ID/secret); never hand-edit this file |
 | `--no-browser` | `PRUEFER_NO_BROWSER` | `no_browser` | `false` | Skip attempting to open a local browser during first-run manifest setup — the setup URL is always printed regardless |
 | `--config` | `PRUEFER_CONFIG` | — | `.pruefer/config.yaml` | Path to the YAML config file itself |

--- a/github/app.go
+++ b/github/app.go
@@ -167,77 +167,128 @@ func appRequest(method, baseURL, path, jwt string, result interface{}) error {
 	return nil
 }
 
+// appFetchPageSize is the page size every paginated App-auth REST fetcher
+// below requests — GitHub's max per_page (its own default is only 30).
+const appFetchPageSize = 100
+
+// appFetchMaxPages bounds FetchAppInstallations/FetchInstallationRepositories'
+// pagination as a sanity ceiling (50 pages * 100/page = 5,000 items),
+// distinct from Pruefer's own operator-facing max_derived_repos cap (R5):
+// this only guards against an unbounded loop against a pathological or
+// misbehaving server, not a deliberate operator choice about review scope.
+const appFetchMaxPages = 50
+
+// fetchAppInstallationsPage and fetchInstallationRepositoriesPage's shared
+// page-loop shape: accumulate pages until one comes back short of
+// appFetchPageSize (the last page) or appFetchMaxPages is reached (in which
+// case truncated=true is returned instead of an error — see the two
+// functions' doc comments for why silent-but-flagged truncation, not a hard
+// failure, is the right trade-off once installation enumeration is the
+// *primary* discovery path, not a verification check against a short list).
+func fetchAppPaginated[T any](fetchPage func(page int) ([]T, error)) (items []T, truncated bool, err error) {
+	for page := 1; page <= appFetchMaxPages; page++ {
+		chunk, err := fetchPage(page)
+		if err != nil {
+			return nil, false, err
+		}
+		items = append(items, chunk...)
+		if len(chunk) < appFetchPageSize {
+			return items, false, nil
+		}
+	}
+	return items, true, nil
+}
+
 // FetchAppInstallations lists every installation of the GitHub App
 // authenticated by jwt via GET /app/installations. Used for dynamic
 // installation discovery: Pruefer watches whatever repos the App is
 // installed on, so adding a repo requires only a GitHub-side installation
 // change, not a Pruefer config or code change (see ADR-1113).
 //
-// Capped at 100 results (GitHub's max per_page, requested explicitly —
-// GitHub's own default is only 30) rather than following the Link header to
-// fetch further pages; a warning is logged (not silently truncated) when
-// exactly 100 are returned, since more installations may exist. Matches the
-// same convention as ListOpenPRs (prs.go): a self-hosted App realistically
-// has far fewer installations than this cap, so full pagination isn't
-// warranted, but silently truncating past it would make an owner beyond
-// page 1 look uninstalled and trigger a spurious guided-install prompt.
-func FetchAppInstallations(baseURL, jwt string) ([]AppInstallation, error) {
-	var raw []struct {
+// Follows GitHub's page-number pagination (not the Link header — every
+// caller already builds page-numbered URLs directly) up to appFetchMaxPages;
+// the returned truncated bool is true if that ceiling was hit before a short
+// page was seen, i.e. more installations may exist beyond what was
+// returned. Once installation enumeration is the primary repo-discovery
+// path (handarbeit/fabrik#1641), silently returning an incomplete list here
+// would make an owner beyond the ceiling look uninstalled and trigger a
+// spurious guided-install prompt — callers must check truncated rather than
+// assume completeness.
+func FetchAppInstallations(baseURL, jwt string) ([]AppInstallation, bool, error) {
+	type rawInstallation struct {
 		ID      int64 `json:"id"`
 		Account struct {
 			Login string `json:"login"`
 		} `json:"account"`
 		RepositorySelection string `json:"repository_selection"`
 	}
-	if err := appRequest("GET", baseURL, "/app/installations?per_page=100", jwt, &raw); err != nil {
-		return nil, fmt.Errorf("fetching app installations: %w", err)
+	raw, truncated, err := fetchAppPaginated(func(page int) ([]rawInstallation, error) {
+		var chunk []rawInstallation
+		path := fmt.Sprintf("/app/installations?per_page=%d&page=%d", appFetchPageSize, page)
+		if err := appRequest("GET", baseURL, path, jwt, &chunk); err != nil {
+			return nil, err
+		}
+		return chunk, nil
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("fetching app installations: %w", err)
 	}
-	if len(raw) == 100 {
-		logf(0, "app", "FetchAppInstallations: received exactly 100 results — more installations may exist (pagination not implemented)\n")
+	if truncated {
+		logf(0, "app", "FetchAppInstallations: hit the %d-page pagination ceiling (%d installations returned) — more installations may exist\n", appFetchMaxPages, len(raw))
 	}
 	out := make([]AppInstallation, len(raw))
 	for i, inst := range raw {
 		out[i] = AppInstallation{ID: inst.ID, Account: inst.Account.Login, RepositorySelection: inst.RepositorySelection}
 	}
-	return out, nil
+	return out, truncated, nil
 }
 
 // FetchInstallationRepositories lists the repositories an installation
-// actually grants access to, via GET /installation/repositories. Only
-// meaningful (and only ever called) for an installation whose
-// RepositorySelection is "selected" — an "all" installation grants access to
-// every current and future repo on the account, so there is nothing to
-// enumerate. Unlike the App-JWT-authenticated calls above, this endpoint is
-// scoped to the installation's own identity: it must be authenticated with
-// that installation's access token, not the App's JWT.
+// actually grants access to, via GET /installation/repositories. Called for
+// every installation regardless of RepositorySelection: unlike an earlier
+// revision of this function (which only bothered for "selected"-mode
+// installations, since "all" was assumed to cover every current and future
+// repo), the endpoint already returns the full accessible set for "all"
+// installations too — calling it unconditionally is what lets
+// installation-derived discovery (handarbeit/fabrik#1641) enumerate an
+// "all"-mode installation's repos without a separate code path, and also
+// makes newly-created repos under an "all" installation show up on the next
+// call with no special casing. Unlike the App-JWT-authenticated calls
+// above, this endpoint is scoped to the installation's own identity: it
+// must be authenticated with that installation's access token, not the
+// App's JWT.
 //
-// Capped at 100 results (GitHub's max per_page, requested explicitly —
-// GitHub's own default is only 30) rather than following the Link header to
-// fetch further pages; a warning is logged (not silently truncated) when
-// exactly 100 are returned, since more accessible repositories may exist —
-// see FetchAppInstallations' doc comment for the same convention and its
-// rationale. Unlike installation counts, a "selected"-mode installation
-// granting more than 100 repos is plausible for a larger org, so a missed
-// repo beyond page 1 would be reported by verifyRepoAccess as unauthorized
-// even though access is actually granted; the warning at least surfaces
-// that the result may be incomplete instead of failing silently.
-func FetchInstallationRepositories(baseURL, installationToken string) ([]string, error) {
-	var result struct {
-		Repositories []struct {
-			FullName string `json:"full_name"`
-		} `json:"repositories"`
+// Follows GitHub's page-number pagination up to appFetchMaxPages, exactly
+// like FetchAppInstallations above; the returned truncated bool reports
+// whether the ceiling was hit. A "selected"-mode installation granting more
+// than 100 repos is plausible for a larger org, and an "all"-mode
+// installation on a large account even more so — callers must check
+// truncated rather than assume the returned list is complete.
+func FetchInstallationRepositories(baseURL, installationToken string) ([]string, bool, error) {
+	type repoEntry struct {
+		FullName string `json:"full_name"`
 	}
-	if err := appRequest("GET", baseURL, "/installation/repositories?per_page=100", installationToken, &result); err != nil {
-		return nil, fmt.Errorf("fetching installation repositories: %w", err)
+	raw, truncated, err := fetchAppPaginated(func(page int) ([]repoEntry, error) {
+		var result struct {
+			Repositories []repoEntry `json:"repositories"`
+		}
+		path := fmt.Sprintf("/installation/repositories?per_page=%d&page=%d", appFetchPageSize, page)
+		if err := appRequest("GET", baseURL, path, installationToken, &result); err != nil {
+			return nil, err
+		}
+		return result.Repositories, nil
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("fetching installation repositories: %w", err)
 	}
-	if len(result.Repositories) == 100 {
-		logf(0, "app", "FetchInstallationRepositories: received exactly 100 results — more accessible repositories may exist (pagination not implemented)\n")
+	if truncated {
+		logf(0, "app", "FetchInstallationRepositories: hit the %d-page pagination ceiling (%d repositories returned) — more accessible repositories may exist\n", appFetchMaxPages, len(raw))
 	}
-	out := make([]string, len(result.Repositories))
-	for i, r := range result.Repositories {
+	out := make([]string, len(raw))
+	for i, r := range raw {
 		out[i] = r.FullName
 	}
-	return out, nil
+	return out, truncated, nil
 }
 
 // MintInstallationToken exchanges a JWT for a short-lived (~1 hour)

--- a/github/app_test.go
+++ b/github/app_test.go
@@ -140,9 +140,12 @@ func TestFetchAppInstallations(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	installs, err := FetchAppInstallations(srv.URL, "test-jwt")
+	installs, truncated, err := FetchAppInstallations(srv.URL, "test-jwt")
 	if err != nil {
 		t.Fatalf("FetchAppInstallations: %v", err)
+	}
+	if truncated {
+		t.Error("truncated = true, want false for a short (2-item) page")
 	}
 	if len(installs) != 2 {
 		t.Fatalf("expected 2 installations, got %d", len(installs))
@@ -152,15 +155,58 @@ func TestFetchAppInstallations(t *testing.T) {
 	}
 }
 
-// TestFetchAppInstallations_WarnsAtCap is the regression test for a review
-// finding: /app/installations was called with no per_page/pagination at
-// all (GitHub's own default page size is only 30), so an App installed on
-// more accounts than fit on one page would silently miss the rest —
-// Reconcile would then treat an already-installed owner beyond page 1 as
-// uninstalled and walk the operator through a spurious guided-install flow.
+// TestFetchAppInstallations_Paginates is the regression test for real
+// pagination (#1641): a first page of exactly 100 (the old cap) followed by
+// a second, short page must all be accumulated, not just the first page
+// returned to the caller.
+func TestFetchAppInstallations_Paginates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		var entries []map[string]interface{}
+		switch page {
+		case "1":
+			entries = make([]map[string]interface{}, 100)
+			for i := range entries {
+				entries[i] = map[string]interface{}{"id": i + 1, "account": map[string]string{"login": "someorg"}}
+			}
+		case "2":
+			entries = []map[string]interface{}{
+				{"id": 101, "account": map[string]string{"login": "anotherorg"}},
+			}
+		default:
+			t.Errorf("unexpected page %q", page)
+		}
+		json.NewEncoder(w).Encode(entries)
+	}))
+	defer srv.Close()
+
+	installs, truncated, err := FetchAppInstallations(srv.URL, "test-jwt")
+	if err != nil {
+		t.Fatalf("FetchAppInstallations: %v", err)
+	}
+	if truncated {
+		t.Error("truncated = true, want false: the second page was short, so pagination reached its natural end")
+	}
+	if len(installs) != 101 {
+		t.Fatalf("expected 101 installations across both pages, got %d", len(installs))
+	}
+	if installs[100].ID != 101 || installs[100].Account != "anotherorg" {
+		t.Errorf("installs[100] = %+v", installs[100])
+	}
+}
+
+// TestFetchAppInstallations_WarnsAtPaginationCeiling is the regression test
+// for a review finding: /app/installations was called with no
+// per_page/pagination at all (GitHub's own default page size is only 30),
+// so an App installed on more accounts than fit on one page would silently
+// miss the rest — Reconcile would then treat an already-installed owner
+// beyond page 1 as uninstalled and walk the operator through a spurious
+// guided-install flow. Now that real pagination follows every full page,
+// only a server that never returns a short page (the appFetchMaxPages
+// ceiling) is genuinely ambiguous — that's what this test simulates.
 // Mirrors TestListOpenPRs_WarnsAtCap's "explicit per_page cap + warn, don't
 // silently truncate" convention (prs.go).
-func TestFetchAppInstallations_WarnsAtCap(t *testing.T) {
+func TestFetchAppInstallations_WarnsAtPaginationCeiling(t *testing.T) {
 	var warned bool
 	Logf = func(issueNumber int, tag, format string, args ...any) {
 		if tag == "app" {
@@ -176,19 +222,25 @@ func TestFetchAppInstallations_WarnsAtCap(t *testing.T) {
 		}
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Every page comes back full (100 items) — never a short page — so
+		// the loop must run out at appFetchMaxPages rather than looping
+		// forever.
 		json.NewEncoder(w).Encode(entries)
 	}))
 	defer srv.Close()
 
-	installs, err := FetchAppInstallations(srv.URL, "test-jwt")
+	installs, truncated, err := FetchAppInstallations(srv.URL, "test-jwt")
 	if err != nil {
 		t.Fatalf("FetchAppInstallations: %v", err)
 	}
-	if len(installs) != 100 {
-		t.Fatalf("expected 100 installations, got %d", len(installs))
+	if !truncated {
+		t.Error("truncated = false, want true: every page was full, so the ceiling should have been hit")
+	}
+	if want := appFetchMaxPages * appFetchPageSize; len(installs) != want {
+		t.Fatalf("expected %d installations (ceiling), got %d", want, len(installs))
 	}
 	if !warned {
-		t.Error("expected a warning when exactly 100 installations are returned (more may exist)")
+		t.Error("expected a warning when the pagination ceiling is hit (more installations may exist)")
 	}
 }
 
@@ -201,7 +253,7 @@ func TestFetchAppInstallations_DecodesRepositorySelection(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	installs, err := FetchAppInstallations(srv.URL, "test-jwt")
+	installs, _, err := FetchAppInstallations(srv.URL, "test-jwt")
 	if err != nil {
 		t.Fatalf("FetchAppInstallations: %v", err)
 	}
@@ -236,9 +288,12 @@ func TestFetchInstallationRepositories(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	repos, err := FetchInstallationRepositories(srv.URL, "ghs_installation_token")
+	repos, truncated, err := FetchInstallationRepositories(srv.URL, "ghs_installation_token")
 	if err != nil {
 		t.Fatalf("FetchInstallationRepositories: %v", err)
+	}
+	if truncated {
+		t.Error("truncated = true, want false for a short (2-item) page")
 	}
 	want := []string{"someorg/repo-one", "someorg/repo-two"}
 	if len(repos) != len(want) {
@@ -251,15 +306,53 @@ func TestFetchInstallationRepositories(t *testing.T) {
 	}
 }
 
-// TestFetchInstallationRepositories_WarnsAtCap is the regression test for a
-// review finding: /installation/repositories was called with no
-// per_page/pagination at all (GitHub's own default page size is only 30),
-// so a "selected"-mode installation granting access to more repos than fit
-// on one page would silently miss the rest — verifyRepoAccess would then
-// report a genuinely-authorized repo beyond page 1 as unauthorized. Mirrors
-// TestListOpenPRs_WarnsAtCap's "explicit per_page cap + warn, don't
-// silently truncate" convention (prs.go).
-func TestFetchInstallationRepositories_WarnsAtCap(t *testing.T) {
+// TestFetchInstallationRepositories_Paginates mirrors
+// TestFetchAppInstallations_Paginates for the sibling endpoint: a full first
+// page followed by a short second page must be fully accumulated.
+func TestFetchInstallationRepositories_Paginates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		var repos []map[string]interface{}
+		switch page {
+		case "1":
+			repos = make([]map[string]interface{}, 100)
+			for i := range repos {
+				repos[i] = map[string]interface{}{"full_name": fmt.Sprintf("someorg/repo-%d", i)}
+			}
+		case "2":
+			repos = []map[string]interface{}{{"full_name": "someorg/repo-100"}}
+		default:
+			t.Errorf("unexpected page %q", page)
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"repositories": repos})
+	}))
+	defer srv.Close()
+
+	got, truncated, err := FetchInstallationRepositories(srv.URL, "ghs_installation_token")
+	if err != nil {
+		t.Fatalf("FetchInstallationRepositories: %v", err)
+	}
+	if truncated {
+		t.Error("truncated = true, want false: the second page was short")
+	}
+	if len(got) != 101 {
+		t.Fatalf("expected 101 repositories across both pages, got %d", len(got))
+	}
+	if got[100] != "someorg/repo-100" {
+		t.Errorf("got[100] = %q, want someorg/repo-100", got[100])
+	}
+}
+
+// TestFetchInstallationRepositories_WarnsAtPaginationCeiling is the
+// regression test for a review finding: /installation/repositories was
+// called with no per_page/pagination at all (GitHub's own default page size
+// is only 30), so an installation granting access to more repos than fit on
+// one page would silently miss the rest. Now that real pagination follows
+// every full page, only a server that never returns a short page (the
+// appFetchMaxPages ceiling) is genuinely ambiguous — that's what this test
+// simulates. Mirrors TestListOpenPRs_WarnsAtCap's "explicit per_page cap +
+// warn, don't silently truncate" convention (prs.go).
+func TestFetchInstallationRepositories_WarnsAtPaginationCeiling(t *testing.T) {
 	var warned bool
 	Logf = func(issueNumber int, tag, format string, args ...any) {
 		if tag == "app" {
@@ -273,19 +366,23 @@ func TestFetchInstallationRepositories_WarnsAtCap(t *testing.T) {
 		repos[i] = map[string]interface{}{"full_name": fmt.Sprintf("someorg/repo-%d", i)}
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Every page comes back full — never a short page.
 		json.NewEncoder(w).Encode(map[string]interface{}{"repositories": repos})
 	}))
 	defer srv.Close()
 
-	got, err := FetchInstallationRepositories(srv.URL, "ghs_installation_token")
+	got, truncated, err := FetchInstallationRepositories(srv.URL, "ghs_installation_token")
 	if err != nil {
 		t.Fatalf("FetchInstallationRepositories: %v", err)
 	}
-	if len(got) != 100 {
-		t.Fatalf("expected 100 repositories, got %d", len(got))
+	if !truncated {
+		t.Error("truncated = false, want true: every page was full, so the ceiling should have been hit")
+	}
+	if want := appFetchMaxPages * appFetchPageSize; len(got) != want {
+		t.Fatalf("expected %d repositories (ceiling), got %d", want, len(got))
 	}
 	if !warned {
-		t.Error("expected a warning when exactly 100 repositories are returned (more may exist)")
+		t.Error("expected a warning when the pagination ceiling is hit (more repositories may exist)")
 	}
 }
 
@@ -296,7 +393,7 @@ func TestFetchInstallationRepositories_ErrorStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := FetchInstallationRepositories(srv.URL, "ghs_bad"); err == nil {
+	if _, _, err := FetchInstallationRepositories(srv.URL, "ghs_bad"); err == nil {
 		t.Fatal("expected error on 403, got nil")
 	}
 }
@@ -435,10 +532,10 @@ func TestAppRequest_EmptyBaseURLFallsBackToDefaultBaseURL(t *testing.T) {
 	})
 	defer func() { appHTTPClient.Transport = origTransport }()
 
-	if _, err := FetchAppInstallations("", "test-jwt"); err != nil {
+	if _, _, err := FetchAppInstallations("", "test-jwt"); err != nil {
 		t.Fatalf("FetchAppInstallations: %v", err)
 	}
-	want := defaultBaseURL + "/app/installations?per_page=100"
+	want := defaultBaseURL + "/app/installations?per_page=100&page=1"
 	if capturedURL != want {
 		t.Errorf("request URL = %q, want %q (empty baseURL must fall back to defaultBaseURL)", capturedURL, want)
 	}
@@ -451,7 +548,7 @@ func TestAppRequest_ErrorStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := FetchAppInstallations(srv.URL, "test-jwt"); err == nil {
+	if _, _, err := FetchAppInstallations(srv.URL, "test-jwt"); err == nil {
 		t.Fatal("expected error on 403, got nil")
 	}
 }

--- a/internal/githubauth/derive.go
+++ b/internal/githubauth/derive.go
@@ -1,0 +1,372 @@
+package githubauth
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// DerivedRepo is one repo Reconciler.Derive found accessible, paired with
+// enough provenance (R4) to explain why it's in the effective set: which
+// account's installation granted it, and that installation's own ID.
+type DerivedRepo struct {
+	// Repo is "owner/repo" in GitHub's canonical casing (the account login
+	// and repo full_name Derive actually observed), not necessarily the
+	// casing a watched_repos filter entry used to name it.
+	Repo string
+	// Owner is Repo's owner half, split out for callers (e.g. Pruefer's
+	// poll()) that need it without re-parsing Repo.
+	Owner string
+	// RepoName is Repo's repo half.
+	RepoName       string
+	InstallationID int64
+}
+
+// DerivedInstallation summarizes one installation's contribution to a
+// DerivedRepoSet, for logging and TUI display (R4) — independent of whether
+// any of its repos survived an optional watched_repos filter (R3) or the
+// max_derived_repos cap (R5): an operator asking "why isn't repo X being
+// reviewed" needs to see that its installation was found and enumerated,
+// even if X itself was filtered or capped out.
+type DerivedInstallation struct {
+	Account             string
+	InstallationID      int64
+	RepositorySelection string
+	// RepoCount is how many repos this installation's own
+	// FetchInstallationRepositories call returned, before any filter or cap
+	// was applied.
+	RepoCount int
+}
+
+// DerivedRepoSet is the result of one Reconciler.Derive call: every repo the
+// App's installations currently grant access to, after the optional
+// watched_repos intersection filter (R3) and the max_derived_repos cap (R5)
+// have both been applied. Repos is sorted by lower-cased "owner/repo" so
+// repeated Derive calls against an unchanged grant produce byte-identical
+// output, and so R5's cap always drops the same repos rather than an
+// arbitrary API-order tail.
+type DerivedRepoSet struct {
+	Repos []DerivedRepo
+	// FilteredOut lists every filter entry that named a repo the
+	// installation grant does not actually cover — reported, per R3/AC4,
+	// rather than silently absent from Repos with no explanation.
+	FilteredOut []string
+	// Truncated is true when either FetchAppInstallations' or any
+	// installation's FetchInstallationRepositories' pagination ceiling was
+	// hit — the grant may be larger than what was actually enumerated.
+	Truncated bool
+	// Capped is true when max_derived_repos (R5) trimmed the union.
+	Capped bool
+	// CapApplied is the max_derived_repos value in effect when Capped is
+	// true; zero otherwise.
+	CapApplied int
+	// Installations summarizes every installation Derive found, regardless
+	// of whether any of its repos survived filtering/capping.
+	Installations []DerivedInstallation
+}
+
+// TotalGranted returns how many repos the installation grant covered before
+// any watched_repos filter or max_derived_repos cap was applied — the sum of
+// every DerivedInstallation's RepoCount. Used by logging/TUI to distinguish
+// "your installations grant N repos" from "M are actually being reviewed
+// after your filter/cap," which len(Repos) alone can't show once either has
+// trimmed the set.
+func (s DerivedRepoSet) TotalGranted() int {
+	total := 0
+	for _, inst := range s.Installations {
+		total += inst.RepoCount
+	}
+	return total
+}
+
+// derivedRepoFromFullName splits a GitHub "owner/repo" full_name into a
+// DerivedRepo, attributed to installationID. Returns ok=false for a
+// malformed full_name (missing/extra slash) — defensive only; GitHub's own
+// API contract always returns a well-formed full_name.
+func derivedRepoFromFullName(fullName string, installationID int64) (DerivedRepo, bool) {
+	owner, repo, ok := splitOwnerRepo(fullName)
+	if !ok {
+		return DerivedRepo{}, false
+	}
+	return DerivedRepo{Repo: fullName, Owner: owner, RepoName: repo, InstallationID: installationID}, true
+}
+
+// derivedSetForPinned builds a DerivedRepoSet directly from filter (the
+// operator's watched_repos) for a pinned-installation Reconciler
+// (opts.AppInstallationID != 0) — see ADR-1233 Decision 4. This compat mode
+// is deliberately exempt from R1's installation-derived inversion: the
+// operator has explicitly asserted the pinned installation covers every
+// watched repo, so there is nothing to discover, filter, or cap. Calling
+// Derive again later (e.g. a re-derivation trigger, R2) against a pinned
+// Reconciler is therefore a safe, cheap no-op that reproduces the same set,
+// rather than requiring every re-derivation call site to special-case
+// pinned mode itself.
+func derivedSetForPinned(filter []string, pinnedInstallationID int64) DerivedRepoSet {
+	var repos []DerivedRepo
+	for _, spec := range filter {
+		if dr, ok := derivedRepoFromFullName(spec, pinnedInstallationID); ok {
+			repos = append(repos, dr)
+		}
+	}
+	sortDerivedRepos(repos)
+	return DerivedRepoSet{Repos: repos}
+}
+
+func sortDerivedRepos(repos []DerivedRepo) {
+	sort.Slice(repos, func(i, j int) bool {
+		return strings.ToLower(repos[i].Repo) < strings.ToLower(repos[j].Repo)
+	})
+}
+
+// Derive re-derives the effective repo set from the App's current
+// installations — the R1 inversion this issue exists to make: installations
+// are the desired state, and filter (the operator's optional watched_repos,
+// R3) is an intersection applied on top, never a widening. Safe to call
+// repeatedly (Reconcile's first call, and any later re-derivation trigger,
+// R2): it always re-fetches every installation's accessible-repo list live
+// from GitHub rather than trusting any cache, which is also what makes
+// AC2/AC3's "future repos become pollable with no restart" requirement true
+// for free — a newly created repo under an "all" or "selected" installation
+// simply appears in the next call's FetchInstallationRepositories result.
+//
+// An owner already holding a client (from a prior Derive call) keeps that
+// same *Auth/*gh.Client — Derive never re-mints a token for an installation
+// it already knows about, only for one it's seeing for the first time (or
+// re-seeing after a prior mint failure) — so a repo gained or lost under an
+// already-known installation never disturbs that installation's running
+// refresh loop. An owner whose installation has disappeared since the last
+// call is detached (mirroring RemoveOwners) and returned as a DetachedAuth
+// for the caller to drain-then-stop once it's confirmed safe (exactly the
+// contract RemoveOwners' own doc comment already establishes) — Derive
+// itself never stops a refresh loop, since a review dispatched before this
+// call may still be holding a *gh.Client backed by it.
+//
+// maxRepos <= 0 means no cap (R5's max_derived_repos "unset/off" case).
+//
+// In pinned-installation mode (r.pinnedInstallationID != 0), this is a
+// no-op wrapper around derivedSetForPinned — see that function's doc
+// comment for why R1 doesn't apply there.
+func (r *Reconciler) Derive(ctx context.Context, filter []string, maxRepos int, logf func(format string, args ...any)) (DerivedRepoSet, []DetachedAuth, error) {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+
+	r.mu.Lock()
+	pinnedID := r.pinnedInstallationID
+	appID := r.appID
+	privateKey := r.privateKey
+	baseURL := r.baseURL
+	botLogin := r.botLogin
+	existingClients := make(map[string]*gh.Client, len(r.clients))
+	for k, v := range r.clients {
+		existingClients[k] = v
+	}
+	r.mu.Unlock()
+
+	if pinnedID != 0 {
+		set := derivedSetForPinned(filter, pinnedID)
+		r.mu.Lock()
+		r.lastDerived = set
+		r.mu.Unlock()
+		return set, nil, nil
+	}
+
+	jwt, err := gh.BuildAppJWT(appID, privateKey)
+	if err != nil {
+		return DerivedRepoSet{}, nil, fmt.Errorf("building app JWT: %w", err)
+	}
+	installations, instTruncated, err := gh.FetchAppInstallations(baseURL, jwt)
+	if err != nil {
+		return DerivedRepoSet{}, nil, fmt.Errorf("discovering app installations: %w", err)
+	}
+
+	byAccount := make(map[string]gh.AppInstallation, len(installations))
+	for _, inst := range installations {
+		byAccount[strings.ToLower(inst.Account)] = inst
+	}
+
+	var allRepos []DerivedRepo
+	var instSummaries []DerivedInstallation
+	truncated := instTruncated
+	newMintErrors := make(map[string]error)
+
+	for _, inst := range installations {
+		key := strings.ToLower(inst.Account)
+		client, ok := existingClients[key]
+		if !ok {
+			a, err := mintAuth(appID, inst.ID, botLogin, privateKey, baseURL)
+			if err != nil {
+				logf("! minting token for installation %d (account %q) failed: %v", inst.ID, inst.Account, err)
+				newMintErrors[key] = err
+				continue
+			}
+			installLogf := func(format string, args ...any) {
+				logf("installation %d: "+format, append([]any{inst.ID}, args...)...)
+			}
+			client = r.CommitOwnerAuth(ctx, inst.Account, a, true, installLogf)
+		}
+
+		repos, repoTruncated, err := gh.FetchInstallationRepositories(baseURL, client.Token())
+		if err != nil {
+			logf("! listing accessible repositories for installation %d (account %q) failed: %v", inst.ID, inst.Account, err)
+		}
+		if repoTruncated {
+			truncated = true
+		}
+		for _, full := range repos {
+			if dr, ok := derivedRepoFromFullName(full, inst.ID); ok {
+				allRepos = append(allRepos, dr)
+			}
+		}
+		instSummaries = append(instSummaries, DerivedInstallation{
+			Account: inst.Account, InstallationID: inst.ID,
+			RepositorySelection: inst.RepositorySelection, RepoCount: len(repos),
+		})
+	}
+
+	// Owners that had a client before this call but no longer have a
+	// matching installation lose it now — the mirror image of the mint-new
+	// branch above. Detached, not stopped: see RemoveOwners' doc comment.
+	var goneOwners []string
+	for owner := range existingClients {
+		if _, ok := byAccount[owner]; !ok {
+			goneOwners = append(goneOwners, owner)
+		}
+	}
+	detached := r.RemoveOwners(goneOwners)
+
+	set := DerivedRepoSet{Truncated: truncated, Installations: instSummaries}
+
+	if len(filter) > 0 {
+		filterSet := make(map[string]bool, len(filter))
+		for _, f := range filter {
+			filterSet[strings.ToLower(f)] = true
+		}
+		granted := make(map[string]bool, len(allRepos))
+		for _, dr := range allRepos {
+			granted[strings.ToLower(dr.Repo)] = true
+		}
+		var kept []DerivedRepo
+		for _, dr := range allRepos {
+			if filterSet[strings.ToLower(dr.Repo)] {
+				kept = append(kept, dr)
+			}
+		}
+		for _, f := range filter {
+			if !granted[strings.ToLower(f)] {
+				set.FilteredOut = append(set.FilteredOut, f)
+			}
+		}
+		allRepos = kept
+	}
+
+	sortDerivedRepos(allRepos)
+
+	if maxRepos > 0 && len(allRepos) > maxRepos {
+		set.Capped = true
+		set.CapApplied = maxRepos
+		logf("! derived repo set (%d repos) exceeds max_derived_repos=%d — capping to the first %d (sorted owner/repo); raise max_derived_repos, or narrow watched_repos, to review the rest", len(allRepos), maxRepos, maxRepos)
+		allRepos = allRepos[:maxRepos]
+	}
+
+	set.Repos = allRepos
+
+	r.mu.Lock()
+	for k, v := range newMintErrors {
+		r.mintErrors[k] = v
+	}
+	r.lastDerived = set
+	r.mu.Unlock()
+
+	return set, detached, nil
+}
+
+// logDerivedSet logs a DerivedRepoSet's contents for R4's "make the derived
+// set observable" requirement — the failure mode this exists to prevent is a
+// repo silently joining or leaving the review set with no record. Called
+// once per Reconcile/Derive round (initial and every re-derivation trigger).
+func logDerivedSet(set DerivedRepoSet, logf func(format string, args ...any)) {
+	for _, inst := range set.Installations {
+		logf("✓ installation %d (%s, repository_selection=%s): %d repo(s) accessible", inst.InstallationID, inst.Account, inst.RepositorySelection, inst.RepoCount)
+	}
+	if len(set.Installations) == 0 {
+		return
+	}
+	suffix := ""
+	if set.Capped {
+		suffix = fmt.Sprintf(" (capped from %d by max_derived_repos=%d)", set.TotalGranted(), set.CapApplied)
+	}
+	if set.Truncated {
+		suffix += " — WARNING: pagination ceiling was hit while enumerating installations/repos; the actual grant may be larger than shown"
+	}
+	logf("derived %d repo(s) to review across %d installation(s)%s", len(set.Repos), len(set.Installations), suffix)
+	for _, f := range set.FilteredOut {
+		logf("! watched_repos entry %q is not covered by any installation's grant — excluded", f)
+	}
+}
+
+// guideMissingInstallations logs (and, at most once per Reconcile call,
+// attempts to open a browser to) the App's guided-install URL for every
+// distinct owner named in opts.WatchedRepos that set's installations don't
+// cover — the same operator guidance the pre-#1641 discovery loop gave for a
+// watched-but-uninstalled owner, preserved even though discovery itself is
+// no longer driven by watched_repos. When opts.WatchedRepos is empty
+// entirely (AC1's primary case — installations are the sole input) and no
+// installation exists at all, a single "install the app somewhere" hint is
+// logged instead, since there is no specific owner name to guide toward.
+func guideMissingInstallations(opts Options, slug string, set DerivedRepoSet, logf func(format string, args ...any)) {
+	installURL := fmt.Sprintf("https://github.com/apps/%s/installations/new", slug)
+
+	if len(opts.WatchedRepos) == 0 {
+		if len(set.Installations) == 0 {
+			logf("no installations found for this App yet — install it on a repo, org, or account to begin reviewing: %s", installURL)
+		}
+		return
+	}
+
+	ownersInstalled := make(map[string]bool, len(set.Installations))
+	for _, inst := range set.Installations {
+		ownersInstalled[strings.ToLower(inst.Account)] = true
+	}
+
+	// openedInstallBrowser bounds guided-installation browser-opening to at
+	// most once per call: watched_repos can plausibly span several owners
+	// with no installation at all, and popping open a separate browser
+	// tab/window per missing owner is surprising, unlike the single-flow
+	// manifest bootstrap. Every missing owner still gets its install URL
+	// logged; only the first one also gets an actual browser-open attempt.
+	openedInstallBrowser := false
+	for _, owner := range distinctOwnersLogging(opts.WatchedRepos, logf) {
+		if ownersInstalled[strings.ToLower(owner)] {
+			continue
+		}
+		notFoundDesc := "has no installation"
+		if set.Truncated {
+			notFoundDesc = "not found among the installations/repos that could be enumerated — the App may have more than could be listed (see the truncation warning above), so this could be a pagination gap rather than an actual missing installation; re-run reconciliation to confirm before assuming it needs installing"
+		}
+		if !opts.NoBrowser && !openedInstallBrowser {
+			logf("! %s %s → opening %s …", owner, notFoundDesc, installURL)
+			if err := openBrowser(installURL); err != nil {
+				logf("could not open browser automatically (%v) — visit the URL above manually", err)
+			}
+			openedInstallBrowser = true
+		} else {
+			logf("! %s %s → %s", owner, notFoundDesc, installURL)
+		}
+	}
+}
+
+// LastDerived returns the DerivedRepoSet from the most recent Derive call —
+// including the one Reconcile itself performs at construction. Callers (e.g.
+// Pruefer's SIGHUP watched_repos reload) use this to re-intersect a changed
+// filter against the already-known installation grant without triggering a
+// fresh, live re-derivation — see this issue's "SIGHUP no longer mints"
+// consequence.
+func (r *Reconciler) LastDerived() DerivedRepoSet {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastDerived
+}

--- a/internal/githubauth/derive.go
+++ b/internal/githubauth/derive.go
@@ -87,6 +87,22 @@ type DerivedRepoSet struct {
 	// CapApplied is the max_derived_repos value in effect when Capped is
 	// true; zero otherwise.
 	CapApplied int
+	// PreCapCount is len(Repos) immediately before the max_derived_repos cap
+	// was applied — i.e. after the watched_repos filter (R3), but before R5's
+	// cap — valid only when Capped is true. This is deliberately NOT the same
+	// as TotalGranted(): TotalGranted sums every installation's raw,
+	// pre-filter RepoCount, which is a different (and, whenever a narrowing
+	// watched_repos filter is also active, larger) number than what the cap
+	// actually sliced from. Reporting TotalGranted() as "capped from N" would
+	// misattribute repos the filter already excluded to the cap instead —
+	// found by review (handarbeit-pruefer): a 1000-repo grant narrowed by
+	// watched_repos to 250 and then capped to 200 would otherwise log
+	// "capped from 1000 by max_derived_repos=200", implying the cap dropped
+	// 800 repos when it actually dropped only 50 (the filter dropped the
+	// other 750) — the opposite of R4's "make the derived set observable"
+	// goal. See logDerivedSet/Pruefer's logRederivedRepos, which both report
+	// this instead of TotalGranted() in the "capped from" message.
+	PreCapCount int
 	// Installations summarizes every installation Derive found, regardless
 	// of whether any of its repos survived filtering/capping.
 	Installations []DerivedInstallation
@@ -329,6 +345,7 @@ func (r *Reconciler) derive(ctx context.Context, filter []string, maxRepos int, 
 	if maxRepos > 0 && len(allRepos) > maxRepos {
 		set.Capped = true
 		set.CapApplied = maxRepos
+		set.PreCapCount = len(allRepos)
 		logf("! derived repo set (%d repos) exceeds max_derived_repos=%d — capping to the first %d (sorted owner/repo); raise max_derived_repos, or narrow watched_repos, to review the rest", len(allRepos), maxRepos, maxRepos)
 		allRepos = allRepos[:maxRepos]
 	}
@@ -366,7 +383,7 @@ func logDerivedSet(set DerivedRepoSet, logf func(format string, args ...any)) {
 	}
 	suffix := ""
 	if set.Capped {
-		suffix = fmt.Sprintf(" (capped from %d by max_derived_repos=%d)", set.TotalGranted(), set.CapApplied)
+		suffix = fmt.Sprintf(" (capped from %d by max_derived_repos=%d)", set.PreCapCount, set.CapApplied)
 	}
 	if set.Truncated {
 		suffix += " — WARNING: pagination ceiling was hit while enumerating installations/repos; the actual grant may be larger than shown"

--- a/internal/githubauth/derive.go
+++ b/internal/githubauth/derive.go
@@ -39,6 +39,13 @@ type DerivedInstallation struct {
 	// FetchInstallationRepositories call returned, before any filter or cap
 	// was applied.
 	RepoCount int
+	// RepoListError is non-empty when this installation's
+	// FetchInstallationRepositories call itself failed (e.g. a transient
+	// network error) — RepoCount is 0 in that case, but that 0 means
+	// "unknown this round," not "genuinely zero accessible repos." Callers
+	// (see logDerivedSet) must say so rather than implying the installation
+	// was actually confirmed to grant nothing.
+	RepoListError string
 }
 
 // DerivedRepoSet is the result of one Reconciler.Derive call: every repo the
@@ -210,8 +217,10 @@ func (r *Reconciler) Derive(ctx context.Context, filter []string, maxRepos int, 
 		}
 
 		repos, repoTruncated, err := gh.FetchInstallationRepositories(baseURL, client.Token())
+		repoListErr := ""
 		if err != nil {
 			logf("! listing accessible repositories for installation %d (account %q) failed: %v", inst.ID, inst.Account, err)
+			repoListErr = err.Error()
 		}
 		if repoTruncated {
 			truncated = true
@@ -224,6 +233,7 @@ func (r *Reconciler) Derive(ctx context.Context, filter []string, maxRepos int, 
 		instSummaries = append(instSummaries, DerivedInstallation{
 			Account: inst.Account, InstallationID: inst.ID,
 			RepositorySelection: inst.RepositorySelection, RepoCount: len(repos),
+			RepoListError: repoListErr,
 		})
 	}
 
@@ -290,6 +300,10 @@ func (r *Reconciler) Derive(ctx context.Context, filter []string, maxRepos int, 
 // once per Reconcile/Derive round (initial and every re-derivation trigger).
 func logDerivedSet(set DerivedRepoSet, logf func(format string, args ...any)) {
 	for _, inst := range set.Installations {
+		if inst.RepoListError != "" {
+			logf("✓ installation %d (%s, repository_selection=%s): repo-access verification was skipped this round (listing failed — see error above); the installation is still authorized", inst.InstallationID, inst.Account, inst.RepositorySelection)
+			continue
+		}
 		logf("✓ installation %d (%s, repository_selection=%s): %d repo(s) accessible", inst.InstallationID, inst.Account, inst.RepositorySelection, inst.RepoCount)
 	}
 	if len(set.Installations) == 0 {

--- a/internal/githubauth/derive.go
+++ b/internal/githubauth/derive.go
@@ -46,6 +46,23 @@ type DerivedInstallation struct {
 	// (see logDerivedSet) must say so rather than implying the installation
 	// was actually confirmed to grant nothing.
 	RepoListError string
+	// MintError is non-empty when minting a token for this installation
+	// itself failed (e.g. a transient GitHub API error) — RepoListError is
+	// always empty in that case, since FetchInstallationRepositories was
+	// never even attempted with no token to call it with. Distinguishing
+	// this from "no installation at all" matters because
+	// guideMissingInstallations otherwise cannot tell a genuinely
+	// uninstalled owner apart from one whose installation exists but whose
+	// mint transiently failed this round — without this field, both looked
+	// identical (absent from Installations entirely), so the former's
+	// guided-install prompt (and, unless NoBrowser is set, an actual
+	// browser-open) fired for the latter too: a misleading "go install the
+	// app" message, and an unwanted browser popup, for what's usually a
+	// transient error that the next reconciliation retry would clear on
+	// its own. See ClientForRepo's mintErrors-aware error message, which
+	// already made this same distinction for the "no client" case —
+	// Installations must make it too, for the same reason.
+	MintError string
 }
 
 // DerivedRepoSet is the result of one Reconciler.Derive call: every repo the
@@ -157,6 +174,26 @@ func sortDerivedRepos(repos []DerivedRepo) {
 // no-op wrapper around derivedSetForPinned — see that function's doc
 // comment for why R1 doesn't apply there.
 func (r *Reconciler) Derive(ctx context.Context, filter []string, maxRepos int, logf func(format string, args ...any)) (DerivedRepoSet, []DetachedAuth, error) {
+	return r.derive(ctx, filter, maxRepos, logf, true)
+}
+
+// derive is Derive's implementation, additionally parameterized by
+// startLoopsForNewOwners: true for every public Derive call (including
+// every re-derivation trigger — installation webhook, the periodic ticker,
+// a SIGHUP watched_repos edit), since nothing else will ever start a
+// refresh loop for an owner one of those calls newly discovers. false only
+// for Reconcile's own first call (see Reconcile's non-pinned discovery
+// path): that caller's own contract (execute.go) is to call
+// Reconciler.RunRefreshLoops itself immediately after Reconcile returns,
+// covering every owner Reconcile just discovered — starting a loop here too
+// would start a *second*, independent refresh-loop goroutine for the exact
+// same *Auth. Auth.startRefreshLoop's cancel func is a single field, so the
+// second call's cancel silently overwrites the first — Auth.Stop (and thus
+// Pruefer's drainThenStopAuth/RemoveOwners cleanup, ADR-1640) could then
+// only ever cancel the second loop, permanently leaking the first for the
+// life of the process, alongside doubling every installation's token-mint
+// API traffic. See TestReconcile_InitialDiscovery_DoesNotDoubleStartRefreshLoops.
+func (r *Reconciler) derive(ctx context.Context, filter []string, maxRepos int, logf func(format string, args ...any), startLoopsForNewOwners bool) (DerivedRepoSet, []DetachedAuth, error) {
 	if logf == nil {
 		logf = func(string, ...any) {}
 	}
@@ -208,12 +245,26 @@ func (r *Reconciler) Derive(ctx context.Context, filter []string, maxRepos int, 
 			if err != nil {
 				logf("! minting token for installation %d (account %q) failed: %v", inst.ID, inst.Account, err)
 				newMintErrors[key] = err
+				// Still recorded in instSummaries — this installation was
+				// found, it just couldn't be minted this round. Omitting it
+				// here would make guideMissingInstallations (which decides
+				// "installed" purely from Installations membership) unable
+				// to tell this apart from a genuinely uninstalled owner. See
+				// MintError's own doc comment.
+				instSummaries = append(instSummaries, DerivedInstallation{
+					Account: inst.Account, InstallationID: inst.ID,
+					RepositorySelection: inst.RepositorySelection,
+					MintError:           err.Error(),
+				})
 				continue
 			}
-			installLogf := func(format string, args ...any) {
-				logf("installation %d: "+format, append([]any{inst.ID}, args...)...)
+			client = r.registerOwnerAuth(inst.Account, a, true)
+			if startLoopsForNewOwners {
+				installLogf := func(format string, args ...any) {
+					logf("installation %d: "+format, append([]any{inst.ID}, args...)...)
+				}
+				a.startRefreshLoop(ctx, installLogf, nil)
 			}
-			client = r.CommitOwnerAuth(ctx, inst.Account, a, true, installLogf)
 		}
 
 		repos, repoTruncated, err := gh.FetchInstallationRepositories(baseURL, client.Token())
@@ -300,6 +351,10 @@ func (r *Reconciler) Derive(ctx context.Context, filter []string, maxRepos int, 
 // once per Reconcile/Derive round (initial and every re-derivation trigger).
 func logDerivedSet(set DerivedRepoSet, logf func(format string, args ...any)) {
 	for _, inst := range set.Installations {
+		if inst.MintError != "" {
+			logf("! installation %d (%s, repository_selection=%s): minting a token failed this round (%s) — the installation exists but is not yet usable; retry reconciliation", inst.InstallationID, inst.Account, inst.RepositorySelection, inst.MintError)
+			continue
+		}
 		if inst.RepoListError != "" {
 			logf("✓ installation %d (%s, repository_selection=%s): repo-access verification was skipped this round (listing failed — see error above); the installation is still authorized", inst.InstallationID, inst.Account, inst.RepositorySelection)
 			continue
@@ -375,10 +430,14 @@ func guideMissingInstallations(opts Options, slug string, set DerivedRepoSet, lo
 
 // LastDerived returns the DerivedRepoSet from the most recent Derive call —
 // including the one Reconcile itself performs at construction. Callers (e.g.
-// Pruefer's SIGHUP watched_repos reload) use this to re-intersect a changed
-// filter against the already-known installation grant without triggering a
-// fresh, live re-derivation — see this issue's "SIGHUP no longer mints"
-// consequence.
+// Pruefer's execute.go, seeding the daemon's initial Clients/derived state
+// right after Reconcile returns) use this to read that already-computed
+// result without triggering a second, redundant live derivation. A later
+// change to watched_repos (SIGHUP) does NOT read this — it triggers a fresh
+// Derive call instead (see Pruefer's rederiveRepos/triggerRederivation),
+// since every re-derivation trigger re-fetches installations/repos live
+// rather than trusting a cached snapshot; this method is a one-time
+// startup convenience, not a caching layer for the reload path.
 func (r *Reconciler) LastDerived() DerivedRepoSet {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/githubauth/derive_test.go
+++ b/internal/githubauth/derive_test.go
@@ -150,6 +150,59 @@ func TestDerive_MaxDerivedReposCapsDeterministically(t *testing.T) {
 	}
 }
 
+// TestDerive_PreCapCount_ReflectsPostFilterNotTotalGrant is the regression
+// test for a review finding (handarbeit-pruefer): the "capped from N"
+// log/TUI message used to report TotalGranted() — the installation grant's
+// raw, pre-watched_repos-filter total — as the pre-cap count. That's wrong
+// whenever a narrowing watched_repos filter and max_derived_repos are both
+// active: the cap actually slices from the post-filter count, not the raw
+// grant, so reporting TotalGranted() misattributes repos the filter already
+// excluded to the cap instead. PreCapCount must reflect the post-filter,
+// pre-cap count that was actually sliced.
+func TestDerive_PreCapCount_ReflectsPostFilterNotTotalGrant(t *testing.T) {
+	oldFlow := runManifestFlow
+	runManifestFlow = failingRunManifestFlow(t)
+	defer func() { runManifestFlow = oldFlow }()
+
+	const totalGrant = 10
+	const wantCap = 3
+	repos := make([]string, totalGrant)
+	for i := range repos {
+		repos[i] = fmt.Sprintf("bigorg/repo-%03d", i)
+	}
+	// filter narrows the grant to 5 of the 10 repos.
+	filter := repos[:5]
+
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "bigorg", RepositorySelection: "selected"},
+	}, func() time.Time { return time.Now().Add(time.Hour) })
+	fake.selectedRepos = map[int64][]string{111: repos}
+	defer srv.Close()
+
+	r, err := Reconcile(context.Background(), Options{
+		AppID: 42, AppPrivateKeyPath: keyPath, AppStatePath: filepath.Join(dir, "app-state.json"),
+		WatchedRepos: filter, MaxDerivedRepos: wantCap, BaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	set := r.LastDerived()
+	if !set.Capped {
+		t.Fatal("expected Capped = true")
+	}
+	if len(set.Repos) != wantCap {
+		t.Fatalf("len(Repos) = %d, want %d", len(set.Repos), wantCap)
+	}
+	if set.TotalGranted() != totalGrant {
+		t.Errorf("TotalGranted() = %d, want %d (the raw installation grant, before the filter)", set.TotalGranted(), totalGrant)
+	}
+	if set.PreCapCount != len(filter) {
+		t.Errorf("PreCapCount = %d, want %d (the post-filter count the cap actually sliced from, not TotalGranted()=%d)", set.PreCapCount, len(filter), set.TotalGranted())
+	}
+}
+
 // --- AC7 containment regression: two distinct App identities ---
 
 // jwtIssuer decodes the "iss" claim (App ID) from an unverified JWT — good

--- a/internal/githubauth/derive_test.go
+++ b/internal/githubauth/derive_test.go
@@ -1,0 +1,351 @@
+package githubauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// TestDerive_FutureRepoPickup is the regression test for AC2/AC3's "future
+// repos become pollable with no restart" requirement: Derive always
+// re-fetches live from GitHub rather than trusting any cache, so a repo
+// added to an installation's grant between two Derive calls must appear in
+// the second call's result with no restart and no re-mint of the owner's
+// token.
+func TestDerive_FutureRepoPickup(t *testing.T) {
+	oldFlow := runManifestFlow
+	runManifestFlow = failingRunManifestFlow(t)
+	defer func() { runManifestFlow = oldFlow }()
+
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "handarbeit", RepositorySelection: "selected"},
+	}, func() time.Time { return time.Now().Add(time.Hour) })
+	fake.selectedRepos = map[int64][]string{111: {"handarbeit/fabrik"}}
+	defer srv.Close()
+
+	r, err := Reconcile(context.Background(), Options{
+		AppID: 42, AppPrivateKeyPath: keyPath, AppStatePath: filepath.Join(dir, "app-state.json"),
+		BaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	first := r.LastDerived()
+	if len(first.Repos) != 1 || first.Repos[0].Repo != "handarbeit/fabrik" {
+		t.Fatalf("first derivation = %+v, want just handarbeit/fabrik", first.Repos)
+	}
+	mintCountAfterFirst := fake.mintCountFor(111)
+
+	// The installation's grant gains a new repo — e.g. the operator created
+	// it, or an "all"-mode installation simply has a new repo now visible.
+	fake.selectedRepos = map[int64][]string{111: {"handarbeit/fabrik", "handarbeit/new-repo"}}
+
+	set, detached, err := r.Derive(context.Background(), nil, 0, func(string, ...any) {})
+	if err != nil {
+		t.Fatalf("Derive (second call): %v", err)
+	}
+	if len(detached) != 0 {
+		t.Errorf("expected no detached owners, got %+v", detached)
+	}
+	if len(set.Repos) != 2 {
+		t.Fatalf("second derivation = %+v, want both handarbeit repos", set.Repos)
+	}
+	foundNew := false
+	for _, dr := range set.Repos {
+		if dr.Repo == "handarbeit/new-repo" {
+			foundNew = true
+		}
+	}
+	if !foundNew {
+		t.Errorf("expected handarbeit/new-repo to appear in the second derivation, got %+v", set.Repos)
+	}
+	// The owner's installation was already known — Derive must not have
+	// re-minted a fresh token for it just to pick up the new repo.
+	if got := fake.mintCountFor(111); got != mintCountAfterFirst {
+		t.Errorf("mint count for installation 111 = %d after second Derive, want unchanged from %d (no re-mint for an already-known installation)", got, mintCountAfterFirst)
+	}
+}
+
+// TestDerive_MaxDerivedReposCapsDeterministically is R5/AC6's regression
+// test: a synthetic installation granting far more repos than
+// max_derived_repos must be capped, with Capped/CapApplied reported, and the
+// same repos dropped every time (sorted owner/repo ascending, not an
+// arbitrary API-order tail).
+func TestDerive_MaxDerivedReposCapsDeterministically(t *testing.T) {
+	oldFlow := runManifestFlow
+	runManifestFlow = failingRunManifestFlow(t)
+	defer func() { runManifestFlow = oldFlow }()
+
+	const totalRepos = 250
+	const wantCap = 200
+	repos := make([]string, totalRepos)
+	for i := range repos {
+		repos[i] = fmt.Sprintf("bigorg/repo-%03d", i)
+	}
+
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "bigorg", RepositorySelection: "all"},
+	}, func() time.Time { return time.Now().Add(time.Hour) })
+	fake.selectedRepos = map[int64][]string{111: repos}
+	defer srv.Close()
+
+	r, err := Reconcile(context.Background(), Options{
+		AppID: 42, AppPrivateKeyPath: keyPath, AppStatePath: filepath.Join(dir, "app-state.json"),
+		MaxDerivedRepos: wantCap, BaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	set := r.LastDerived()
+	if !set.Capped {
+		t.Fatal("expected Capped = true")
+	}
+	if set.CapApplied != wantCap {
+		t.Errorf("CapApplied = %d, want %d", set.CapApplied, wantCap)
+	}
+	if len(set.Repos) != wantCap {
+		t.Fatalf("len(Repos) = %d, want %d", len(set.Repos), wantCap)
+	}
+	if set.TotalGranted() != totalRepos {
+		t.Errorf("TotalGranted() = %d, want %d (the full grant, before capping)", set.TotalGranted(), totalRepos)
+	}
+	// Deterministic: sorted owner/repo ascending, so repo-199 (0-indexed)
+	// survives and repo-249 does not.
+	if set.Repos[len(set.Repos)-1].Repo != "bigorg/repo-199" {
+		t.Errorf("last surviving repo = %q, want bigorg/repo-199 (sorted, first 200 kept)", set.Repos[len(set.Repos)-1].Repo)
+	}
+	for _, dr := range set.Repos {
+		if dr.Repo == "bigorg/repo-249" {
+			t.Error("expected bigorg/repo-249 to be dropped by the cap, found it in the surviving set")
+		}
+	}
+
+	// Calling Derive again must drop exactly the same repos, not an
+	// arbitrary subset — determinism across repeated calls.
+	set2, _, err := r.Derive(context.Background(), nil, wantCap, func(string, ...any) {})
+	if err != nil {
+		t.Fatalf("Derive (second call): %v", err)
+	}
+	if len(set2.Repos) != len(set.Repos) {
+		t.Fatalf("second Derive returned %d repos, want %d", len(set2.Repos), len(set.Repos))
+	}
+	for i := range set.Repos {
+		if set.Repos[i].Repo != set2.Repos[i].Repo {
+			t.Errorf("repo[%d] = %q on first call, %q on second — capping must be deterministic", i, set.Repos[i].Repo, set2.Repos[i].Repo)
+		}
+	}
+}
+
+// --- AC7 containment regression: two distinct App identities ---
+
+// jwtIssuer decodes the "iss" claim (App ID) from an unverified JWT — good
+// enough for this test's fake server, which only needs to distinguish which
+// App a request is authenticating as, not verify the signature.
+func jwtIssuer(t *testing.T, jwt string) int64 {
+	t.Helper()
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		t.Fatalf("malformed JWT: %q", jwt)
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decoding JWT payload: %v", err)
+	}
+	var claims struct {
+		Iss int64 `json:"iss"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("unmarshaling JWT claims: %v", err)
+	}
+	return claims.Iss
+}
+
+// multiAppFakeServer serves /app, /app/installations, .../access_tokens, and
+// /installation/repositories for TWO distinct GitHub App identities on one
+// httptest server, keyed by the JWT's own "iss" claim (App ID) — simulating
+// two operators, each with their own dedicated App (post-#1253's model),
+// sharing nothing except this test's HTTP endpoint. This is what makes AC7's
+// containment property structural rather than allowlist-based: a request
+// authenticated as App A's JWT can only ever resolve App A's installations,
+// because GitHub's own /app/installations is scoped to the calling App's
+// identity by construction — there is no owner-allowlist code path to bypass
+// or forget.
+type multiAppFakeServer struct {
+	t *testing.T
+
+	mu               sync.Mutex
+	installTokenToID map[string]int64 // token -> installation ID, across both apps
+
+	appAID    int64
+	appASlug  string
+	appAInsts []gh.AppInstallation
+	appARepos map[int64][]string
+
+	appBID    int64
+	appBSlug  string
+	appBInsts []gh.AppInstallation
+	appBRepos map[int64][]string
+
+	// contactedAppB is set if any request ever authenticates as App B's
+	// JWT/installation token — the assertion this whole test exists to make.
+	contactedAppB bool
+}
+
+func newMultiAppFakeServer(t *testing.T) (*httptest.Server, *multiAppFakeServer) {
+	f := &multiAppFakeServer{
+		t:                t,
+		installTokenToID: map[string]int64{},
+		appAID:           42, appASlug: "operator-a-bot",
+		appAInsts: []gh.AppInstallation{{ID: 1001, Account: "operator-a-org"}},
+		appARepos: map[int64][]string{1001: {"operator-a-org/repo"}},
+		appBID:    99, appBSlug: "operator-b-bot",
+		appBInsts: []gh.AppInstallation{{ID: 2001, Account: "operator-b-org"}},
+		appBRepos: map[int64][]string{2001: {"operator-b-org/repo"}},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
+		jwt := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		iss := jwtIssuer(f.t, jwt)
+		f.recordIfAppB(iss)
+		slug := f.appASlug
+		if iss == f.appBID {
+			slug = f.appBSlug
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"slug": slug, "id": iss})
+	})
+	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, r *http.Request) {
+		jwt := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		iss := jwtIssuer(f.t, jwt)
+		f.recordIfAppB(iss)
+		if r.URL.Query().Get("page") != "" && r.URL.Query().Get("page") != "1" {
+			json.NewEncoder(w).Encode([]map[string]interface{}{})
+			return
+		}
+		insts := f.appAInsts
+		if iss == f.appBID {
+			insts = f.appBInsts
+		}
+		raw := make([]map[string]interface{}, len(insts))
+		for i, inst := range insts {
+			raw[i] = map[string]interface{}{"id": inst.ID, "account": map[string]string{"login": inst.Account}}
+		}
+		json.NewEncoder(w).Encode(raw)
+	})
+	mux.HandleFunc("/app/installations/", func(w http.ResponseWriter, r *http.Request) {
+		var instID int64
+		fmt.Sscanf(r.URL.Path, "/app/installations/%d/access_tokens", &instID)
+		jwt := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		iss := jwtIssuer(f.t, jwt)
+		f.recordIfAppB(iss)
+
+		token := fmt.Sprintf("ghs_token_app%d_inst%d", iss, instID)
+		f.mu.Lock()
+		f.installTokenToID[token] = instID
+		f.mu.Unlock()
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token": token, "expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		})
+	})
+	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+		auth := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		f.mu.Lock()
+		instID := f.installTokenToID[auth]
+		f.mu.Unlock()
+		if strings.Contains(auth, fmt.Sprintf("app%d", f.appBID)) {
+			f.mu.Lock()
+			f.contactedAppB = true
+			f.mu.Unlock()
+		}
+		if r.URL.Query().Get("page") != "" && r.URL.Query().Get("page") != "1" {
+			json.NewEncoder(w).Encode(map[string]interface{}{"repositories": []map[string]interface{}{}})
+			return
+		}
+		repos := f.appARepos[instID]
+		if _, ok := f.appBRepos[instID]; ok {
+			repos = f.appBRepos[instID]
+		}
+		out := make([]map[string]interface{}, len(repos))
+		for i, name := range repos {
+			out[i] = map[string]interface{}{"full_name": name}
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"repositories": out})
+	})
+	return httptest.NewServer(mux), f
+}
+
+func (f *multiAppFakeServer) recordIfAppB(iss int64) {
+	if iss != f.appBID {
+		return
+	}
+	f.mu.Lock()
+	f.contactedAppB = true
+	f.mu.Unlock()
+}
+
+func (f *multiAppFakeServer) everContactedAppB() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.contactedAppB
+}
+
+// TestDerive_Containment_NeverContactsOtherAppsInstallations is AC7's
+// regression test: a Reconciler built from operator A's own App key must
+// never see or contact operator B's App's installations, even though both
+// Apps' endpoints live behind the same GitHub host in this test. This is
+// what makes containment structural post-#1253 rather than an
+// allowlist-derived property (ADR-1233's superseded model): FetchAppInstallations
+// is JWT-scoped to the calling App's own identity by GitHub's own API
+// contract — there is no owner list to check against, and so no owner list
+// to get wrong.
+func TestDerive_Containment_NeverContactsOtherAppsInstallations(t *testing.T) {
+	oldFlow := runManifestFlow
+	runManifestFlow = failingRunManifestFlow(t)
+	defer func() { runManifestFlow = oldFlow }()
+
+	srv, fake := newMultiAppFakeServer(t)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+
+	// Reconcile as operator A's own App (ID 42) — deliberately never given
+	// any credential or identifier for App B (ID 99).
+	r, err := Reconcile(context.Background(), Options{
+		AppID: 42, AppPrivateKeyPath: keyPath, AppStatePath: filepath.Join(dir, "app-state.json"),
+		BaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if _, err := r.ClientForRepo(context.Background(), "operator-a-org", "repo"); err != nil {
+		t.Errorf("expected a client for operator-a-org (App A's own installation): %v", err)
+	}
+	if _, err := r.ClientForRepo(context.Background(), "operator-b-org", "repo"); err == nil {
+		t.Error("expected no client for operator-b-org — it belongs to a different App entirely")
+	}
+	if fake.everContactedAppB() {
+		t.Error("App B's installations/tokens were contacted from a Reconciler built with App A's own key — containment violated")
+	}
+	derived := r.LastDerived()
+	for _, dr := range derived.Repos {
+		if dr.Owner == "operator-b-org" {
+			t.Errorf("derived set includes operator-b-org's repo %q — containment violated", dr.Repo)
+		}
+	}
+}

--- a/internal/githubauth/installations.go
+++ b/internal/githubauth/installations.go
@@ -28,20 +28,10 @@ type RepoStatus struct {
 // GET /installation/repositories is scoped to the installation identity,
 // not the App's JWT.
 func verifyRepoAccess(baseURL, installToken string, installationID int64, owner string, watchedRepos []string) ([]RepoStatus, error) {
-	accessible, err := gh.FetchInstallationRepositories(baseURL, installToken)
+	accessible, truncated, err := gh.FetchInstallationRepositories(baseURL, installToken)
 	if err != nil {
 		return nil, fmt.Errorf("listing accessible repositories for owner %q's installation: %w", owner, err)
 	}
-	// FetchInstallationRepositories caps at 100 results and only surfaces
-	// truncation via a package-level log line (github/app.go) — this caller
-	// has no other way to know the list it received was incomplete. Without
-	// this check, a watched repo that exists beyond page 1 of a >100-repo
-	// "selected" installation would be reported Authorized: false with a
-	// reason implying GitHub actively excludes it, when the true state is
-	// simply unknown. Re-derived here (rather than threading a return value
-	// through FetchInstallationRepositories) since 100 is that function's own
-	// documented, fixed page size.
-	truncated := len(accessible) == 100
 	// Keyed by lower-cased "owner/repo": GitHub org/user (and repo) names are
 	// case-insensitive, but FetchInstallationRepositories returns each
 	// full_name in its canonical case while repoSpec (below) comes verbatim

--- a/internal/githubauth/installations_test.go
+++ b/internal/githubauth/installations_test.go
@@ -137,6 +137,7 @@ func TestVerifyRepoAccess_TruncatedListYieldsAmbiguousReason(t *testing.T) {
 		{ID: 111, Account: "someorg", RepositorySelection: "selected"},
 	}, func() time.Time { return time.Now().Add(time.Hour) })
 	fake.selectedRepos = map[int64][]string{111: accessibleRepos}
+	fake.neverShortPage = true // simulate a server that never signals the end of the list
 	defer srv.Close()
 
 	dir := t.TempDir()

--- a/internal/githubauth/reconciler.go
+++ b/internal/githubauth/reconciler.go
@@ -721,12 +721,23 @@ func Reconcile(ctx context.Context, opts Options) (*Reconciler, error) {
 	logDerivedSet(set, logf)
 	guideMissingInstallations(opts, slug, set, logf)
 
+	// repoCache only gets an entry for an installation Derive got a
+	// definitive answer for this round — one whose FetchInstallationRepositories
+	// call actually succeeded (RepoListError == ""). An installation whose
+	// listing failed this round (a transient error) contributes no entry at
+	// all, mirroring the pre-Derive discovery loop's repoVerifyFailed
+	// handling: saveInstallationRepoCache's per-owner merge then leaves that
+	// owner's last-known-good cache entry untouched instead of wiping it to
+	// empty over a transient hiccup.
 	repoCache := make(map[string][]string)
 	for _, dr := range set.Repos {
 		key := strings.ToLower(dr.Owner)
 		repoCache[key] = append(repoCache[key], dr.Repo)
 	}
 	for _, inst := range set.Installations {
+		if inst.RepoListError != "" {
+			continue
+		}
 		key := strings.ToLower(inst.Account)
 		if _, ok := repoCache[key]; !ok {
 			repoCache[key] = []string{}

--- a/internal/githubauth/reconciler.go
+++ b/internal/githubauth/reconciler.go
@@ -116,7 +116,19 @@ type Options struct {
 	// persisted. Never config.yaml — see the Plan's "config.yaml is never
 	// written back to" decision.
 	AppStatePath string
+	// WatchedRepos is, since this issue (handarbeit/fabrik#1641), no longer
+	// the primary input to discovery — it is an optional intersection
+	// filter (R3) applied on top of whatever the App's installations
+	// actually grant. Absent/empty means "everything the installations
+	// grant"; present narrows to the intersection, and a named repo the
+	// installation grant doesn't cover is reported via
+	// DerivedRepoSet.FilteredOut rather than silently included or excluded
+	// with no explanation. See Derive.
 	WatchedRepos []string
+	// MaxDerivedRepos bounds the derived set's size (R5) — applied last,
+	// after the installation-grant union and any WatchedRepos filter. <= 0
+	// means no cap.
+	MaxDerivedRepos int
 	// NoBrowser is forwarded to RunManifestFlow unchanged.
 	NoBrowser bool
 	// BaseURL selects GitHub's API host. "" = production; tests point it at
@@ -185,6 +197,11 @@ type Reconciler struct {
 	// Reconciler's lifetime (restart-only, see above), so this is set once
 	// in Reconcile and never itself changes.
 	pinnedInstallationID int64
+
+	// lastDerived is the result of the most recent Derive call (including
+	// the one Reconcile itself performs) — see LastDerived and Derive's own
+	// doc comment.
+	lastDerived DerivedRepoSet
 }
 
 // BotLogin returns the App's own identity as it appears as a PR/review
@@ -293,17 +310,15 @@ func (r *Reconciler) MintOwnerAuth(owner string, watchedRepos []string, logf fun
 	if err != nil {
 		return nil, false, fmt.Errorf("building app JWT: %w", err)
 	}
-	installations, err := gh.FetchAppInstallations(baseURL, jwt)
+	installations, installationsTruncated, err := gh.FetchAppInstallations(baseURL, jwt)
 	if err != nil {
 		return nil, false, fmt.Errorf("discovering app installations: %w", err)
 	}
-	// Mirrors Reconcile's own discovery loop: FetchAppInstallations caps at
-	// 100 results, so a hit at exactly that count means owner's actual
-	// installation could be sitting just past the first page rather than
-	// genuinely missing — a newly-watched owner on a very large App must
-	// not be misreported (and the whole reload aborted on) a pagination
-	// gap it never had.
-	installationsTruncated := len(installations) == 100
+	// Mirrors Reconcile's own discovery loop: a truncated result means
+	// owner's actual installation could be sitting past the pagination
+	// ceiling rather than genuinely missing — a newly-watched owner on a
+	// very large App must not be misreported (and the whole reload aborted
+	// on) a pagination gap it never had.
 	var inst *gh.AppInstallation
 	for i := range installations {
 		if strings.EqualFold(installations[i].Account, owner) {
@@ -635,17 +650,6 @@ func Reconcile(ctx context.Context, opts Options) (*Reconciler, error) {
 		pinnedInstallationID: opts.AppInstallationID,
 	}
 
-	// A single pass both validates and enumerates — see
-	// distinctOwnersLogging's own doc comment for why this replaced two
-	// separate passes (one purely to log malformed entries, one via
-	// distinctOwners to actually use them) that re-ran the identical
-	// splitOwnerRepo check over the same slice.
-	owners := distinctOwnersLogging(opts.WatchedRepos, logf)
-	if len(owners) == 0 {
-		logf("no watched repos configured — reconciliation has nothing to authorize")
-		return r, nil
-	}
-
 	// Compat path: a pinned installation ID skips discovery entirely,
 	// preserving pre-reconciler behavior byte-for-byte — see ADR-1233
 	// Decision 4. Every watched repo is cached as authorized under the
@@ -666,6 +670,12 @@ func Reconcile(ctx context.Context, opts Options) (*Reconciler, error) {
 	// legacy behavior this compat path exists to preserve, not a
 	// regression introduced by the reconciler.
 	if opts.AppInstallationID != 0 {
+		// A single pass both validates and enumerates — see
+		// distinctOwnersLogging's own doc comment for why this replaced two
+		// separate passes (one purely to log malformed entries, one via
+		// distinctOwners to actually use them) that re-ran the identical
+		// splitOwnerRepo check over the same slice.
+		owners := distinctOwnersLogging(opts.WatchedRepos, logf)
 		a, err := mintAuth(appID, opts.AppInstallationID, botLogin, privateKey, opts.BaseURL)
 		if err != nil {
 			return nil, fmt.Errorf("minting pinned installation token: %w", err)
@@ -687,6 +697,7 @@ func Reconcile(ctx context.Context, opts Options) (*Reconciler, error) {
 			}
 		}
 		r.auths = []*Auth{a}
+		r.lastDerived = derivedSetForPinned(opts.WatchedRepos, opts.AppInstallationID)
 		saveInstallationRepoCache(opts.AppStatePath, opts.AppPrivateKeyPath, appID, slug, repoCache, logf)
 		// Unlike the discovery path below (verifyRepoAccess), minting a
 		// token here is the only check this compat path performs — it
@@ -698,128 +709,29 @@ func Reconcile(ctx context.Context, opts Options) (*Reconciler, error) {
 		return r, nil
 	}
 
-	installations, err := gh.FetchAppInstallations(opts.BaseURL, jwt)
+	// Non-pinned: installations are the desired state (R1) — Derive
+	// discovers every installation of this App and enumerates its
+	// accessible repos; opts.WatchedRepos (if any) is only an optional
+	// intersection filter (R3), never the primary input. See Derive's doc
+	// comment — this is the core inversion handarbeit/fabrik#1641 makes.
+	set, _, err := r.Derive(ctx, opts.WatchedRepos, opts.MaxDerivedRepos, logf)
 	if err != nil {
-		return nil, fmt.Errorf("discovering app installations: %w", err)
+		return nil, fmt.Errorf("deriving repo set from app installations: %w", err)
 	}
-	// FetchAppInstallations caps at 100 results and only surfaces
-	// truncation via its own package-level log line (github/app.go) — this
-	// caller has no other way to know the list it received was incomplete.
-	// Without this, an owner whose installation exists beyond page 1 of a
-	// >100-installation App would be reported "no installation" below with
-	// the same confidence as a genuinely missing one — a false negative
-	// that triggers an unnecessary guided-install browser-open, unlike
-	// verifyRepoAccess's analogous truncated case below, which this
-	// mirrors.
-	installationsTruncated := len(installations) == 100
-	// Keyed by lower-cased account login: GitHub org/user logins are
-	// case-insensitive, but FetchAppInstallations returns each Account in
-	// its canonical case while owner (below) comes verbatim from the
-	// user's watched_repos config string — an exact-case map would treat
-	// e.g. a config entry "MyOrg/repo" against a canonical "myorg"
-	// installation as uninstalled, spuriously re-triggering guided-install
-	// guidance every restart despite the installation already existing.
-	byAccount := make(map[string]gh.AppInstallation, len(installations))
-	for _, inst := range installations {
-		byAccount[strings.ToLower(inst.Account)] = inst
-	}
+	logDerivedSet(set, logf)
+	guideMissingInstallations(opts, slug, set, logf)
 
-	// repoCache accumulates the "which of this owner's watched repos does
-	// the installation actually grant access to" diagnostic the issue's
-	// credential-model requirement asks the reconciler to persist
-	// (Credentials.InstallationRepoCache) — populated here, from data this
-	// loop already fetches, and saved once discovery completes. Purely a
-	// human-readable cache: Reconcile always re-verifies live against
-	// GitHub on the next run rather than trusting it (see that field's own
-	// doc comment).
 	repoCache := make(map[string][]string)
-
-	// openedInstallBrowser bounds guided-installation browser-opening to at
-	// most once per Reconcile call: WatchedRepos can plausibly span several
-	// owners with no installation at all (e.g. a first run watching repos
-	// under three different orgs), and popping open a separate browser
-	// tab/window per missing owner is surprising, unlike the single-flow
-	// manifest bootstrap. Every missing owner still gets its install URL
-	// logged; only the first one also gets an actual browser-open attempt.
-	openedInstallBrowser := false
-	for _, owner := range owners {
-		inst, ok := byAccount[strings.ToLower(owner)]
-		if !ok {
-			installURL := fmt.Sprintf("https://github.com/apps/%s/installations/new", slug)
-			notFoundDesc := "has no installation"
-			if installationsTruncated {
-				notFoundDesc = "not found in the first 100 installations returned — the App may have ≥100 installations, so this could be a pagination gap rather than an actual missing installation; re-run reconciliation to confirm before assuming it needs installing"
-			}
-			if !opts.NoBrowser && !openedInstallBrowser {
-				logf("! %s %s → opening %s …", owner, notFoundDesc, installURL)
-				if err := openBrowser(installURL); err != nil {
-					logf("could not open browser automatically (%v) — visit the URL above manually", err)
-				}
-				openedInstallBrowser = true
-			} else {
-				logf("! %s %s → %s", owner, notFoundDesc, installURL)
-			}
-			continue
-		}
-
-		a, err := mintAuth(appID, inst.ID, botLogin, privateKey, opts.BaseURL)
-		if err != nil {
-			logf("! minting token for owner %q (installation %d) failed: %v", owner, inst.ID, err)
-			r.mintErrors[strings.ToLower(owner)] = err
-			continue
-		}
-
-		// repoVerifyFailed tracks whether the "selected"-mode repo-access
-		// check below errored (e.g. a transient failure listing
-		// /installation/repositories) — the minted token is still usable
-		// either way, but the final "✓ authorized" log line must say so
-		// rather than implying repo access was actually confirmed.
-		repoVerifyFailed := false
-		if inst.RepositorySelection == "selected" {
-			statuses, err := verifyRepoAccess(opts.BaseURL, a.client.Token(), inst.ID, owner, opts.WatchedRepos)
-			if err != nil {
-				logf("! verifying repo access for owner %q failed: %v", owner, err)
-				repoVerifyFailed = true
-			} else {
-				// A definitive answer for this owner this round — set the
-				// map key now (possibly to an empty, non-nil slice) so
-				// saveInstallationRepoCache's per-owner merge overwrites
-				// whatever stale entry it holds, even when zero repos come
-				// back authorized. Leaving the key unset here would be
-				// indistinguishable from the repoVerifyFailed ("we didn't
-				// check this round") case above, silently perpetuating a
-				// stale "authorized" cache entry that a live, successful
-				// check just definitively contradicted.
-				repoCache[strings.ToLower(owner)] = []string{}
-			}
-			for _, st := range statuses {
-				if st.Authorized {
-					repoCache[strings.ToLower(owner)] = append(repoCache[strings.ToLower(owner)], st.Repo)
-				} else {
-					logf("! %s is not authorized (%s) → %s", st.Repo, st.Reason, st.GrantURL)
-				}
-			}
-		} else {
-			// An "all" installation grants access to every current and
-			// future repo on the account, so every one of owner's watched
-			// repos is authorized — no live per-repo check to make, unlike
-			// the "selected" branch above.
-			for _, spec := range opts.WatchedRepos {
-				if o, _, ok := splitOwnerRepo(spec); ok && strings.EqualFold(o, owner) {
-					repoCache[strings.ToLower(owner)] = append(repoCache[strings.ToLower(owner)], spec)
-				}
-			}
-		}
-
-		r.clients[strings.ToLower(owner)] = a.client
-		r.auths = append(r.auths, a)
-		if repoVerifyFailed {
-			logf("✓ %s authorized (installation token minted; repo-access verification was skipped — see error above)", owner)
-		} else {
-			logf("✓ %s authorized", owner)
+	for _, dr := range set.Repos {
+		key := strings.ToLower(dr.Owner)
+		repoCache[key] = append(repoCache[key], dr.Repo)
+	}
+	for _, inst := range set.Installations {
+		key := strings.ToLower(inst.Account)
+		if _, ok := repoCache[key]; !ok {
+			repoCache[key] = []string{}
 		}
 	}
-
 	saveInstallationRepoCache(opts.AppStatePath, opts.AppPrivateKeyPath, appID, slug, repoCache, logf)
 
 	return r, nil

--- a/internal/githubauth/reconciler.go
+++ b/internal/githubauth/reconciler.go
@@ -228,7 +228,7 @@ func (r *Reconciler) ClientForRepo(ctx context.Context, owner, repo string) (*gh
 		if mintErr, ok := r.mintErrors[strings.ToLower(owner)]; ok {
 			return nil, fmt.Errorf("owner %q has an App installation, but minting a token for it failed during the last reconciliation: %w — this is not a missing-installation problem; retry Reconcile (e.g. restart Pruefer)", owner, mintErr)
 		}
-		return nil, fmt.Errorf("no authorized GitHub App installation for owner %q — if it's already in watched_repos, install the App on %q (Reconcile logs the install URL at startup); otherwise add it to watched_repos and restart to trigger reconciliation", owner, owner)
+		return nil, fmt.Errorf("no authorized GitHub App installation for owner %q — install the App on %q (Reconcile logs the guided-install URL at startup, or on the next re-derivation if it's still missing); this is picked up automatically within repo_rederivation_interval, or immediately on the next installation webhook event in event_source: hookdeck mode — no watched_repos entry or restart needed, unless github_app_installation_id is pinned, in which case add %q's repos to watched_repos instead", owner, owner, owner)
 	}
 	return client, nil
 }
@@ -354,6 +354,25 @@ func (r *Reconciler) MintOwnerAuth(owner string, watchedRepos []string, logf fun
 	return newAuth, true, nil
 }
 
+// registerOwnerAuth registers an already-minted *Auth for owner into
+// r.clients (and, when mintedFresh, r.auths), clearing any stale mintErrors
+// entry — the bookkeeping half of "committing" an Auth, shared by
+// CommitOwnerAuth and Derive's own registration path below. Split out from
+// CommitOwnerAuth specifically so Derive can register a newly-discovered
+// owner WITHOUT also starting its refresh loop there — see Derive's
+// startLoopsForNewOwners parameter for why that distinction matters.
+func (r *Reconciler) registerOwnerAuth(owner string, a *Auth, mintedFresh bool) *gh.Client {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := strings.ToLower(owner)
+	r.clients[key] = a.client
+	delete(r.mintErrors, key)
+	if mintedFresh {
+		r.auths = append(r.auths, a)
+	}
+	return a.client
+}
+
 // CommitOwnerAuth registers an already-minted *Auth (from MintOwnerAuth)
 // for owner — the "commit" half of the two-phase split. mintedFresh must be
 // exactly the value MintOwnerAuth returned alongside a. When mintedFresh is
@@ -362,19 +381,12 @@ func (r *Reconciler) MintOwnerAuth(owner string, watchedRepos []string, logf fun
 // not get a second). Returns the *gh.Client now resolvable via
 // ClientForRepo for owner.
 func (r *Reconciler) CommitOwnerAuth(ctx context.Context, owner string, a *Auth, mintedFresh bool, logf func(format string, args ...any)) *gh.Client {
-	r.mu.Lock()
-	key := strings.ToLower(owner)
-	r.clients[key] = a.client
-	delete(r.mintErrors, key)
-	if mintedFresh {
-		r.auths = append(r.auths, a)
-	}
-	r.mu.Unlock()
+	client := r.registerOwnerAuth(owner, a, mintedFresh)
 
 	if mintedFresh {
 		a.startRefreshLoop(ctx, logf, nil)
 	}
-	return a.client
+	return client
 }
 
 // DetachedAuth pairs a removed owner with the *Auth its token was minted
@@ -714,7 +726,13 @@ func Reconcile(ctx context.Context, opts Options) (*Reconciler, error) {
 	// accessible repos; opts.WatchedRepos (if any) is only an optional
 	// intersection filter (R3), never the primary input. See Derive's doc
 	// comment — this is the core inversion handarbeit/fabrik#1641 makes.
-	set, _, err := r.Derive(ctx, opts.WatchedRepos, opts.MaxDerivedRepos, logf)
+	//
+	// startLoopsForNewOwners=false: every owner discovered here gets its
+	// refresh loop started by the caller's own subsequent RunRefreshLoops
+	// call instead (see execute.go) — starting it here too would double-
+	// start it. See derive's own doc comment for why this distinction
+	// exists only for Reconcile's first call.
+	set, _, err := r.derive(ctx, opts.WatchedRepos, opts.MaxDerivedRepos, logf, false)
 	if err != nil {
 		return nil, fmt.Errorf("deriving repo set from app installations: %w", err)
 	}

--- a/internal/githubauth/reconciler_test.go
+++ b/internal/githubauth/reconciler_test.go
@@ -244,7 +244,18 @@ func TestReconcile_PinnedInstallation_CacheWriteFailureIsNonFatal(t *testing.T) 
 	}
 }
 
-func TestReconcile_BackwardCompat_MultiOwnerNeverTouchesStranger(t *testing.T) {
+// TestReconcile_MultiOwner_WatchedReposNarrowsButEveryInstalledOwnerGetsAClient
+// replaces the pre-#1641 TestReconcile_BackwardCompat_MultiOwnerNeverTouchesStranger,
+// which asserted the *opposite* of what this issue intentionally inverts:
+// under the old (ADR-1233) model, watched_repos was the containment
+// boundary, so an installed-but-unwatched owner ("stranger" below) was never
+// even contacted. Post-#1253/#1641, containment comes from the operator's
+// own dedicated App identity, not from watched_repos membership — every
+// installation of *this* App is now derived and minted regardless of
+// whether watched_repos names it, and watched_repos (R3) only narrows which
+// of those repos are *reviewed*, never which owners get a client. See the
+// issue body's own "safety property that makes this hard" section.
+func TestReconcile_MultiOwner_WatchedReposNarrowsButEveryInstalledOwnerGetsAClient(t *testing.T) {
 	oldFlow := runManifestFlow
 	runManifestFlow = failingRunManifestFlow(t)
 	defer func() { runManifestFlow = oldFlow }()
@@ -254,8 +265,13 @@ func TestReconcile_BackwardCompat_MultiOwnerNeverTouchesStranger(t *testing.T) {
 	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
 		{ID: 111, Account: "handarbeit"},
 		{ID: 222, Account: "verveguy"},
-		{ID: 333, Account: "stranger"}, // installed on the App, never watched
+		{ID: 333, Account: "stranger"}, // installed on this same App, but not named in watched_repos
 	}, func() time.Time { return time.Now().Add(time.Hour) })
+	fake.selectedRepos = map[int64][]string{
+		111: {"handarbeit/fabrik"},
+		222: {"verveguy/otherrepo"},
+		333: {"stranger/repo"},
+	}
 	defer srv.Close()
 
 	r, err := Reconcile(context.Background(), Options{
@@ -276,16 +292,31 @@ func TestReconcile_BackwardCompat_MultiOwnerNeverTouchesStranger(t *testing.T) {
 	if handarbeitClient.Token() == verveguyClient.Token() {
 		t.Error("expected distinct tokens for distinct owners")
 	}
-	if _, err := r.ClientForRepo(context.Background(), "stranger", "repo"); err == nil {
-		t.Fatal("expected no client for the unwatched stranger installation")
+	// stranger's installation belongs to the SAME App this operator
+	// authenticated as — it is minted like any other, since R1 derives from
+	// installations, not from watched_repos.
+	if _, err := r.ClientForRepo(context.Background(), "stranger", "repo"); err != nil {
+		t.Errorf("expected a client for stranger's installation too (it's this same App's own installation): %v", err)
 	}
+	strangerHit := false
 	for _, instID := range fake.hitInstallations() {
 		if instID == 333 {
-			t.Fatal("expected installation 333 (stranger, unwatched) to never be minted a token")
+			strangerHit = true
 		}
 	}
-	if r.InstallationCount() != 2 {
-		t.Errorf("InstallationCount() = %d, want 2", r.InstallationCount())
+	if !strangerHit {
+		t.Error("expected installation 333 (stranger) to be minted a token — it's this App's own installation")
+	}
+	if r.InstallationCount() != 3 {
+		t.Errorf("InstallationCount() = %d, want 3 (every installation of this App, regardless of watched_repos)", r.InstallationCount())
+	}
+	// watched_repos still narrows the *derived, reviewed* set (R3): stranger's
+	// repo is minted/authorized but excluded from what's actually reviewed.
+	derived := r.LastDerived()
+	for _, dr := range derived.Repos {
+		if dr.Owner == "stranger" {
+			t.Errorf("expected stranger/repo to be excluded from the derived (reviewed) set by the watched_repos filter, found: %+v", dr)
+		}
 	}
 }
 
@@ -464,7 +495,7 @@ func TestReconcile_MintFailure_ClientForRepoDistinguishesFromMissingInstallation
 	}
 	found := false
 	for _, l := range lines() {
-		if strings.Contains(l, "minting token for owner") && strings.Contains(l, "flaky") {
+		if strings.Contains(l, "minting token for installation") && strings.Contains(l, "flaky") {
 			found = true
 		}
 	}
@@ -607,6 +638,11 @@ func TestReconcile_MultipleMissingOwnerInstallations_OpensBrowserOnlyOnce(t *tes
 	}
 }
 
+// TestReconcile_SelectedModeExclusion_SoftStatusNotHardError asserts AC4's
+// "reported, not silently included/excluded" requirement: a watched_repos
+// entry a "selected"-mode installation doesn't actually grant must be named
+// in the log (via DerivedRepoSet.FilteredOut), not merely dropped, while the
+// owner's other, actually-granted repo stays authorized.
 func TestReconcile_SelectedModeExclusion_SoftStatusNotHardError(t *testing.T) {
 	oldFlow := runManifestFlow
 	runManifestFlow = failingRunManifestFlow(t)
@@ -633,12 +669,12 @@ func TestReconcile_SelectedModeExclusion_SoftStatusNotHardError(t *testing.T) {
 	}
 	found := false
 	for _, l := range lines() {
-		if strings.Contains(l, "someorg/repo-excluded") && strings.Contains(l, "settings/installations") {
+		if strings.Contains(l, "someorg/repo-excluded") && strings.Contains(l, "not covered") {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected a soft-status log line naming the excluded repo and a grant URL, got: %v", lines())
+		t.Errorf("expected a soft-status log line naming the excluded repo, got: %v", lines())
 	}
 }
 
@@ -706,7 +742,8 @@ func TestReconcile_TruncatedInstallationsListYieldsAmbiguousNotFoundMessage(t *t
 	for i := range installations {
 		installations[i] = gh.AppInstallation{ID: int64(i + 1), Account: fmt.Sprintf("someorg-%03d", i)}
 	}
-	srv, _ := newFakeAppServer("pruefer-bot", installations, func() time.Time { return time.Now().Add(time.Hour) })
+	srv, fake := newFakeAppServer("pruefer-bot", installations, func() time.Time { return time.Now().Add(time.Hour) })
+	fake.neverShortPage = true // simulate a server that never signals the end of the list
 	defer srv.Close()
 
 	dir := t.TempDir()
@@ -729,8 +766,8 @@ func TestReconcile_TruncatedInstallationsListYieldsAmbiguousNotFoundMessage(t *t
 	if found == "" {
 		t.Fatalf("expected a log line about missingowner, got: %v", lines())
 	}
-	if !strings.Contains(found, "100") || !strings.Contains(found, "pagination") {
-		t.Errorf("log line = %q, expected it to flag the 100-result truncation as a possible pagination gap", found)
+	if !strings.Contains(found, "pagination") {
+		t.Errorf("log line = %q, expected it to flag the truncation as a possible pagination gap", found)
 	}
 	if strings.Contains(found, "has no installation") {
 		t.Errorf("log line = %q, should not confidently claim no installation when the result set was truncated", found)
@@ -755,7 +792,8 @@ func TestMintOwnerAuth_TruncatedInstallationsListYieldsAmbiguousError(t *testing
 	for i := range installations {
 		installations[i] = gh.AppInstallation{ID: int64(i + 1), Account: fmt.Sprintf("someorg-%03d", i)}
 	}
-	srv, _ := newFakeAppServer("pruefer-bot", installations, func() time.Time { return time.Now().Add(time.Hour) })
+	srv, fake := newFakeAppServer("pruefer-bot", installations, func() time.Time { return time.Now().Add(time.Hour) })
+	fake.neverShortPage = true // simulate a server that never signals the end of the list
 	defer srv.Close()
 
 	dir := t.TempDir()
@@ -801,7 +839,10 @@ func TestReconcile_PopulatesInstallationRepoCache(t *testing.T) {
 		{ID: 111, Account: "handarbeit", RepositorySelection: "all"},
 		{ID: 222, Account: "someorg", RepositorySelection: "selected"},
 	}, func() time.Time { return time.Now().Add(time.Hour) })
-	fake.selectedRepos = map[int64][]string{222: {"someorg/repo-one"}}
+	fake.selectedRepos = map[int64][]string{
+		111: {"handarbeit/fabrik"}, // "all"-mode installation: FetchInstallationRepositories is now called unconditionally too (#1641)
+		222: {"someorg/repo-one"},
+	}
 	defer srv.Close()
 
 	_, err := Reconcile(context.Background(), Options{
@@ -850,7 +891,10 @@ func TestReconcile_InstallationRepoCache_KeysAreLowerCased(t *testing.T) {
 		{ID: 111, Account: "handarbeit", RepositorySelection: "all"},
 		{ID: 222, Account: "someorg", RepositorySelection: "selected"},
 	}, func() time.Time { return time.Now().Add(time.Hour) })
-	fake.selectedRepos = map[int64][]string{222: {"SomeOrg/repo-one"}}
+	fake.selectedRepos = map[int64][]string{
+		111: {"HandArbeit/fabrik"}, // "all"-mode installation: FetchInstallationRepositories is now called unconditionally too (#1641)
+		222: {"SomeOrg/repo-one"},
+	}
 	defer srv.Close()
 
 	_, err := Reconcile(context.Background(), Options{
@@ -1023,9 +1067,10 @@ func TestReconcile_AppIDChange_ClearsStaleSecretsAndCache(t *testing.T) {
 	// Reconcile now runs against a *different* App ID (99), e.g. because the
 	// operator pointed github_app_id at a new App while reusing the same
 	// AppStatePath.
-	srv, _ := newFakeAppServer("new-app", []gh.AppInstallation{{ID: 222, Account: "someorg"}}, func() time.Time {
+	srv, fake := newFakeAppServer("new-app", []gh.AppInstallation{{ID: 222, Account: "someorg"}}, func() time.Time {
 		return time.Now().Add(time.Hour)
 	})
+	fake.selectedRepos = map[int64][]string{222: {"someorg/repo-one"}}
 	defer srv.Close()
 
 	if _, err := Reconcile(context.Background(), Options{
@@ -1895,7 +1940,11 @@ func TestReconcile_JustBootstrapped_PersistentIdentityFailure_WithPinnedInstalla
 	}
 }
 
-func TestReconcile_NoWatchedRepos_MintsNothing(t *testing.T) {
+// TestReconcile_NoWatchedRepos_DerivesFromInstallations is AC1's direct
+// regression test: with no watched_repos configured at all, Reconcile must
+// derive its repo set from the App's installations rather than minting
+// nothing (the pre-#1641 behavior, when watched_repos was the sole input).
+func TestReconcile_NoWatchedRepos_DerivesFromInstallations(t *testing.T) {
 	oldFlow := runManifestFlow
 	runManifestFlow = failingRunManifestFlow(t)
 	defer func() { runManifestFlow = oldFlow }()
@@ -1905,6 +1954,7 @@ func TestReconcile_NoWatchedRepos_MintsNothing(t *testing.T) {
 	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
 		{ID: 111, Account: "handarbeit"},
 	}, func() time.Time { return time.Now().Add(time.Hour) })
+	fake.selectedRepos = map[int64][]string{111: {"handarbeit/fabrik", "handarbeit/other"}}
 	defer srv.Close()
 
 	r, err := Reconcile(context.Background(), Options{
@@ -1914,11 +1964,18 @@ func TestReconcile_NoWatchedRepos_MintsNothing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
-	if r.InstallationCount() != 0 {
-		t.Errorf("InstallationCount() = %d, want 0 with no watched repos", r.InstallationCount())
+	if r.InstallationCount() != 1 {
+		t.Errorf("InstallationCount() = %d, want 1 — an installed owner must be minted even with no watched_repos filter (AC1)", r.InstallationCount())
 	}
-	if fake.mintCount.Load() != 0 {
-		t.Errorf("mintCount = %d, want 0 (no installation calls with zero watched repos)", fake.mintCount.Load())
+	if fake.mintCount.Load() != 1 {
+		t.Errorf("mintCount = %d, want 1", fake.mintCount.Load())
+	}
+	if _, err := r.ClientForRepo(context.Background(), "handarbeit", "fabrik"); err != nil {
+		t.Errorf("expected a client for handarbeit's installed repo with no watched_repos filter: %v", err)
+	}
+	derived := r.LastDerived()
+	if len(derived.Repos) != 2 {
+		t.Errorf("LastDerived().Repos = %v, want both of handarbeit's accessible repos with no filter applied", derived.Repos)
 	}
 }
 

--- a/internal/githubauth/reconciler_test.go
+++ b/internal/githubauth/reconciler_test.go
@@ -502,6 +502,34 @@ func TestReconcile_MintFailure_ClientForRepoDistinguishesFromMissingInstallation
 	if !found {
 		t.Errorf("expected a log line about the failed mint for flaky, got: %v", lines())
 	}
+
+	// Regression: a mint failure must not be indistinguishable from a
+	// genuinely missing installation. Before MintError existed, an
+	// installation whose mint failed was omitted from
+	// DerivedRepoSet.Installations entirely — the same shape as an owner
+	// with no installation at all — so guideMissingInstallations couldn't
+	// tell them apart and misreported "flaky has no installation", which
+	// (absent -no-browser) also popped open a browser for what's usually a
+	// transient error a reconciliation retry would clear on its own.
+	for _, l := range lines() {
+		if strings.Contains(l, "flaky") && strings.Contains(l, "has no installation") {
+			t.Errorf("mint failure misreported as a missing installation (would trigger guided-install/browser-open for a transient error): %s", l)
+		}
+	}
+	derived := r.LastDerived()
+	foundFlaky := false
+	for _, inst := range derived.Installations {
+		if inst.Account != "flaky" {
+			continue
+		}
+		foundFlaky = true
+		if inst.MintError == "" {
+			t.Error("expected flaky's DerivedInstallation to carry a non-empty MintError")
+		}
+	}
+	if !foundFlaky {
+		t.Error("expected flaky to still appear in DerivedRepoSet.Installations (found, but not mintable this round) rather than being omitted like a genuinely missing installation")
+	}
 }
 
 // TestReconciler_RemoveOwners_ClearsMintErrorEvenWithoutClientEntry covers
@@ -1976,6 +2004,70 @@ func TestReconcile_NoWatchedRepos_DerivesFromInstallations(t *testing.T) {
 	derived := r.LastDerived()
 	if len(derived.Repos) != 2 {
 		t.Errorf("LastDerived().Repos = %v, want both of handarbeit's accessible repos with no filter applied", derived.Repos)
+	}
+}
+
+// TestReconcile_InitialDiscovery_DoesNotDoubleStartRefreshLoops is the
+// regression test for a review finding: Derive's own mint+commit path
+// (invoked internally by Reconcile's non-pinned discovery) used to start a
+// refresh loop for every newly-discovered installation immediately, using
+// whatever ctx Reconcile itself was called with. Every production caller
+// (execute.go) then calls Reconciler.RunRefreshLoops right after Reconcile
+// returns, expecting to be the *sole* starter of the initial batch's
+// refresh loops — so this doubled every installation's refresh-loop
+// goroutine (and its GitHub App token-mint API traffic), and the second
+// start silently overwrote Auth.cancel, permanently orphaning the first
+// loop with no way to ever stop it (not even via Auth.Stop/
+// drainThenStopAuth/RemoveOwners) short of a process restart.
+//
+// This test passes Reconcile and RunRefreshLoops two INDEPENDENT contexts
+// specifically to make the bug observable deterministically: reconcileCtx
+// is never cancelled, so if Derive had started a loop under it, that loop
+// would keep refreshing forever regardless of what happens to runCtx.
+// Cancelling only runCtx and then confirming refreshing has genuinely
+// stopped (no further mints after a full refresh interval) is proof no
+// second, reconcileCtx-rooted loop is still running.
+func TestReconcile_InitialDiscovery_DoesNotDoubleStartRefreshLoops(t *testing.T) {
+	oldFlow := runManifestFlow
+	runManifestFlow = failingRunManifestFlow(t)
+	defer func() { runManifestFlow = oldFlow }()
+
+	oldMargin, oldRetry := tokenRefreshMargin, tokenRefreshRetryDelay
+	tokenRefreshMargin = 30 * time.Millisecond
+	tokenRefreshRetryDelay = 20 * time.Millisecond
+	defer func() { tokenRefreshMargin, tokenRefreshRetryDelay = oldMargin, oldRetry }()
+
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "handarbeit"},
+	}, func() time.Time { return time.Now().Add(60 * time.Millisecond) })
+	defer srv.Close()
+
+	reconcileCtx := context.Background() // deliberately never cancelled
+	r, err := Reconcile(reconcileCtx, Options{
+		AppID: 42, AppPrivateKeyPath: keyPath, AppStatePath: filepath.Join(dir, "app-state.json"),
+		BaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	wait := r.RunRefreshLoops(runCtx, func(int64) func(string, ...any) { return func(string, ...any) {} })
+
+	// Let at least one refresh cycle happen under runCtx, then stop it.
+	time.Sleep(80 * time.Millisecond)
+	cancelRun()
+	wait()
+
+	countAtStop := fake.mintCountFor(111)
+	// If Derive had also started a loop under reconcileCtx, it would keep
+	// refreshing on its own schedule — give it a full refresh interval's
+	// worth of time to prove it, then check the count didn't move.
+	time.Sleep(3 * (tokenRefreshMargin + tokenRefreshRetryDelay))
+	if countAfterWait := fake.mintCountFor(111); countAfterWait != countAtStop {
+		t.Errorf("mint count for installation 111 grew from %d to %d after RunRefreshLoops' own loop was stopped — a second refresh loop (started by Reconcile/Derive under a context that's never cancelled) is still running, meaning Auth.Stop/drainThenStopAuth/RemoveOwners can never actually silence this installation short of a process restart", countAtStop, countAfterWait)
 	}
 }
 

--- a/internal/githubauth/tokenauth_test.go
+++ b/internal/githubauth/tokenauth_test.go
@@ -65,6 +65,16 @@ type fakeAppServer struct {
 	// request (simulating a transient listing failure) without affecting
 	// installation-token minting.
 	failRepoList func(installationID int64) bool
+	// neverShortPage, when true, makes both /app/installations and
+	// /installation/repositories ignore the requested page and always
+	// return their full item list — simulating a server that never returns
+	// a short page, i.e. forcing FetchAppInstallations/
+	// FetchInstallationRepositories to hit their pagination ceiling
+	// (truncated=true). false (the default, and what every existing test
+	// wants) instead returns the full list on page 1 and an empty page
+	// thereafter, so real pagination terminates after exactly one request —
+	// matching this fake server's pre-pagination behavior.
+	neverShortPage bool
 
 	mintCount atomic.Int32
 
@@ -85,6 +95,10 @@ func newFakeAppServer(slug string, installations []gh.AppInstallation, tokenExpi
 		json.NewEncoder(w).Encode(map[string]interface{}{"slug": f.slug, "id": 1})
 	})
 	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, r *http.Request) {
+		if !f.neverShortPage && r.URL.Query().Get("page") != "" && r.URL.Query().Get("page") != "1" {
+			json.NewEncoder(w).Encode([]map[string]interface{}{})
+			return
+		}
 		raw := make([]map[string]interface{}, len(f.installations))
 		for i, inst := range f.installations {
 			raw[i] = map[string]interface{}{
@@ -132,6 +146,10 @@ func newFakeAppServer(slug string, installations []gh.AppInstallation, tokenExpi
 		if f.failRepoList != nil && f.failRepoList(instID) {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(`{"message":"simulated repo-list failure"}`))
+			return
+		}
+		if !f.neverShortPage && r.URL.Query().Get("page") != "" && r.URL.Query().Get("page") != "1" {
+			json.NewEncoder(w).Encode(map[string]interface{}{"repositories": []map[string]interface{}{}})
 			return
 		}
 		repos := f.selectedRepos[instID]

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -100,11 +100,13 @@ type Config struct {
 	// in applyConfigReload — it's diffed and applied specially (diffRepos)
 	// so the reload summary can name individual repos added/removed rather
 	// than a single before/after slice dump. A SIGHUP-triggered change to
-	// this field no longer mints or removes any owner's installation
-	// auth (unlike pre-#1641): every installation is already minted
-	// unconditionally by Derive, so a filter edit only needs to
-	// re-intersect against the already-known installation grant
-	// (Reconciler.LastDerived()) — see execute.go's handleReload.
+	// this field triggers a fresh, live re-derivation (daemon.rederiveRepos,
+	// via execute.go's handleReload) rather than minting or removing any
+	// owner's installation auth itself: every installation is already
+	// minted unconditionally by Derive, so re-deriving after a filter edit
+	// never needs a new token for an already-known owner — but it is a live
+	// call to GitHub (re-listing every installation's accessible repos),
+	// not a local re-intersection against a cached result.
 	WatchedRepos   []string      `reload:"live"` // "owner/repo"
 	PollInterval   time.Duration `reload:"live"`
 	Model          string        `reload:"live"`

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -50,6 +50,27 @@ const (
 	DefaultReconciliationFallbackInterval = 2 * time.Minute
 )
 
+// Defaults for installation-derived repo discovery (#1641). See ADR-1641.
+const (
+	// DefaultMaxDerivedRepos bounds a single Derive call's result (R5) — a
+	// deliberately generous default (an org-level install this large is
+	// unusual but not implausible) that still protects an operator who
+	// installs the App broadly from an unbounded, silent jump in poll
+	// cost/GraphQL budget/concurrency contention. 0 (or a negative value)
+	// disables the cap entirely — see MaxDerivedRepos' own doc comment.
+	DefaultMaxDerivedRepos = 200
+	// DefaultRepoRederivationInterval is how often the daemon re-derives its
+	// repo set from the App's installations on a timer, independent of any
+	// installation webhook event — the R2 mechanism poll-mode deployments
+	// need since they have no webhook event to react to at all, and a
+	// low-frequency safety net for event-driven mode alongside its own
+	// event-triggered re-derivation. Deliberately coarser than PollInterval:
+	// re-derivation mints a fresh token and re-lists accessible repos for
+	// every installation, which is more expensive than a single
+	// ListOpenPRs call.
+	DefaultRepoRederivationInterval = 10 * time.Minute
+)
+
 // Config holds Pruefer's fully-resolved runtime configuration, after
 // applying the flag > env > YAML file > default precedence chain in
 // LoadConfig.
@@ -63,17 +84,49 @@ const (
 // on the next process start); "skip" is neither reported nor applied
 // (VersionRequested only — never a real runtime value). See ADR-1640.
 type Config struct {
-	// WatchedRepos is tagged "live" but is never applied through the
-	// generic reflection loop in applyConfigReload — it's diffed and
-	// applied specially (diffRepos) so the reload summary can name
-	// individual repos added/removed rather than a single before/after
-	// slice dump.
+	// WatchedRepos is, since #1641, no longer the primary source of which
+	// repos Pruefer reviews — installation-derived discovery
+	// (internal/githubauth.Reconciler.Derive) is. Absent/empty means
+	// "everything the App's installations grant"; present narrows the
+	// derived set to the intersection (R3) — it can only ever exclude a
+	// repo the installation grants, never include one it doesn't (a
+	// watched_repos entry the installation doesn't cover is reported, not
+	// silently added or dropped with no trace — see AC4). Kept as the same
+	// config key (rather than a rename) since it's deeply threaded through
+	// this struct, yamlConfig, and the reload machinery below; see
+	// ADR-1641 for the naming decision.
+	//
+	// Tagged "live" but never applied through the generic reflection loop
+	// in applyConfigReload — it's diffed and applied specially (diffRepos)
+	// so the reload summary can name individual repos added/removed rather
+	// than a single before/after slice dump. A SIGHUP-triggered change to
+	// this field no longer mints or removes any owner's installation
+	// auth (unlike pre-#1641): every installation is already minted
+	// unconditionally by Derive, so a filter edit only needs to
+	// re-intersect against the already-known installation grant
+	// (Reconciler.LastDerived()) — see execute.go's handleReload.
 	WatchedRepos   []string      `reload:"live"` // "owner/repo"
 	PollInterval   time.Duration `reload:"live"`
 	Model          string        `reload:"live"`
 	Effort         string        `reload:"live"`
 	ConcurrencyCap int           `reload:"live"`
 	MaxDiffBytes   int64         `reload:"live"`
+	// MaxDerivedRepos bounds the size of a single installation-derivation
+	// result (R5) — applied last, after the full installation-grant union
+	// and any WatchedRepos filter (R3) are computed, over a deterministic
+	// sort (owner/repo ascending) so the same repos are dropped consistently
+	// across re-derivations rather than an arbitrary API-order cut. <= 0
+	// disables the cap entirely (an explicit operator opt-out — R5's "or
+	// explicit acceptance" option). Live: the next re-derivation (event-
+	// triggered or timer-driven) picks up a changed value; a lowered cap
+	// takes effect on that same call, not only after a restart.
+	MaxDerivedRepos int `reload:"live"`
+	// RepoRederivationInterval is how often the daemon re-derives its repo
+	// set from the App's installations on a timer (R2), independent of any
+	// installation webhook event. See DefaultRepoRederivationInterval.
+	// Live: the ticker re-reads this on every tick (mirroring
+	// ReconciliationFallbackInterval's own reload-live convention).
+	RepoRederivationInterval time.Duration `reload:"live"`
 	// MaxWallTime caps a single claude review invocation's wall-clock
 	// duration. Zero means no cap (only the fixed 15-minute inactivity
 	// watchdog applies), matching Fabrik's own stage `max_wall_time`
@@ -211,6 +264,14 @@ type yamlConfig struct {
 	TUI                     *bool    `yaml:"tui"`
 	LogFile                 *string  `yaml:"log_file"`
 	AutoUpgrade             *bool    `yaml:"auto_upgrade"`
+	MaxDerivedRepos         *int     `yaml:"max_derived_repos"`
+	// RepoRederivationInterval is a Go duration string (e.g. "10m"),
+	// matching reconciliation.fallback_interval's own convention below,
+	// unlike this file's other duration fields (which use a "_seconds" int
+	// convention) — both govern a re-derivation/reconciliation timer, not a
+	// human-authored short interval, so a duration string reads more
+	// naturally here.
+	RepoRederivationInterval string `yaml:"repo_rederivation_interval"`
 
 	EventSource string `yaml:"event_source"`
 	Hookdeck    *struct {
@@ -272,6 +333,9 @@ type flagValues struct {
 	hookdeckWebhookSecretEnv       string
 	reconciliationStartup          bool
 	reconciliationFallbackInterval string
+
+	maxDerivedRepos          int
+	repoRederivationInterval string
 }
 
 // LoadConfig resolves Pruefer's configuration from, in increasing priority:
@@ -309,6 +373,8 @@ func LoadConfig(args []string) (Config, error) {
 	fs.StringVar(&fv.hookdeckWebhookSecretEnv, "hookdeck-webhook-secret-env", "", "Environment variable name holding the GitHub App's webhook secret")
 	fs.BoolVar(&fv.reconciliationStartup, "reconciliation-startup", true, "Run a full poll reconciliation pass at startup in event-driven mode")
 	fs.StringVar(&fv.reconciliationFallbackInterval, "reconciliation-fallback-interval", "", "Low-frequency poll interval used as a safety net in event-driven mode (Go duration, e.g. 2m)")
+	fs.IntVar(&fv.maxDerivedRepos, "max-derived-repos", 0, "Cap on the number of repos a single installation-derivation may yield (R5); 0 or negative disables the cap")
+	fs.StringVar(&fv.repoRederivationInterval, "repo-rederivation-interval", "", "How often to re-derive the watched repo set from the App's installations on a timer (Go duration, e.g. 10m)")
 	if err := fs.Parse(args); err != nil {
 		return Config{}, err
 	}
@@ -347,6 +413,9 @@ func LoadConfig(args []string) (Config, error) {
 		TUI:               true,
 		LogFile:           DefaultLogPath,
 		AutoUpgrade:       false,
+		MaxDerivedRepos:   DefaultMaxDerivedRepos,
+
+		RepoRederivationInterval: DefaultRepoRederivationInterval,
 
 		EventSource:                    DefaultEventSource,
 		HookdeckAPIKeyEnv:              DefaultHookdeckAPIKeyEnv,
@@ -362,6 +431,16 @@ func LoadConfig(args []string) (Config, error) {
 	}
 	if yc.AutoUpgrade != nil {
 		cfg.AutoUpgrade = *yc.AutoUpgrade
+	}
+	if yc.MaxDerivedRepos != nil {
+		cfg.MaxDerivedRepos = *yc.MaxDerivedRepos
+	}
+	if yc.RepoRederivationInterval != "" {
+		d, err := time.ParseDuration(yc.RepoRederivationInterval)
+		if err != nil {
+			return Config{}, fmt.Errorf("parsing repo_rederivation_interval %q: %w", yc.RepoRederivationInterval, err)
+		}
+		cfg.RepoRederivationInterval = d
 	}
 	if yc.PollIntervalSec != nil {
 		cfg.PollInterval = time.Duration(*yc.PollIntervalSec) * time.Second
@@ -482,6 +561,16 @@ func LoadConfig(args []string) (Config, error) {
 	if explicit["auto-upgrade"] {
 		cfg.AutoUpgrade = fv.autoUpgrade
 	}
+	if explicit["max-derived-repos"] {
+		cfg.MaxDerivedRepos = fv.maxDerivedRepos
+	}
+	if explicit["repo-rederivation-interval"] {
+		d, err := time.ParseDuration(fv.repoRederivationInterval)
+		if err != nil {
+			return Config{}, fmt.Errorf("parsing -repo-rederivation-interval %q: %w", fv.repoRederivationInterval, err)
+		}
+		cfg.RepoRederivationInterval = d
+	}
 	if explicit["event-source"] {
 		cfg.EventSource = fv.eventSource
 	}
@@ -599,6 +688,16 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("PRUEFER_AUTO_UPGRADE"); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {
 			cfg.AutoUpgrade = b
+		}
+	}
+	if v := os.Getenv("PRUEFER_MAX_DERIVED_REPOS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.MaxDerivedRepos = n
+		}
+	}
+	if v := os.Getenv("PRUEFER_REPO_REDERIVATION_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.RepoRederivationInterval = d
 		}
 	}
 	if v := os.Getenv("PRUEFER_EVENT_SOURCE"); v != "" {

--- a/pruefer/config_test.go
+++ b/pruefer/config_test.go
@@ -423,6 +423,90 @@ func TestLoadConfig_AutoUpgradePrecedence(t *testing.T) {
 	}
 }
 
+// TestLoadConfig_MaxDerivedReposDefaultsAndPrecedence covers R5's
+// max_derived_repos knob (#1641): the default, and the YAML < env < flag
+// precedence chain every other numeric field in this file already follows.
+func TestLoadConfig_MaxDerivedReposDefaultsAndPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := LoadConfig([]string{"-config", filepath.Join(dir, "missing.yaml")})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.MaxDerivedRepos != DefaultMaxDerivedRepos {
+		t.Errorf("MaxDerivedRepos = %d, want default %d", cfg.MaxDerivedRepos, DefaultMaxDerivedRepos)
+	}
+
+	path := writeYAMLConfig(t, dir, `max_derived_repos: 50`)
+	cfg, err = LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.MaxDerivedRepos != 50 {
+		t.Errorf("MaxDerivedRepos = %d, want 50 (from YAML)", cfg.MaxDerivedRepos)
+	}
+
+	t.Setenv("PRUEFER_MAX_DERIVED_REPOS", "75")
+	cfg, err = LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.MaxDerivedRepos != 75 {
+		t.Errorf("MaxDerivedRepos = %d, want 75 (env should override YAML)", cfg.MaxDerivedRepos)
+	}
+
+	cfg, err = LoadConfig([]string{"-config", path, "-max-derived-repos", "10"})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.MaxDerivedRepos != 10 {
+		t.Errorf("MaxDerivedRepos = %d, want 10 (flag should override env)", cfg.MaxDerivedRepos)
+	}
+}
+
+// TestLoadConfig_RepoRederivationIntervalDefaultsAndPrecedence mirrors
+// TestLoadConfig_ReconciliationPrecedence's duration-string handling for
+// repo_rederivation_interval (#1641/R2).
+func TestLoadConfig_RepoRederivationIntervalDefaultsAndPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := LoadConfig([]string{"-config", filepath.Join(dir, "missing.yaml")})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.RepoRederivationInterval != DefaultRepoRederivationInterval {
+		t.Errorf("RepoRederivationInterval = %s, want default %s", cfg.RepoRederivationInterval, DefaultRepoRederivationInterval)
+	}
+
+	path := writeYAMLConfig(t, dir, `repo_rederivation_interval: "5m"`)
+	cfg, err = LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.RepoRederivationInterval != 5*time.Minute {
+		t.Errorf("RepoRederivationInterval = %s, want 5m (from YAML)", cfg.RepoRederivationInterval)
+	}
+
+	t.Setenv("PRUEFER_REPO_REDERIVATION_INTERVAL", "7m")
+	cfg, err = LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.RepoRederivationInterval != 7*time.Minute {
+		t.Errorf("RepoRederivationInterval = %s, want 7m (env should override YAML)", cfg.RepoRederivationInterval)
+	}
+
+	cfg, err = LoadConfig([]string{"-config", path, "-repo-rederivation-interval", "3m"})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.RepoRederivationInterval != 3*time.Minute {
+		t.Errorf("RepoRederivationInterval = %s, want 3m (flag should override env)", cfg.RepoRederivationInterval)
+	}
+
+	if _, err := LoadConfig([]string{"-config", path, "-repo-rederivation-interval", "not-a-duration"}); err == nil {
+		t.Error("expected an error for an invalid -repo-rederivation-interval value")
+	}
+}
+
 func TestLoadConfig_VersionRequestedShortCircuits(t *testing.T) {
 	// --version must work even with no config file present and no other
 	// required flags set, so it short-circuits before YAML/env resolution.

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -931,7 +931,8 @@ func (d *Daemon) rederiveRepos(ctx context.Context) {
 	// of whether any of its repos survived the watched_repos filter/cap, so
 	// an owner whose repos are all filtered out today can still be minted
 	// and ready the moment the filter changes (e.g. a SIGHUP watched_repos
-	// edit re-intersecting against Reconciler.LastDerived()).
+	// edit, which triggers this same rederiveRepos call — see execute.go's
+	// handleReload — not a local re-intersection against a cached result).
 	clients := make(map[string]GitHubLister, len(set.Installations))
 	for _, inst := range set.Installations {
 		client, err := d.Reconciler.ClientForRepo(ctx, inst.Account, "")
@@ -969,6 +970,10 @@ func (d *Daemon) rederiveRepos(ctx context.Context) {
 // review set with no record (the same class of invisibility as #1428/#1563).
 func logRederivedRepos(set githubauth.DerivedRepoSet) {
 	for _, inst := range set.Installations {
+		if inst.MintError != "" {
+			logf(0, "derive", "installation %d (%s, repository_selection=%s): minting a token failed this round (%s) — the installation exists but is not yet usable; retry reconciliation\n", inst.InstallationID, inst.Account, inst.RepositorySelection, inst.MintError)
+			continue
+		}
 		logf(0, "derive", "installation %d (%s, repository_selection=%s): %d repo(s) accessible\n", inst.InstallationID, inst.Account, inst.RepositorySelection, inst.RepoCount)
 	}
 	suffix := ""

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -978,7 +978,7 @@ func logRederivedRepos(set githubauth.DerivedRepoSet) {
 	}
 	suffix := ""
 	if set.Capped {
-		suffix = fmt.Sprintf(" (capped from %d by max_derived_repos=%d)", set.TotalGranted(), set.CapApplied)
+		suffix = fmt.Sprintf(" (capped from %d by max_derived_repos=%d)", set.PreCapCount, set.CapApplied)
 	}
 	if set.Truncated {
 		suffix += " — WARNING: a pagination ceiling was hit while enumerating installations/repos; the actual grant may be larger than shown"

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -71,16 +71,46 @@ type Daemon struct {
 	Config   Config
 	BotLogin string
 
-	// cfgMu guards Config, Clients, and sem together — not three
-	// independent locks — because ApplyReload's owner-addition needs
-	// WatchedRepos and its corresponding Clients entry to become visible as
-	// one atomic unit; two locks would let a reader observe the new repo in
-	// Config.WatchedRepos before its owner's client exists in Clients. sem
-	// is included because its size is derived from Config.ConcurrencyCap
-	// (see semaphore()) and a resize must not race a config read. Zero
-	// value is a ready-to-use, unlocked RWMutex, so a Daemon{} struct
-	// literal (the existing test pattern) needs no change.
+	// Reconciler is the installation-derived discovery engine (#1641):
+	// rederiveRepos calls its Derive method to re-fetch the App's current
+	// installation grant and re-populate derived/Clients below. nil (only
+	// possible in a hand-built test Daemon{} literal that never wires one,
+	// or a pinned-AppInstallationID compat deployment where re-derivation
+	// is a documented no-op — see Derive's own doc comment) makes
+	// rederiveRepos a no-op; production construction (execute.go) always
+	// sets it.
+	Reconciler *githubauth.Reconciler
+
+	// derived is the result of the most recent rederiveRepos call — the
+	// installation-derived, watched_repos-filtered, max_derived_repos-capped
+	// repo set poll()/isWatchedRepo actually consume, replacing
+	// Config.WatchedRepos as of #1641 (which is now only an input to
+	// derivation, an optional intersection filter — see Config.WatchedRepos'
+	// own doc comment). Guarded by cfgMu alongside Config/Clients: a reader
+	// must never observe a derived repo whose owner's Clients entry hasn't
+	// been committed in the same update, exactly the same invariant
+	// ApplyReload already established for Config.WatchedRepos/Clients.
+	derived githubauth.DerivedRepoSet
+
+	// cfgMu guards Config, Clients, derived, and sem together — not
+	// independent locks — because a re-derivation's owner addition needs
+	// derived and its corresponding Clients entry to become visible as one
+	// atomic unit; two locks would let a reader observe a new repo in
+	// derived before its owner's client exists in Clients. sem is included
+	// because its size is derived from Config.ConcurrencyCap (see
+	// semaphore()) and a resize must not race a config read. Zero value is
+	// a ready-to-use, unlocked RWMutex, so a Daemon{} struct literal (the
+	// existing test pattern) needs no change.
 	cfgMu sync.RWMutex
+
+	// rederiveInFlight coalesces concurrent re-derivation triggers (an
+	// installation webhook event racing the periodic ticker, or a burst of
+	// installation_repositories events) — mirrors pollInFlight's own
+	// CompareAndSwap-guarded shape below. A trigger arriving while one is
+	// already in flight is dropped: the in-flight call already re-derives
+	// current GitHub state, and any further change is still covered by the
+	// next ticker tick or the next webhook event.
+	rederiveInFlight atomic.Bool
 
 	// FabrikDir is the directory containing .pruefer/pruefer.lock. Defaults
 	// to "." (cwd) when empty.
@@ -186,6 +216,17 @@ func (d *Daemon) config() Config {
 	return d.Config
 }
 
+// derivedSet returns a snapshot of the daemon's current
+// githubauth.DerivedRepoSet, safe for concurrent use alongside a
+// rederiveRepos-triggered ApplyDerivedRepos. Every production read of the
+// effective (installation-derived, filtered, capped) repo set must go
+// through this — poll() and isWatchedRepo below are the two consumers.
+func (d *Daemon) derivedSet() githubauth.DerivedRepoSet {
+	d.cfgMu.RLock()
+	defer d.cfgMu.RUnlock()
+	return d.derived
+}
+
 // client resolves owner's GitHubLister via an exact map lookup, safe for
 // concurrent use alongside ApplyReload. Unlike clientForOwner, this performs
 // no case-insensitive fallback scan — callers that already have an
@@ -237,6 +278,26 @@ func (d *Daemon) ApplyReload(merged Config, addedClients map[string]GitHubLister
 	for owner, c := range addedClients {
 		d.Clients[owner] = c
 	}
+}
+
+// ApplyDerivedRepos atomically swaps in a freshly derived repo set and
+// rebuilds Clients wholesale from clients — the installation-derived analog
+// of ApplyReload (#1641), sharing its concurrency-safety shape: a reader can
+// never observe a repo in derived whose owner's Clients entry isn't there
+// yet. Unlike ApplyReload's incremental addedClients/removedOwners merge,
+// this replaces Clients wholesale rather than diffing — installation counts
+// for one operator's own dedicated App are small (their own orgs/repos, not
+// a shared-App fleet), so a full rebuild on every re-derivation is cheap and
+// avoids an entire class of incremental-diff bugs (see ADR-1641). Called
+// only from rederiveRepos, after githubauth.Reconciler.Derive has already
+// minted/committed every new owner's auth and detached every owner that lost
+// its installation (the detach-then-drain half is the caller's
+// responsibility — see RemoveOwners' doc comment, mirrored by rederiveRepos).
+func (d *Daemon) ApplyDerivedRepos(set githubauth.DerivedRepoSet, clients map[string]GitHubLister) {
+	d.cfgMu.Lock()
+	defer d.cfgMu.Unlock()
+	d.derived = set
+	d.Clients = clients
 }
 
 // prGate is one PR's dispatch gate, plus the reference count that decides
@@ -531,6 +592,17 @@ func (d *Daemon) Run(ctx context.Context) (err error) {
 		}()
 	}
 
+	// The periodic re-derivation ticker (#1641/R2) runs uniformly in both
+	// poll-mode and event-driven mode — a poll-mode deployment has no
+	// installation webhook event to react to at all, and event-driven mode
+	// gets this as a low-frequency safety net alongside its own
+	// event-triggered re-derivation. Started here, before either mode's own
+	// loop, so it's running for the daemon's whole lifetime; it exits on
+	// its own once ctx is cancelled, with nothing else to join it against
+	// (mirroring the refresh-loop goroutines' own unmanaged-but-ctx-scoped
+	// lifecycle in internal/githubauth.Reconciler.RunRefreshLoops).
+	go d.runRederivationTicker(ctx)
+
 	if d.EventSource != nil {
 		return d.runEventDriven(ctx)
 	}
@@ -544,7 +616,7 @@ func (d *Daemon) Run(ctx context.Context) (err error) {
 func (d *Daemon) runPollOnly(ctx context.Context) error {
 	initial := d.config()
 	logf(0, "poll", "pruefer starting: watching %d repo(s), poll interval %s, concurrency %d\n",
-		len(initial.WatchedRepos), pollInterval(initial), d.effectiveConcurrency())
+		len(d.derivedSet().Repos), pollInterval(initial), d.effectiveConcurrency())
 
 	// lastUpgradeCheck is local to Run, not a Daemon field: Run is the sole
 	// sequential caller (both TUI and headless modes call d.Run), so there's
@@ -624,7 +696,7 @@ func (d *Daemon) runEventDriven(ctx context.Context) error {
 	initial := d.config()
 	fallback := d.reconciliationFallbackInterval()
 	logf(0, "poll", "pruefer starting: watching %d repo(s) in event-driven mode, reconciliation fallback %s, concurrency %d\n",
-		len(initial.WatchedRepos), fallback, d.effectiveConcurrency())
+		len(d.derivedSet().Repos), fallback, d.effectiveConcurrency())
 
 	if initial.ReconciliationStartup {
 		logf(0, "poll", "running startup reconciliation poll\n")
@@ -816,61 +888,225 @@ func (d *Daemon) triggerReconciliationPoll(ctx context.Context) {
 	}()
 }
 
-// poll runs one polling cycle across every watched repo, dispatching
+// repoRederivationInterval returns Config.RepoRederivationInterval, falling
+// back to DefaultRepoRederivationInterval for an absent/non-positive value —
+// mirrors pollInterval/reconciliationFallbackInterval's own fallback
+// convention.
+func (d *Daemon) repoRederivationInterval() time.Duration {
+	if v := d.config().RepoRederivationInterval; v > 0 {
+		return v
+	}
+	return DefaultRepoRederivationInterval
+}
+
+// rederiveRepos is the single entry point every re-derivation trigger
+// (startup, an installation/installation_repositories webhook event, and
+// the periodic ticker below) converges on (#1641/R2): it re-fetches the
+// App's current installation grant via Reconciler.Derive, resolves a
+// GitHubLister for every installation found, and atomically applies both to
+// the daemon via ApplyDerivedRepos. A nil Reconciler (only possible in a
+// hand-built test Daemon{} literal that never wires one) makes this a no-op
+// — production construction (execute.go) always sets it.
+//
+// Derive's own maxRepos<=0 "no cap" convention means Config.MaxDerivedRepos
+// is passed straight through with no additional fallback here — unlike
+// PollInterval/ConcurrencyCap's zero-means-default convention, MaxDerivedRepos'
+// own doc comment documents zero/negative as an explicit operator opt-out
+// (R5), and LoadConfig has already resolved "unset" to DefaultMaxDerivedRepos
+// by the time Config reaches here — see that field's doc comment.
+func (d *Daemon) rederiveRepos(ctx context.Context) {
+	if d.Reconciler == nil {
+		return
+	}
+	cfg := d.config()
+	set, detached, err := d.Reconciler.Derive(ctx, cfg.WatchedRepos, cfg.MaxDerivedRepos, func(format string, args ...any) {
+		logf(0, "derive", format+"\n", args...)
+	})
+	if err != nil {
+		logf(0, "warn", "re-deriving repo set from installations: %v — keeping the previous derived set\n", err)
+		return
+	}
+
+	// Resolve one GitHubLister per installation Derive found — regardless
+	// of whether any of its repos survived the watched_repos filter/cap, so
+	// an owner whose repos are all filtered out today can still be minted
+	// and ready the moment the filter changes (e.g. a SIGHUP watched_repos
+	// edit re-intersecting against Reconciler.LastDerived()).
+	clients := make(map[string]GitHubLister, len(set.Installations))
+	for _, inst := range set.Installations {
+		client, err := d.Reconciler.ClientForRepo(ctx, inst.Account, "")
+		if err != nil {
+			logf(0, "warn", "no client for installed owner %q after derivation: %v\n", inst.Account, err)
+			continue
+		}
+		clients[strings.ToLower(inst.Account)] = client
+	}
+
+	d.ApplyDerivedRepos(set, clients)
+	logRederivedRepos(set)
+	d.emit(ptui.DerivedRepoSetEvent{
+		Repos:       derivedRepoNames(set),
+		Installations: derivedInstallationSummaries(set),
+		FilteredOut: append([]string(nil), set.FilteredOut...),
+		Truncated:   set.Truncated,
+		Capped:      set.Capped,
+		CapApplied:  set.CapApplied,
+		At:          time.Now(),
+	})
+
+	// Owners that lost their installation between this and the previous
+	// derivation are drained-then-stopped exactly like a SIGHUP-removed
+	// owner (ADR-1640) — an in-flight review dispatched before this
+	// re-derivation may still hold a *gh.Client backed by one of these
+	// Auths, so it must be allowed to finish before the refresh loop stops.
+	for _, det := range detached {
+		go d.drainThenStopAuth(ctx, det.Owner, det.Auth)
+	}
+}
+
+// logRederivedRepos logs the derived set's contents and provenance (R4) —
+// the failure mode this prevents is a repo silently joining or leaving the
+// review set with no record (the same class of invisibility as #1428/#1563).
+func logRederivedRepos(set githubauth.DerivedRepoSet) {
+	for _, inst := range set.Installations {
+		logf(0, "derive", "installation %d (%s, repository_selection=%s): %d repo(s) accessible\n", inst.InstallationID, inst.Account, inst.RepositorySelection, inst.RepoCount)
+	}
+	suffix := ""
+	if set.Capped {
+		suffix = fmt.Sprintf(" (capped from %d by max_derived_repos=%d)", set.TotalGranted(), set.CapApplied)
+	}
+	if set.Truncated {
+		suffix += " — WARNING: a pagination ceiling was hit while enumerating installations/repos; the actual grant may be larger than shown"
+	}
+	logf(0, "derive", "derived %d repo(s) to review across %d installation(s)%s\n", len(set.Repos), len(set.Installations), suffix)
+	for _, f := range set.FilteredOut {
+		logf(0, "derive", "watched_repos entry %q is not covered by any installation's grant — excluded\n", f)
+	}
+}
+
+// derivedRepoNames extracts set.Repos' "owner/repo" names, for
+// ptui.DerivedRepoSetEvent — kept a plain []string (rather than exposing
+// githubauth.DerivedRepo to the tui package) so pruefer/tui stays free of a
+// dependency on internal/githubauth, mirroring ReviewCompletedEvent.Reason's
+// existing "re-express as a plain type" convention.
+func derivedRepoNames(set githubauth.DerivedRepoSet) []string {
+	out := make([]string, len(set.Repos))
+	for i, dr := range set.Repos {
+		out[i] = dr.Repo
+	}
+	return out
+}
+
+// derivedInstallationSummaries re-expresses set.Installations as
+// ptui.DerivedInstallationSummary, for the same reason derivedRepoNames
+// re-expresses set.Repos.
+func derivedInstallationSummaries(set githubauth.DerivedRepoSet) []ptui.DerivedInstallationSummary {
+	out := make([]ptui.DerivedInstallationSummary, len(set.Installations))
+	for i, inst := range set.Installations {
+		out[i] = ptui.DerivedInstallationSummary{
+			Account: inst.Account, InstallationID: inst.InstallationID,
+			RepositorySelection: inst.RepositorySelection, RepoCount: inst.RepoCount,
+		}
+	}
+	return out
+}
+
+// triggerRederivation re-derives the repo set (see rederiveRepos) and then
+// triggers a follow-up reconciliation poll — so a repo an installation
+// event just added becomes pollable promptly, in the same cycle, rather
+// than only on the next fallback-interval tick (AC3) — coalescing
+// concurrent triggers via rederiveInFlight exactly as triggerReconciliationPoll
+// coalesces concurrent polls.
+func (d *Daemon) triggerRederivation(ctx context.Context) {
+	if !d.rederiveInFlight.CompareAndSwap(false, true) {
+		logf(0, "derive", "re-derivation already in flight — coalescing this trigger\n")
+		return
+	}
+	go func() {
+		defer d.rederiveInFlight.Store(false)
+		d.rederiveRepos(ctx)
+		d.triggerReconciliationPoll(ctx)
+	}()
+}
+
+// runRederivationTicker periodically calls triggerRederivation on
+// RepoRederivationInterval, independent of any installation webhook event —
+// the R2 mechanism poll-mode deployments need (no webhook event to react to
+// at all) and a low-frequency safety net for event-driven mode alongside its
+// own event-triggered re-derivation. One uniform ticker for both modes,
+// started unconditionally by Run, rather than two mode-specific mechanisms.
+func (d *Daemon) runRederivationTicker(ctx context.Context) {
+	interval := d.repoRederivationInterval()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if next := d.repoRederivationInterval(); next != interval {
+				interval = next
+				ticker.Reset(interval)
+			}
+			d.triggerRederivation(ctx)
+		}
+	}
+}
+
+// poll runs one polling cycle across every derived repo, dispatching
 // eligible PRs to ReviewPR through a concurrency-capped semaphore shared
 // across the whole cycle (not per-repo) — Pruefer's claude capacity is one
 // subscription shared across every watched repo, not one per repo.
 func (d *Daemon) poll(ctx context.Context) {
 	var wg sync.WaitGroup
 
-	// One snapshot for the whole cycle: WatchedRepos is read exactly once
-	// here rather than once per loop iteration, so a reload that lands
-	// mid-cycle can't make this loop observe a different repo list than it
-	// started with. A repo removed mid-cycle is simply not polled on the
-	// *next* cycle — this one still runs against the set it started with,
-	// including finishing any review it already dispatched (ADR-1640's R3).
-	cfg := d.config()
+	// One snapshot for the whole cycle: the derived set is read exactly once
+	// here rather than once per loop iteration, so a re-derivation that
+	// lands mid-cycle can't make this loop observe a different repo list
+	// than it started with. A repo removed mid-cycle is simply not polled
+	// on the *next* cycle — this one still runs against the set it started
+	// with, including finishing any review it already dispatched
+	// (ADR-1640's R3, unchanged by #1641's derivation source swap).
+	derived := d.derivedSet()
 
-	for _, repoSpec := range cfg.WatchedRepos {
-		owner, repo, ok := splitOwnerRepo(repoSpec)
+	for _, dr := range derived.Repos {
+		client, ok := d.client(strings.ToLower(dr.Owner))
 		if !ok {
-			logf(0, "warn", "skipping malformed watched repo %q (want owner/repo)\n", repoSpec)
+			// Expected when an owner's installation was found but minting
+			// failed this round (see Reconciler.Derive's mintErrors). Not
+			// transient in general: it recurs every poll cycle until the
+			// next successful re-derivation. Skip rather than panic.
+			logf(0, "warn", "no client for owner %q (repo %s) — skipping this repo until the next re-derivation succeeds\n", dr.Owner, dr.Repo)
 			continue
 		}
-		client, ok := d.client(strings.ToLower(owner))
-		if !ok {
-			// Expected when an owner has no resolved App installation (see
-			// internal/githubauth.Reconcile, which already logged a guided-
-			// install URL for this owner at startup). Reconcile does not
-			// re-run after startup, so this is not transient: it recurs
-			// every poll cycle until the operator installs the App and
-			// restarts Pruefer. Skip rather than panic.
-			logf(0, "warn", "no client for owner %q (repo %s) — install the GitHub App on %q, then restart Pruefer to pick it up; skipping this repo until then\n", owner, repoSpec, owner)
-			continue
-		}
-		repoName := owner + "/" + repo
 		pollAt := time.Now()
-		prs, err := client.ListOpenPRs(owner, repo)
+		prs, err := client.ListOpenPRs(dr.Owner, dr.RepoName)
 		if err != nil {
-			logf(0, "warn", "listing open PRs for %s/%s: %v — skipping this repo this cycle\n", owner, repo, err)
-			d.emit(ptui.RepoPollEvent{Repo: repoName, At: pollAt, Err: err.Error()})
+			logf(0, "warn", "listing open PRs for %s: %v — skipping this repo this cycle\n", dr.Repo, err)
+			d.emit(ptui.RepoPollEvent{Repo: dr.Repo, At: pollAt, Err: err.Error()})
 			continue
 		}
-		d.emit(ptui.RepoPollEvent{Repo: repoName, At: pollAt, PRCount: len(prs)})
+		d.emit(ptui.RepoPollEvent{Repo: dr.Repo, At: pollAt, PRCount: len(prs)})
 		for _, pr := range prs {
-			d.reviewOne(ctx, &wg, client, owner, repo, pr)
+			d.reviewOne(ctx, &wg, client, dr.Owner, dr.RepoName, pr)
 		}
 	}
 	wg.Wait()
 
-	for _, owner := range distinctOwners(cfg.WatchedRepos) {
-		client, ok := d.client(strings.ToLower(owner))
+	seenOwner := make(map[string]bool, len(derived.Repos))
+	for _, dr := range derived.Repos {
+		key := strings.ToLower(dr.Owner)
+		if seenOwner[key] {
+			continue
+		}
+		seenOwner[key] = true
+		client, ok := d.client(key)
 		if !ok {
 			continue
 		}
 		if reporter, ok := client.(RateLimitReporter); ok {
 			rest, _ := reporter.RateLimitStats()
-			d.emit(ptui.RateLimitSnapshotEvent{Owner: owner, Stats: rest})
+			d.emit(ptui.RateLimitSnapshotEvent{Owner: dr.Owner, Stats: rest})
 		}
 	}
 }
@@ -960,108 +1196,32 @@ func (d *Daemon) executeReview(ctx context.Context, client GitHubLister, owner, 
 	})
 }
 
-// isWatchedRepo reports whether owner/repo is one of Config.WatchedRepos.
-// poll() never needs this check — it only ever iterates WatchedRepos in the
-// first place — but event-triggered dispatch (ReviewFromEvent) must check
-// explicitly: Daemon.Clients is owner-keyed, not repo-keyed, and an owner's
-// installation token can plausibly cover repos beyond what Pruefer is
-// configured to watch. In particular, the Hookdeck adapter creates its
-// session with webhook_ids: [] (see hookdeck/client.go's createSession) —
-// "every connection visible to this API key," not scoped to watched repos —
-// so a webhook event for an unwatched repo under a watched owner is a
-// plausible real delivery, not just a hypothetical one.
+// isWatchedRepo reports whether owner/repo is one of the daemon's currently
+// derived repos (#1641 — was Config.WatchedRepos directly, pre-derivation).
+// poll() never needs this check — it only ever iterates the derived set in
+// the first place — but event-triggered dispatch (ReviewFromEvent) must
+// check explicitly: Daemon.Clients is owner-keyed, not repo-keyed, and an
+// owner's installation token can plausibly cover repos beyond the derived
+// (filtered/capped) set Pruefer is actually reviewing. In particular, the
+// Hookdeck adapter creates its session with webhook_ids: [] (see
+// hookdeck/client.go's createSession) — "every connection visible to this
+// API key," not scoped to the derived set — so a webhook event for a
+// covered-but-unreviewed repo under a watched owner is a plausible real
+// delivery, not just a hypothetical one.
 // Matching is case-insensitive: GitHub treats owner and repository names as
 // case-insensitive, and the two sides of this comparison have different
 // provenance — `owner`/`repo` come from the webhook payload's
 // `repository.owner.login`/`repository.name` (GitHub's canonical casing at
-// delivery time), while WatchedRepos is hand-typed config. A casing
-// divergence between them, including one introduced by a later owner or repo
-// rename, would otherwise silently drop every event for that repo.
+// delivery time), while the derived set's Repo field comes from whatever
+// casing FetchInstallationRepositories/the watched_repos filter used. A
+// casing divergence between them, including one introduced by a later owner
+// or repo rename, would otherwise silently drop every event for that repo.
 func (d *Daemon) isWatchedRepo(owner, repo string) bool {
 	target := owner + "/" + repo
-	for _, spec := range d.config().WatchedRepos {
-		if strings.EqualFold(spec, target) {
+	for _, dr := range d.derivedSet().Repos {
+		if strings.EqualFold(dr.Repo, target) {
 			return true
 		}
 	}
 	return false
-}
-
-// splitOwnerRepo splits "owner/repo" into its two parts. Returns ok=false
-// for anything else (missing/extra slash, empty parts).
-func splitOwnerRepo(spec string) (owner, repo string, ok bool) {
-	parts := strings.Split(spec, "/")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", false
-	}
-	return parts[0], parts[1], true
-}
-
-// distinctOwners returns the distinct owners of every well-formed
-// "owner/repo" entry in watchedRepos, in first-seen order. Malformed entries
-// are skipped here — poll() already logs and skips them independently.
-//
-// Dedup is case-insensitive (keyed on the lower-cased owner, keeping the
-// first-seen literal casing in the result), mirroring
-// internal/githubauth's distinctOwnersLogging: GitHub org/user logins are
-// case-insensitive, so "MyOrg/repo1" and "myorg/repo2" name the same
-// account. d.Clients (built by execute.go from this same function) is
-// itself keyed by lower-cased owner for the same reason — an exact-case
-// dedup here would produce a second "distinct" owner with no corresponding
-// d.Clients entry, silently dropping that repo from every poll cycle.
-func distinctOwners(watchedRepos []string) []string {
-	seen := make(map[string]bool)
-	var owners []string
-	for _, spec := range watchedRepos {
-		owner, _, ok := splitOwnerRepo(spec)
-		if !ok {
-			continue
-		}
-		key := strings.ToLower(owner)
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		owners = append(owners, owner)
-	}
-	return owners
-}
-
-// newlyWatchedOwners returns the distinct owners present in cand's
-// WatchedRepos but absent from old's, in cand's first-seen order — the set
-// a config reload must mint a token for before it can be applied
-// (ADR-1640). Adding a repo under an already-watched owner never appears
-// here. Comparison is case-insensitive, matching distinctOwners' own dedup.
-func newlyWatchedOwners(old, cand Config) []string {
-	oldOwners := make(map[string]bool)
-	for _, o := range distinctOwners(old.WatchedRepos) {
-		oldOwners[strings.ToLower(o)] = true
-	}
-	var added []string
-	for _, o := range distinctOwners(cand.WatchedRepos) {
-		if !oldOwners[strings.ToLower(o)] {
-			added = append(added, o)
-		}
-	}
-	return added
-}
-
-// noLongerWatchedOwners returns the distinct owners present in old's
-// WatchedRepos but absent from cand's, in old's first-seen order — the set
-// a config reload must prune auth/client state for via
-// internal/githubauth.Reconciler.RemoveOwners. Removing one repo under an
-// owner that still has another watched repo never appears here — the
-// mirror image of newlyWatchedOwners.
-func noLongerWatchedOwners(old, cand Config) []string {
-	candOwners := make(map[string]bool)
-	for _, o := range distinctOwners(cand.WatchedRepos) {
-		candOwners[strings.ToLower(o)] = true
-	}
-	var removed []string
-	for _, o := range distinctOwners(old.WatchedRepos) {
-		if !candOwners[strings.ToLower(o)] {
-			removed = append(removed, o)
-		}
-	}
-	return removed
 }

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -945,13 +945,13 @@ func (d *Daemon) rederiveRepos(ctx context.Context) {
 	d.ApplyDerivedRepos(set, clients)
 	logRederivedRepos(set)
 	d.emit(ptui.DerivedRepoSetEvent{
-		Repos:       derivedRepoNames(set),
+		Repos:         derivedRepoEntries(set),
 		Installations: derivedInstallationSummaries(set),
-		FilteredOut: append([]string(nil), set.FilteredOut...),
-		Truncated:   set.Truncated,
-		Capped:      set.Capped,
-		CapApplied:  set.CapApplied,
-		At:          time.Now(),
+		FilteredOut:   append([]string(nil), set.FilteredOut...),
+		Truncated:     set.Truncated,
+		Capped:        set.Capped,
+		CapApplied:    set.CapApplied,
+		At:            time.Now(),
 	})
 
 	// Owners that lost their installation between this and the previous
@@ -993,6 +993,19 @@ func derivedRepoNames(set githubauth.DerivedRepoSet) []string {
 	out := make([]string, len(set.Repos))
 	for i, dr := range set.Repos {
 		out[i] = dr.Repo
+	}
+	return out
+}
+
+// derivedRepoEntries re-expresses set.Repos as ptui.DerivedRepoEntry —
+// "owner/repo" paired with its granting installation ID — the per-repo half
+// of R4's "exactly which repos it derived and from which installation"
+// requirement DerivedRepoSetEvent carries (derivedRepoNames above discards
+// that pairing; it exists only for tui.New's plain-name seed).
+func derivedRepoEntries(set githubauth.DerivedRepoSet) []ptui.DerivedRepoEntry {
+	out := make([]ptui.DerivedRepoEntry, len(set.Repos))
+	for i, dr := range set.Repos {
+		out[i] = ptui.DerivedRepoEntry{Repo: dr.Repo, InstallationID: dr.InstallationID}
 	}
 	return out
 }

--- a/pruefer/daemon_eventdriven_test.go
+++ b/pruefer/daemon_eventdriven_test.go
@@ -50,14 +50,14 @@ func newEventDrivenTestDaemon(source *fakeEventSource) (*Daemon, *fakeLister) {
 	clone := func(ctx context.Context, owner, repo, token string, prNumber int) (string, func(), error) {
 		return "/tmp", func() {}, nil
 	}
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:     map[string]GitHubLister{"owner": client},
 		Claude:      claude,
 		Clone:       clone,
 		Config:      Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 3},
 		BotLogin:    "pruefer-bot[bot]",
 		EventSource: source,
-	}
+	}, "owner/repo")
 	return d, client
 }
 

--- a/pruefer/daemon_test.go
+++ b/pruefer/daemon_test.go
@@ -6,14 +6,46 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
 	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/githubauth"
 	ptui "github.com/handarbeit/fabrik/pruefer/tui"
 )
+
+// testDerivedRepoSet builds a githubauth.DerivedRepoSet directly from a list
+// of "owner/repo" strings, treating every well-formed entry as fully
+// granted with no filtering/capping — the "no derivation, just trust the
+// list" shape most pre-#1641 test fixtures assumed when they set
+// Config.WatchedRepos directly. A malformed entry is silently skipped,
+// mirroring internal/githubauth.derivedRepoFromFullName's own handling.
+// Tests that need FilteredOut/Truncated/Capped semantics construct a
+// githubauth.DerivedRepoSet directly instead of using this helper.
+func testDerivedRepoSet(repos ...string) githubauth.DerivedRepoSet {
+	var out []githubauth.DerivedRepo
+	for _, spec := range repos {
+		owner, name, ok := strings.Cut(spec, "/")
+		if !ok || owner == "" || name == "" {
+			continue
+		}
+		out = append(out, githubauth.DerivedRepo{Repo: spec, Owner: owner, RepoName: name})
+	}
+	return githubauth.DerivedRepoSet{Repos: out}
+}
+
+// withDerivedRepos is a small test-fixture helper: it seeds d's derived
+// state directly from repos (see testDerivedRepoSet) and returns d, so a
+// test can build a Daemon{} literal and apply the derived-set migration in
+// one expression — e.g. `d := withDerivedRepos(&Daemon{...}, "owner/repo")`.
+// See the pruefer test-fixture migration note in ADR-1641.
+func withDerivedRepos(d *Daemon, repos ...string) *Daemon {
+	d.derived = testDerivedRepoSet(repos...)
+	return d
+}
 
 // fakeLister extends fakeReviewer with ListOpenPRs and FetchPRDetails,
 // keyed by "owner/repo".
@@ -172,13 +204,13 @@ func TestDaemonPoll_EnforcesConcurrencyCap(t *testing.T) {
 	claude := newConcurrencyTrackingInvoker()
 	clone, _ := fakeClone(t, nil)
 
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 2},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "owner/repo")
 
 	done := make(chan struct{})
 	go func() {
@@ -220,13 +252,13 @@ func TestDaemonPoll_DiffSizeGuardAppliesAcrossRepos(t *testing.T) {
 	claude := &mockClaudeInvoker{}
 	clone, cloneCalls := fakeClone(t, nil)
 
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, MaxDiffBytes: 5, ConcurrencyCap: 3},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "owner/repo")
 	d.poll(context.Background())
 
 	if cloneCalls.Load() != 0 {
@@ -240,17 +272,21 @@ func TestDaemonPoll_DiffSizeGuardAppliesAcrossRepos(t *testing.T) {
 	}
 }
 
+// TestDaemonPoll_SkipsMalformedWatchedRepo covers an empty derived set
+// (e.g. a malformed watched_repos entry, which internal/githubauth's own
+// owner-parsing already skips and logs before Derive ever runs — see
+// distinctOwnersLogging/derivedRepoFromFullName) — poll() must not panic.
 func TestDaemonPoll_SkipsMalformedWatchedRepo(t *testing.T) {
 	claude := &mockClaudeInvoker{}
 	clone, _ := fakeClone(t, nil)
 
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"not-a-valid-repo-spec"}},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "not-a-valid-repo-spec")
 	d.poll(context.Background()) // must not panic
 }
 
@@ -261,13 +297,13 @@ func TestDaemonPoll_ContinuesAfterOneRepoListFails(t *testing.T) {
 	claude := &mockClaudeInvoker{}
 	clone, _ := fakeClone(t, nil)
 
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/broken", "owner/good"}, ConcurrencyCap: 3},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "owner/broken", "owner/good")
 	d.poll(context.Background())
 
 	if client.submitCallCount() != 1 {
@@ -302,9 +338,9 @@ func TestDaemonPoll_RoutesEachRepoThroughOwnersToken(t *testing.T) {
 		return t.TempDir(), func() {}, nil
 	}
 
-	d := &Daemon{
-		// Clients is keyed by lower-cased owner — see distinctOwners' and
-		// poll()'s doc comments for why (execute.go, the real caller,
+	d := withDerivedRepos(&Daemon{
+		// Clients is keyed by lower-cased owner — see poll()'s and
+		// rederiveRepos' doc comments for why (execute.go, the real caller,
 		// always lower-cases when populating this map).
 		Clients: map[string]GitHubLister{"ownera": clientA, "ownerb": clientB},
 		Claude:  claude,
@@ -314,7 +350,7 @@ func TestDaemonPoll_RoutesEachRepoThroughOwnersToken(t *testing.T) {
 			ConcurrencyCap: 3,
 		},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "ownerA/repoA", "ownerB/repoB")
 	d.poll(context.Background())
 
 	if clientA.submitCallCount() != 1 {
@@ -361,14 +397,14 @@ func buildParityFixture(t *testing.T, emit func(ptui.Event)) (*Daemon, *fakeList
 	}
 	claude := &mockClaudeInvoker{}
 	clone, _ := fakeClone(t, nil)
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 3},
 		BotLogin: "pruefer-bot[bot]",
 		Emit:     emit,
-	}
+	}, "owner/repo")
 	return d, client, claude
 }
 
@@ -407,41 +443,6 @@ func TestDaemonPoll_TUIOffAndOnProduceIdenticalDecisions(t *testing.T) {
 	mu.Unlock()
 	if n == 0 {
 		t.Error("TUI-on run emitted no events — Emit wiring is not actually exercised by this test")
-	}
-}
-
-func TestSplitOwnerRepo(t *testing.T) {
-	cases := []struct {
-		spec      string
-		wantOwner string
-		wantRepo  string
-		wantOK    bool
-	}{
-		{"handarbeit/fabrik", "handarbeit", "fabrik", true},
-		{"handarbeit", "", "", false},
-		{"handarbeit/fabrik/extra", "", "", false},
-		{"/fabrik", "", "", false},
-		{"handarbeit/", "", "", false},
-		{"", "", "", false},
-	}
-	for _, tc := range cases {
-		owner, repo, ok := splitOwnerRepo(tc.spec)
-		if ok != tc.wantOK || owner != tc.wantOwner || repo != tc.wantRepo {
-			t.Errorf("splitOwnerRepo(%q) = (%q, %q, %v), want (%q, %q, %v)", tc.spec, owner, repo, ok, tc.wantOwner, tc.wantRepo, tc.wantOK)
-		}
-	}
-}
-
-func TestDistinctOwners(t *testing.T) {
-	got := distinctOwners([]string{"a/one", "b/two", "a/three", "malformed", "b/four"})
-	want := []string{"a", "b"}
-	if len(got) != len(want) {
-		t.Fatalf("distinctOwners = %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("distinctOwners[%d] = %q, want %q", i, got[i], want[i])
-		}
 	}
 }
 

--- a/pruefer/eventsink.go
+++ b/pruefer/eventsink.go
@@ -116,18 +116,15 @@ var reviewTriggerActions = map[string]bool{
 }
 
 // installEventTypes are GitHub webhook event types signaling an
-// installation/repo-selection change. These trigger a full reconciliation
-// poll rather than a single-PR review: Daemon.Clients is owner-keyed
-// (execute.go's githubauth.Reconcile/ClientForRepo wiring), and while a
-// SIGHUP-triggered config reload (ADR-1640) can now dynamically mint an
-// Auth for an owner newly added to watched_repos
-// (Reconciler.MintOwnerAuth/CommitOwnerAuth), that path is driven by a
-// config change, not by these installation-scoped webhook events — an
-// existing owner gaining/losing repos under an installation, or an
-// installation appearing for an owner not yet in watched_repos, has no
-// config change to react to here. Re-checking GitHub state via a poll
-// sweep satisfies "webhooks are triggers, GitHub is truth" without
-// inventing new auth machinery for this narrower case.
+// installation/repo-selection change. These trigger a full re-derivation
+// (daemon.triggerRederivation, #1641/R2) rather than a single-PR review:
+// installing/uninstalling the App, or changing its repository selection,
+// must be picked up without a restart — Reconciler.Derive re-fetches every
+// installation's current grant live, mints a client for any newly-installed
+// owner, and detaches one that lost its installation, satisfying AC3's
+// "repo added becomes pollable, repo removed stops being polled, no
+// restart" requirement directly, rather than only re-listing PRs against an
+// unchanged repo set the way a plain reconciliation poll would.
 var installEventTypes = map[string]bool{
 	"installation":              true,
 	"installation_repositories": true,
@@ -157,12 +154,12 @@ type daemonEventSink struct {
 //
 // The pull_request branch dispatches via its own `go`, since
 // ReviewFromEvent itself blocks (on the semaphore, then optionally the PR
-// lock). The install-event branch calls triggerReconciliationPoll directly,
-// not via `go` — that's still non-blocking, but by triggerReconciliationPoll's
-// own construction (an atomic CompareAndSwap guard around an internally
-// spawned goroutine), not because this call site wraps it. If
-// triggerReconciliationPoll ever grew blocking work ahead of that
-// CompareAndSwap, this call site would need its own `go` too.
+// lock). The install-event branch calls triggerRederivation directly, not
+// via `go` — that's still non-blocking, but by triggerRederivation's own
+// construction (an atomic CompareAndSwap guard around an internally spawned
+// goroutine, mirroring triggerReconciliationPoll's own shape), not because
+// this call site wraps it. If triggerRederivation ever grew blocking work
+// ahead of that CompareAndSwap, this call site would need its own `go` too.
 //
 // This makes the per-event goroutine count itself uncapped — a burst of
 // legitimate events across many distinct PRs can pile up more goroutines
@@ -184,7 +181,7 @@ func (s *daemonEventSink) Handle(ctx context.Context, ev events.GitHubEvent) {
 		}
 		go s.daemon.ReviewFromEvent(ctx, ev.Owner, ev.Repo, prNumber)
 	case installEventTypes[ev.EventType]:
-		logf(0, "poll", "installation change event (%s) — triggering a reconciliation poll\n", ev.EventType)
-		s.daemon.triggerReconciliationPoll(ctx)
+		logf(0, "poll", "installation change event (%s) — re-deriving the repo set\n", ev.EventType)
+		s.daemon.triggerRederivation(ctx)
 	}
 }

--- a/pruefer/eventsink_test.go
+++ b/pruefer/eventsink_test.go
@@ -18,13 +18,13 @@ func newTestDaemonForEvents(client *fakeLister) *Daemon {
 	clone := func(ctx context.Context, owner, repo, token string, prNumber int) (string, func(), error) {
 		return "/tmp", func() {}, nil
 	}
-	return &Daemon{
+	return withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 3},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "owner/repo")
 }
 
 func TestDaemonEventSink_PullRequestTriggerActions_DispatchReview(t *testing.T) {
@@ -165,7 +165,7 @@ func TestDaemonEventSink_CaseMismatchedOwnerInClientsMap_DispatchesReview(t *tes
 	clone := func(ctx context.Context, owner, repo, token string, prNumber int) (string, func(), error) {
 		return "/tmp", func() {}, nil
 	}
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		// Keyed lower-case, matching how Reconciler/execute.go actually
 		// build this map — the event below uses GitHub's own canonical
 		// casing for the same account, which differs.
@@ -174,7 +174,7 @@ func TestDaemonEventSink_CaseMismatchedOwnerInClientsMap_DispatchesReview(t *tes
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"MyOrg/repo"}, ConcurrencyCap: 3},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "MyOrg/repo")
 	sink := &daemonEventSink{daemon: d}
 
 	sink.Handle(context.Background(), events.GitHubEvent{
@@ -198,7 +198,7 @@ func TestDaemonEventSink_CaseMismatchedWatchedRepoSpec_DispatchesReview(t *testi
 	clone := func(ctx context.Context, owner, repo, token string, prNumber int) (string, func(), error) {
 		return "/tmp", func() {}, nil
 	}
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients: map[string]GitHubLister{"myorg": client},
 		Claude:  claude,
 		Clone:   clone,
@@ -207,7 +207,7 @@ func TestDaemonEventSink_CaseMismatchedWatchedRepoSpec_DispatchesReview(t *testi
 		// Clients-map lookup above already matches, via strings.ToLower).
 		Config:   Config{WatchedRepos: []string{"MyOrg/Repo"}, ConcurrencyCap: 3},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "MyOrg/Repo")
 	sink := &daemonEventSink{daemon: d}
 
 	sink.Handle(context.Background(), events.GitHubEvent{
@@ -297,13 +297,13 @@ func TestDaemonEventSink_Handle_ReturnsPromptlyUnderSemaphoreSaturation(t *testi
 	clone := func(ctx context.Context, owner, repo, token string, prNumber int) (string, func(), error) {
 		return "/tmp", func() {}, nil
 	}
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 1},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "owner/repo")
 	sink := &daemonEventSink{daemon: d}
 
 	// Saturate the daemon's single concurrency slot with PR #1's review.
@@ -365,13 +365,13 @@ func TestDaemonEventSink_DuplicateInFlightEvent_DroppedWithoutConsumingSemaphore
 	clone := func(ctx context.Context, owner, repo, token string, prNumber int) (string, func(), error) {
 		return "/tmp", func() {}, nil
 	}
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 2},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "owner/repo")
 	sink := &daemonEventSink{daemon: d}
 
 	// Start PR #1's review, occupying one of two slots.
@@ -477,13 +477,13 @@ func TestDaemonEventSink_ReviewFromEvent_AcquiresSemaphoreBeforePRLock(t *testin
 	clone := func(ctx context.Context, owner, repo, token string, prNumber int) (string, func(), error) {
 		return "/tmp", func() {}, nil
 	}
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 1},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "owner/repo")
 
 	// Saturate the daemon's single concurrency slot with a bystander review
 	// of an unrelated PR (#99), the same dispatch path poll() itself uses.

--- a/pruefer/execute.go
+++ b/pruefer/execute.go
@@ -44,10 +44,12 @@ func Execute() error {
 	// Deliberately no cfg.AppID == 0 hard error here (unlike pre-#1253
 	// behavior): a fresh install with no App ID yet is exactly what
 	// githubauth.Reconcile's manifest bootstrap flow below handles — see
-	// adrs/1253-github-app-manifest-auth-reconciler.md.
-	if len(cfg.WatchedRepos) == 0 {
-		return fmt.Errorf("no watched repos configured (set watched_repos, PRUEFER_REPOS, or --repos)")
-	}
+	// adrs/1253-github-app-manifest-auth-reconciler.md. Nor is there a
+	// cfg.WatchedRepos == 0 hard error (unlike pre-#1641 behavior): with no
+	// watched_repos configured, the daemon now derives its repo set
+	// entirely from the App's installations (AC1) — WatchedRepos is an
+	// optional narrowing filter (R3), not a required primary input. See
+	// ADR-1641.
 
 	// Wire the package-level Logf hook (per cfg.LogFile/useTUI) before
 	// anything below logs a line — including githubauth.Reconcile's own
@@ -113,6 +115,7 @@ func Execute() error {
 		AppPrivateKeyPath: cfg.AppPrivateKeyPath,
 		AppStatePath:      cfg.AppStatePath,
 		WatchedRepos:      cfg.WatchedRepos,
+		MaxDerivedRepos:   cfg.MaxDerivedRepos,
 		NoBrowser:         cfg.NoBrowser,
 		Logf:              func(format string, args ...any) { logf(0, "auth", format+"\n", args...) },
 	})
@@ -128,17 +131,20 @@ func Execute() error {
 		}
 	})
 
-	clients := make(map[string]GitHubLister, len(distinctOwners(cfg.WatchedRepos)))
-	for _, owner := range distinctOwners(cfg.WatchedRepos) {
-		client, err := auth.ClientForRepo(ctx, owner, "")
+	// Reconcile has already performed the initial derivation (its own call
+	// to Derive) — build the daemon's initial Clients/derived state from
+	// that result (auth.LastDerived()) rather than deriving a second time
+	// here, and log the repo set/provenance it found (R4).
+	initialDerived := auth.LastDerived()
+	logRederivedRepos(initialDerived)
+	clients := make(map[string]GitHubLister, len(initialDerived.Installations))
+	for _, inst := range initialDerived.Installations {
+		client, err := auth.ClientForRepo(ctx, inst.Account, "")
 		if err != nil {
-			logf(0, "warn", "no authorized client for owner %q yet — repos under it will be skipped until reconciled: %v\n", owner, err)
+			logf(0, "warn", "no authorized client for owner %q yet — repos under it will be skipped until the next re-derivation: %v\n", inst.Account, err)
 			continue
 		}
-		// Keyed by lower-cased owner — see daemon.go's distinctOwners and
-		// poll()'s d.Clients lookups, which both normalize case the same
-		// way for this exact reason.
-		clients[strings.ToLower(owner)] = client
+		clients[strings.ToLower(inst.Account)] = client
 	}
 
 	// NewDaemon's own wireLogf call is a no-op here (Logf was already wired
@@ -146,6 +152,8 @@ func Execute() error {
 	// favor of the one already captured, which is what actually owns the
 	// open log file.
 	daemon, _ := NewDaemon(cfg, clients, &RealClaudeInvoker{}, CloneForReview, auth.BotLogin())
+	daemon.Reconciler = auth
+	daemon.ApplyDerivedRepos(initialDerived, clients)
 	// waitRefreshLoops must run before closeLog: the refresh-loop goroutines
 	// spawned above are unmanaged by Daemon.Run's own lifecycle (unlike its
 	// internal poll/review goroutines, which Run joins before returning), so
@@ -214,7 +222,7 @@ func Execute() error {
 				return
 			case <-hupCh:
 				logf(0, "reload", "SIGHUP received — reloading config\n")
-				handleReload(ctx, args, auth, daemon)
+				handleReload(ctx, args, daemon)
 			}
 		}
 	}()
@@ -227,24 +235,22 @@ func Execute() error {
 
 // handleReload processes one SIGHUP (ADR-1640): re-reads config via
 // LoadConfig(args), merges it against daemon's currently running config
-// (applyConfigReload), mints a token for any newly-watched owner
-// (MintOwnerAuth, all-or-nothing across the whole reload — see that
-// method's doc comment), and only once every step has succeeded does it
-// apply the merged config (and any newly-minted clients) to daemon and log
-// a diff-style summary.
+// (applyConfigReload), and applies the merged config to daemon.
 //
-// A failure at any step — a malformed/invalid config file, or a newly
-// watched owner with no matching App installation — leaves daemon and
-// reconciler completely untouched: nothing is committed until every owner
-// in the batch has minted successfully. Nothing here cancels a running
-// review, drops the Hookdeck EventSource, or resets its dedupe ring — those
-// are untouched by construction, since this function never rebuilds or
-// reaches into any of them. This includes a removed owner's installation
-// token: its refresh loop is only ever stopped once
-// Daemon.drainThenStopAuth (spawned below) has confirmed no review is still
-// in flight for that owner, so an in-flight review's remaining GitHub calls
-// never lose a valid token out from under them.
-func handleReload(ctx context.Context, args []string, reconciler *githubauth.Reconciler, daemon *Daemon) {
+// Since #1641, this no longer mints or removes any owner's installation
+// auth itself: every installation of the operator's own App is already
+// minted unconditionally by Reconciler.Derive (called from rederiveRepos),
+// regardless of whether watched_repos names it — a watched_repos edit only
+// changes which of those already-authorized repos are *reviewed*, not which
+// owners have a client. So a changed WatchedRepos or MaxDerivedRepos
+// triggers a fresh re-derivation (daemon.triggerRederivation) instead: this
+// does still make a live call to re-list each installation's accessible
+// repos (a WatchedRepos-only edit doesn't strictly need to re-mint any
+// token, since Derive reuses an already-known owner's client unchanged —
+// see its own doc comment), but requires no bespoke owner-diff/mint/detach
+// logic here, reusing the exact same re-derivation path installation events
+// and the periodic ticker already use.
+func handleReload(ctx context.Context, args []string, daemon *Daemon) {
 	cand, err := LoadConfig(args)
 	if err != nil {
 		logf(0, "reload", "config reload failed: %v — keeping current config\n", err)
@@ -264,56 +270,23 @@ func handleReload(ctx context.Context, args []string, reconciler *githubauth.Rec
 
 	old := daemon.config()
 	merged, diff := applyConfigReload(old, cand)
-
-	newOwners := newlyWatchedOwners(old, merged)
-	type mintedOwner struct {
-		owner       string
-		auth        *githubauth.Auth
-		mintedFresh bool
-	}
-	minted := make([]mintedOwner, 0, len(newOwners))
-	for _, owner := range newOwners {
-		reloadLogf := func(format string, args ...any) { logf(0, "reload", format+"\n", args...) }
-		a, fresh, err := reconciler.MintOwnerAuth(owner, merged.WatchedRepos, reloadLogf)
-		if err != nil {
-			logf(0, "reload", "config reload failed: %v — keeping current config\n", err)
-			return
-		}
-		minted = append(minted, mintedOwner{owner: owner, auth: a, mintedFresh: fresh})
-	}
-
-	addedClients := make(map[string]GitHubLister, len(minted))
-	for _, m := range minted {
-		installationID := m.auth.InstallationID
-		prefix := fmt.Sprintf("installation %d: ", installationID)
-		client := reconciler.CommitOwnerAuth(ctx, m.owner, m.auth, m.mintedFresh, func(format string, args ...any) {
-			logf(0, "auth", prefix+format, args...)
-		})
-		addedClients[strings.ToLower(m.owner)] = client
-	}
-
-	// Owners no longer present in watched_repos are pruned only now, after
-	// every newly-watched owner in this same batch has already minted
-	// successfully — an earlier prune (e.g. right after computing merged)
-	// would violate atomicity if a later owner's mint then failed and
-	// aborted the whole reload above: the removed owner's client would
-	// already be gone even though the reload as a whole never took effect.
-	// RemoveOwners only detaches each removed (non-pinned) owner's *Auth
-	// from the Reconciler's own bookkeeping — it deliberately does NOT stop
-	// its refresh goroutine yet. That happens below, once
-	// drainThenStopAuth confirms no review is still in flight for the
-	// owner being removed.
-	removedOwners := noLongerWatchedOwners(old, merged)
-	detached := reconciler.RemoveOwners(removedOwners)
-
-	removedLowered := make([]string, len(removedOwners))
-	for i, o := range removedOwners {
-		removedLowered[i] = strings.ToLower(o)
-	}
-	daemon.ApplyReload(merged, addedClients, removedLowered)
+	daemon.ApplyReload(merged, nil, nil)
 	logReloadSummary(diff)
 
-	for _, d := range detached {
-		go daemon.drainThenStopAuth(ctx, d.Owner, d.Auth)
+	if len(diff.ReposAdded) > 0 || len(diff.ReposRemoved) > 0 || fieldChanged(diff.FieldsChanged, "MaxDerivedRepos") {
+		logf(0, "reload", "watched_repos/max_derived_repos changed — re-deriving the effective repo set\n")
+		daemon.triggerRederivation(ctx)
 	}
+}
+
+// fieldChanged reports whether changes contains an entry for the named
+// Config field — used by handleReload to decide whether a reload should
+// trigger a fresh re-derivation.
+func fieldChanged(changes []FieldChange, name string) bool {
+	for _, c := range changes {
+		if c.Field == name {
+			return true
+		}
+	}
+	return false
 }

--- a/pruefer/fallback_coalesce_test.go
+++ b/pruefer/fallback_coalesce_test.go
@@ -30,14 +30,14 @@ func TestFallbackTickerCoalescesWithInFlightPoll(t *testing.T) {
 	client := newFakeLister()
 	client.prsByRepo["owner/repo"] = nil
 
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:     map[string]GitHubLister{"owner": client},
 		EventSource: blockingEventSource{},
 		Config: Config{
 			WatchedRepos:                   []string{"owner/repo"},
 			ReconciliationFallbackInterval: 10 * time.Millisecond,
 		},
-	}
+	}, "owner/repo")
 
 	// Simulate a reconciliation poll already in flight, exactly as
 	// triggerReconciliationPoll would have left it.
@@ -63,14 +63,14 @@ func TestFallbackTickerPollsWhenIdle(t *testing.T) {
 	client := newFakeLister()
 	client.prsByRepo["owner/repo"] = nil
 
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:     map[string]GitHubLister{"owner": client},
 		EventSource: blockingEventSource{},
 		Config: Config{
 			WatchedRepos:                   []string{"owner/repo"},
 			ReconciliationFallbackInterval: 10 * time.Millisecond,
 		},
-	}
+	}, "owner/repo")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()

--- a/pruefer/prgate_test.go
+++ b/pruefer/prgate_test.go
@@ -116,7 +116,7 @@ func TestAcquirePRGateRefcountedAcrossHolders(t *testing.T) {
 // in GitHub's canonical casing, while WatchedRepos is hand-typed. A divergence
 // silently dropped every event for that repo.
 func TestIsWatchedRepoCaseInsensitive(t *testing.T) {
-	d := &Daemon{Config: Config{WatchedRepos: []string{"handarbeit/fabrik"}}}
+	d := withDerivedRepos(&Daemon{Config: Config{WatchedRepos: []string{"handarbeit/fabrik"}}}, "handarbeit/fabrik")
 
 	for _, tc := range []struct {
 		owner, repo string

--- a/pruefer/reload_test.go
+++ b/pruefer/reload_test.go
@@ -289,21 +289,28 @@ func TestDaemon_OwnerReviewsInFlight(t *testing.T) {
 // internal/githubauth's own unexported test helpers, since this test lives
 // in a different package). ---
 
-// fakeReloadAppServer is a minimal httptest server covering exactly the
-// three GitHub App endpoints Reconcile/MintOwnerAuth need: app identity
-// (/app), installation discovery (/app/installations), and token minting
-// (/app/installations/{id}/access_tokens). Unlike internal/githubauth's own
-// fakeAppServer, this never needs to serve the manifest-exchange endpoint —
-// every test here starts from an already-bootstrapped App (an explicit
-// AppID + on-disk PEM), never the first-run flow.
+// fakeReloadAppServer is a minimal httptest server covering the GitHub App
+// endpoints Reconcile/Derive need: app identity (/app), installation
+// discovery (/app/installations), token minting
+// (/app/installations/{id}/access_tokens), and installation repo
+// enumeration (/installation/repositories) — since #1641, Derive calls the
+// latter unconditionally for every installation. Unlike internal/githubauth's
+// own fakeAppServer, this never needs to serve the manifest-exchange
+// endpoint — every test here starts from an already-bootstrapped App (an
+// explicit AppID + on-disk PEM), never the first-run flow.
 type fakeReloadAppServer struct {
-	mu        sync.Mutex
-	mintCalls map[int64]int
+	mu               sync.Mutex
+	mintCalls        map[int64]int
+	installTokenToID map[string]int64
+	// selectedRepos maps an installation ID to the repos it grants access
+	// to — populated by tests that need the derived (reviewed) set to
+	// actually contain repos, not just resolve a client per owner.
+	selectedRepos map[int64][]string
 }
 
 func newFakeReloadAppServer(t *testing.T, slug string, installations []gh.AppInstallation) (*httptest.Server, *fakeReloadAppServer) {
 	t.Helper()
-	fake := &fakeReloadAppServer{mintCalls: map[int64]int{}}
+	fake := &fakeReloadAppServer{mintCalls: map[int64]int{}, installTokenToID: map[string]int64{}, selectedRepos: map[int64][]string{}}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -311,6 +318,10 @@ func newFakeReloadAppServer(t *testing.T, slug string, installations []gh.AppIns
 	})
 	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "" && r.URL.Query().Get("page") != "1" {
+			w.Write([]byte("[]"))
+			return
+		}
 		w.Write([]byte("["))
 		for i, inst := range installations {
 			if i > 0 {
@@ -335,9 +346,31 @@ func newFakeReloadAppServer(t *testing.T, slug string, installations []gh.AppIns
 		fmt.Sscanf(trimmed, "%d", &instID)
 		fake.mu.Lock()
 		fake.mintCalls[instID]++
+		token := fmt.Sprintf("tok-%d-%d", instID, fake.mintCalls[instID])
+		fake.installTokenToID[token] = instID
 		fake.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"token": "tok-%d", "expires_at": %q}`, instID, time.Now().Add(time.Hour).Format(time.RFC3339))
+		fmt.Fprintf(w, `{"token": %q, "expires_at": %q}`, token, time.Now().Add(time.Hour).Format(time.RFC3339))
+	})
+	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+		auth := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		fake.mu.Lock()
+		instID, ok := fake.installTokenToID[auth]
+		repos := fake.selectedRepos[instID]
+		fake.mu.Unlock()
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"repositories": [`))
+		for i, r := range repos {
+			if i > 0 {
+				w.Write([]byte(","))
+			}
+			fmt.Fprintf(w, `{"full_name": %q}`, r)
+		}
+		w.Write([]byte("]}"))
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
@@ -352,9 +385,10 @@ func (f *fakeReloadAppServer) mintCountFor(installationID int64) int {
 
 // setupReloadDaemon writes the given initial YAML, reconciles auth and
 // builds a Daemon against it via the real LoadConfig/githubauth.Reconcile/
-// NewDaemon production path, and returns the pieces handleReload needs.
-// args is the flag slice a later call to handleReload should reuse,
-// mirroring Execute()'s own single `args` capture.
+// NewDaemon production path (including the initial derivation, wired via
+// Daemon.Reconciler/ApplyDerivedRepos exactly as Execute does), and returns
+// the pieces handleReload needs. args is the flag slice a later call to
+// handleReload should reuse, mirroring Execute()'s own single `args` capture.
 func setupReloadDaemon(t *testing.T, dir, keyPath string, installations []gh.AppInstallation) (args []string, reconciler *githubauth.Reconciler, daemon *Daemon, srv *httptest.Server, fake *fakeReloadAppServer, closeLog func() error) {
 	t.Helper()
 	srv, fake = newFakeReloadAppServer(t, "pruefer-bot", installations)
@@ -372,22 +406,43 @@ func setupReloadDaemon(t *testing.T, dir, keyPath string, installations []gh.App
 		AppPrivateKeyPath: cfg.AppPrivateKeyPath,
 		AppStatePath:      filepath.Join(dir, "app-state.json"),
 		WatchedRepos:      cfg.WatchedRepos,
+		MaxDerivedRepos:   cfg.MaxDerivedRepos,
 		BaseURL:           srv.URL,
 	})
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
 	cfg.AppStatePath = filepath.Join(dir, "app-state.json")
+	derived := reconciler.LastDerived()
 	clients := map[string]GitHubLister{}
-	for _, owner := range distinctOwners(cfg.WatchedRepos) {
-		c, err := reconciler.ClientForRepo(context.Background(), owner, "")
+	for _, inst := range derived.Installations {
+		c, err := reconciler.ClientForRepo(context.Background(), inst.Account, "")
 		if err != nil {
 			continue
 		}
-		clients[strings.ToLower(owner)] = c
+		clients[strings.ToLower(inst.Account)] = c
 	}
 	daemon, closeLog = NewDaemon(cfg, clients, &RealClaudeInvoker{}, nil, reconciler.BotLogin())
+	daemon.Reconciler = reconciler
+	daemon.ApplyDerivedRepos(derived, clients)
 	return args, reconciler, daemon, srv, fake, closeLog
+}
+
+// waitForRederivation polls until cond is true or timeout elapses, for tests
+// that trigger an async re-derivation (daemon.triggerRederivation, invoked
+// from handleReload) and need to observe its effect.
+func waitForRederivation(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !cond() {
+		t.Fatalf("condition not met within %s", timeout)
+	}
 }
 
 // captureLogf swaps in a capturing Logf for the duration of the test and

--- a/pruefer/reload_test.go
+++ b/pruefer/reload_test.go
@@ -78,13 +78,13 @@ func TestDaemon_ApplyReload_WatchedReposAddedPolledNextCycle(t *testing.T) {
 	client.prsByRepo["owner/repo1"] = []gh.PRDetails{{Number: 1, Author: "alice", HeadSHA: "sha1"}}
 	client.prsByRepo["owner/repo2"] = []gh.PRDetails{{Number: 2, Author: "alice", HeadSHA: "sha2"}}
 
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   &mockClaudeInvoker{},
 		Clone:    mustFakeClone(t),
 		Config:   Config{WatchedRepos: []string{"owner/repo1"}, ConcurrencyCap: 3},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "owner/repo1")
 
 	d.poll(context.Background())
 	if hist := client.historySnapshot(); len(hist) != 1 || hist[0] != "owner/repo1" {
@@ -93,6 +93,12 @@ func TestDaemon_ApplyReload_WatchedReposAddedPolledNextCycle(t *testing.T) {
 
 	merged, _ := applyConfigReload(d.config(), Config{WatchedRepos: []string{"owner/repo1", "owner/repo2"}, ConcurrencyCap: 3})
 	d.ApplyReload(merged, nil, nil) // same owner already has a client — nothing new to add
+	// Simulate the effect of the reload-triggered re-derivation
+	// (daemon.triggerRederivation) that a real watched_repos change would
+	// kick off asynchronously — this test only exercises poll()'s own
+	// consumption of the derived set, not the async re-derivation path
+	// itself (see TestHandleReload_* in this file for that).
+	d.ApplyDerivedRepos(testDerivedRepoSet("owner/repo1", "owner/repo2"), d.Clients)
 
 	d.poll(context.Background())
 	hist := client.historySnapshot()
@@ -115,13 +121,13 @@ func TestDaemon_ApplyReload_RemovedRepoStopsPollingButInFlightReviewCompletes(t 
 
 	claude := newConcurrencyTrackingInvoker()
 
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    mustFakeClone(t),
 		Config:   Config{WatchedRepos: []string{"owner/repoA", "owner/repoB"}, ConcurrencyCap: 3},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "owner/repoA", "owner/repoB")
 
 	done := make(chan struct{})
 	go func() {
@@ -133,6 +139,9 @@ func TestDaemon_ApplyReload_RemovedRepoStopsPollingButInFlightReviewCompletes(t 
 
 	merged, _ := applyConfigReload(d.config(), Config{WatchedRepos: []string{"owner/repoB"}, ConcurrencyCap: 3})
 	d.ApplyReload(merged, nil, nil)
+	// See the sibling test above for why ApplyDerivedRepos is called
+	// explicitly here too.
+	d.ApplyDerivedRepos(testDerivedRepoSet("owner/repoB"), d.Clients)
 
 	close(claude.release)
 	select {
@@ -212,13 +221,13 @@ func TestDaemon_ConcurrentReloadDuringActivePoll(t *testing.T) {
 		})
 	}
 
-	d := &Daemon{
+	d := withDerivedRepos(&Daemon{
 		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   &mockClaudeInvoker{},
 		Clone:    mustFakeClone(t),
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 4},
 		BotLogin: "pruefer-bot[bot]",
-	}
+	}, "owner/repo")
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
@@ -244,6 +253,11 @@ func TestDaemon_ConcurrentReloadDuringActivePoll(t *testing.T) {
 			d.ApplyReload(Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: newCap}, map[string]GitHubLister{
 				"owner": client,
 			}, nil)
+			// Also exercise ApplyDerivedRepos' wholesale rebuild concurrently
+			// with an active poll cycle — a new write pattern distinct from
+			// ApplyReload's incremental merge (see this method's own risk
+			// note in the Plan), so it needs its own race coverage.
+			d.ApplyDerivedRepos(testDerivedRepoSet("owner/repo"), map[string]GitHubLister{"owner": client})
 		}
 	}()
 
@@ -445,6 +459,26 @@ func waitForRederivation(t *testing.T, timeout time.Duration, cond func() bool) 
 	}
 }
 
+// waitForRederivationDone blocks until daemon.rederiveInFlight clears, and
+// then until pollInFlight clears too — i.e. both the async re-derivation
+// triggerRederivation spawned (from handleReload, an installation event, or
+// the ticker) AND the follow-up reconciliation poll it chains into (AC3:
+// "so newly-derived repos are pollable promptly") have fully returned,
+// including every logf call either one makes. pollInFlight is only ever
+// set (by triggerReconciliationPoll) synchronously before rederiveInFlight's
+// own deferred clear runs, so waiting for rederiveInFlight first, then
+// pollInFlight, cannot miss the follow-up poll's own in-flight window.
+// Tests that trigger an async re-derivation must call this before
+// returning (not just before asserting): a still-running goroutine calling
+// logf after the test's own deferred closeLog() has already nilled the
+// package-level Logf hook is a real data race, not just a flaky assertion —
+// see wireLogf's own doc comment on this exact hazard.
+func waitForRederivationDone(t *testing.T, d *Daemon) {
+	t.Helper()
+	waitForRederivation(t, 2*time.Second, func() bool { return !d.rederiveInFlight.Load() })
+	waitForRederivation(t, 2*time.Second, func() bool { return !d.pollInFlight.Load() })
+}
+
 // captureLogf swaps in a capturing Logf for the duration of the test and
 // returns a snapshot function.
 func captureLogf(t *testing.T) func() []string {
@@ -475,7 +509,7 @@ func TestHandleReload_MalformedConfigLeavesRunningConfigUntouched(t *testing.T) 
 		t.Fatalf("writing initial config: %v", err)
 	}
 
-	args, reconciler, daemon, _, _, closeLog := setupReloadDaemon(t, dir, keyPath, []gh.AppInstallation{{ID: 111, Account: "handarbeit"}})
+	args, _, daemon, _, _, closeLog := setupReloadDaemon(t, dir, keyPath, []gh.AppInstallation{{ID: 111, Account: "handarbeit"}})
 	defer closeLog()
 	snapshot := captureLogf(t)
 
@@ -485,7 +519,7 @@ func TestHandleReload_MalformedConfigLeavesRunningConfigUntouched(t *testing.T) 
 		t.Fatalf("writing malformed config: %v", err)
 	}
 
-	handleReload(context.Background(), args, reconciler, daemon)
+	handleReload(context.Background(), args, daemon)
 
 	if got := daemon.config(); !reflect.DeepEqual(got, before) {
 		t.Errorf("daemon.config() = %+v, want the original config untouched by the failed reload: %+v", got, before)
@@ -502,23 +536,40 @@ func TestHandleReload_MalformedConfigLeavesRunningConfigUntouched(t *testing.T) 
 	}
 }
 
-// TestHandleReload_NewOwnerMintsInstallationTokenAndServable covers the
-// success path: adding a repo under a previously-unwatched owner mints that
-// owner's installation token as part of the reload, and the new owner's
-// repo is servable (has a client) immediately after.
-func TestHandleReload_NewOwnerMintsInstallationTokenAndServable(t *testing.T) {
+// TestHandleReload_WatchedRepoUnderAlreadyInstalledOwner_BecomesReviewable
+// covers #1641's success path: since every installation of the operator's
+// own App is already minted unconditionally by Derive (not just owners
+// named in watched_repos — see the issue's own containment explanation),
+// adding a repo under an owner that's already installed (but wasn't
+// previously named in watched_repos) needs no new mint at all — it becomes
+// part of the derived, reviewed set as soon as the reload's triggered
+// re-derivation completes.
+func TestHandleReload_WatchedRepoUnderAlreadyInstalledOwner_BecomesReviewable(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := writeTestPrivateKey(t, dir)
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("watched_repos:\n  - handarbeit/fabrik\n"), 0600); err != nil {
 		t.Fatalf("writing initial config: %v", err)
 	}
 
-	args, reconciler, daemon, _, fake, closeLog := setupReloadDaemon(t, dir, keyPath, []gh.AppInstallation{
+	args, _, daemon, _, fake, closeLog := setupReloadDaemon(t, dir, keyPath, []gh.AppInstallation{
 		{ID: 111, Account: "handarbeit"},
 		{ID: 222, Account: "newowner"},
 	})
 	defer closeLog()
 	captureLogf(t)
+	fake.selectedRepos[111] = []string{"handarbeit/fabrik"}
+	fake.selectedRepos[222] = []string{"newowner/repo"}
+
+	// newowner's installation already existed and was already minted by the
+	// initial Derive call (setupReloadDaemon) — confirm the precondition
+	// this test's whole point rests on: no new mint should be needed.
+	mintsBefore := fake.mintCountFor(222)
+	if mintsBefore == 0 {
+		t.Fatal("precondition failed: newowner should already have been minted by the initial derivation")
+	}
+	if _, ok := daemon.client("newowner"); !ok {
+		t.Fatal("precondition failed: newowner should already be servable before watched_repos ever named it")
+	}
 
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("watched_repos:\n  - handarbeit/fabrik\n  - newowner/repo\n"), 0600); err != nil {
 		t.Fatalf("writing updated config: %v", err)
@@ -526,13 +577,21 @@ func TestHandleReload_NewOwnerMintsInstallationTokenAndServable(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	handleReload(ctx, args, reconciler, daemon)
+	handleReload(ctx, args, daemon)
+	waitForRederivationDone(t, daemon) // must complete (incl. every logf call) before this test returns and closeLog() nils Logf
 
-	if fake.mintCountFor(222) != 1 {
-		t.Errorf("mintCountFor(222 = newowner) = %d, want 1 — reload must mint a token for the newly-watched owner", fake.mintCountFor(222))
+	found := false
+	for _, dr := range daemon.derivedSet().Repos {
+		if dr.Repo == "newowner/repo" {
+			found = true
+		}
 	}
-	if _, ok := daemon.client("newowner"); !ok {
-		t.Error("expected daemon to have a servable client for newowner after reload")
+	if !found {
+		t.Fatalf("derived set = %+v, want newowner/repo included", daemon.derivedSet().Repos)
+	}
+
+	if got := fake.mintCountFor(222); got != mintsBefore {
+		t.Errorf("mintCountFor(222 = newowner) = %d, want unchanged from %d — no re-mint needed for an already-known installation", got, mintsBefore)
 	}
 	got := daemon.config()
 	if len(got.WatchedRepos) != 2 {
@@ -540,12 +599,13 @@ func TestHandleReload_NewOwnerMintsInstallationTokenAndServable(t *testing.T) {
 	}
 }
 
-// TestHandleReload_NewOwnerNoInstallation_FailsWholeReloadAllOrNothing
-// covers the failure path and the all-or-nothing guarantee across a
-// multi-owner batch: when one of two newly-watched owners has no App
-// installation, neither new owner is registered and the running config is
-// untouched.
-func TestHandleReload_NewOwnerNoInstallation_FailsWholeReloadAllOrNothing(t *testing.T) {
+// TestHandleReload_WatchedRepoNamingUninstalledOwner_ReportedNotFailed is
+// #1641's replacement for the old all-or-nothing mint-failure test: naming
+// an owner with no App installation in watched_repos is no longer a reload
+// failure at all (there is nothing to mint or roll back) — it's reported via
+// the derived set's FilteredOut (R3/AC4), while every other repo (including
+// one under an owner that *does* have an installation) is unaffected.
+func TestHandleReload_WatchedRepoNamingUninstalledOwner_ReportedNotFailed(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := writeTestPrivateKey(t, dir)
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("watched_repos:\n  - handarbeit/fabrik\n"), 0600); err != nil {
@@ -553,34 +613,48 @@ func TestHandleReload_NewOwnerNoInstallation_FailsWholeReloadAllOrNothing(t *tes
 	}
 
 	// "goodowner" has an installation; "badowner" does not.
-	args, reconciler, daemon, _, _, closeLog := setupReloadDaemon(t, dir, keyPath, []gh.AppInstallation{
+	args, _, daemon, _, fake, closeLog := setupReloadDaemon(t, dir, keyPath, []gh.AppInstallation{
 		{ID: 111, Account: "handarbeit"},
 		{ID: 222, Account: "goodowner"},
 	})
 	defer closeLog()
 	captureLogf(t)
-
-	before := daemon.config()
-	beforeInstallationCount := reconciler.InstallationCount()
+	fake.selectedRepos[111] = []string{"handarbeit/fabrik"}
+	fake.selectedRepos[222] = []string{"goodowner/repo"}
 
 	newYAML := "watched_repos:\n  - handarbeit/fabrik\n  - goodowner/repo\n  - badowner/repo\n"
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(newYAML), 0600); err != nil {
 		t.Fatalf("writing updated config: %v", err)
 	}
 
-	handleReload(context.Background(), args, reconciler, daemon)
+	handleReload(context.Background(), args, daemon)
+	waitForRederivationDone(t, daemon) // must complete (incl. every logf call) before this test returns and closeLog() nils Logf
 
-	if got := daemon.config(); !reflect.DeepEqual(got, before) {
-		t.Errorf("daemon.config() changed despite a failed reload: got %+v, want unchanged %+v", got, before)
+	found := false
+	for _, dr := range daemon.derivedSet().Repos {
+		if dr.Repo == "goodowner/repo" {
+			found = true
+		}
 	}
-	if _, ok := daemon.client("goodowner"); ok {
-		t.Error("goodowner must not be registered — the whole reload failed because badowner had no installation (all-or-nothing)")
+	if !found {
+		t.Fatalf("derived set = %+v, want goodowner/repo included", daemon.derivedSet().Repos)
 	}
-	if _, err := reconciler.ClientForRepo(context.Background(), "goodowner", ""); err == nil {
-		t.Error("reconciler must not have a client for goodowner — CommitOwnerAuth must never run for a batch that ultimately fails")
+
+	if _, ok := daemon.client("goodowner"); !ok {
+		t.Error("expected goodowner to be servable — its own installation exists regardless of badowner's absence")
 	}
-	if reconciler.InstallationCount() != beforeInstallationCount {
-		t.Errorf("InstallationCount() = %d, want unchanged %d — a minted-but-uncommitted Auth must never be registered", reconciler.InstallationCount(), beforeInstallationCount)
+	foundBad := false
+	for _, f := range daemon.derivedSet().FilteredOut {
+		if f == "badowner/repo" {
+			foundBad = true
+		}
+	}
+	if !foundBad {
+		t.Errorf("expected badowner/repo in FilteredOut, got %v", daemon.derivedSet().FilteredOut)
+	}
+	got := daemon.config()
+	if len(got.WatchedRepos) != 3 {
+		t.Errorf("daemon.config().WatchedRepos = %v, want all 3 entries applied — naming an uninstalled owner is not a reload failure", got.WatchedRepos)
 	}
 }
 
@@ -593,14 +667,15 @@ func TestHandleReload_LogsDiffSummary(t *testing.T) {
 		t.Fatalf("writing initial config: %v", err)
 	}
 
-	args, reconciler, daemon, _, _, closeLog := setupReloadDaemon(t, dir, keyPath, []gh.AppInstallation{{ID: 111, Account: "handarbeit"}})
+	args, _, daemon, _, _, closeLog := setupReloadDaemon(t, dir, keyPath, []gh.AppInstallation{{ID: 111, Account: "handarbeit"}})
 	defer closeLog()
 	snapshot := captureLogf(t)
 
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("watched_repos: []\nmodel: opus\n"), 0600); err != nil {
 		t.Fatalf("writing updated config: %v", err)
 	}
-	handleReload(context.Background(), args, reconciler, daemon)
+	handleReload(context.Background(), args, daemon)
+	waitForRederivationDone(t, daemon) // must complete (incl. every logf call) before this test returns and closeLog() nils Logf
 
 	joined := strings.Join(snapshot(), "\n")
 	if !strings.Contains(joined, "handarbeit/fabrik") {
@@ -611,23 +686,32 @@ func TestHandleReload_LogsDiffSummary(t *testing.T) {
 	}
 }
 
-// TestHandleReload_RemovedOwnerPrunesClient is the handleReload-level proof
-// that dropping an owner's last watched repo via reload leaves that owner
-// unresolvable through the daemon (not just absent from watched_repos) and
-// drops its Auth from the reconciler.
-func TestHandleReload_RemovedOwnerPrunesClient(t *testing.T) {
+// TestHandleReload_RemovedWatchedRepo_NoLongerReviewed_ButInstallationStaysAuthorized
+// is #1641's replacement for the old owner-pruning test: dropping verveguy's
+// only watched repo no longer drops verveguy's installation Auth at all —
+// R3 is a review-scope narrowing filter, not the containment boundary
+// (that's the operator's own App identity, #1253) — so verveguy stays
+// servable through the daemon, just excluded from the reviewed set. This is
+// a deliberate behavior change from the pre-#1641 model this test used to
+// assert the opposite of.
+func TestHandleReload_RemovedWatchedRepo_NoLongerReviewed_ButInstallationStaysAuthorized(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := writeTestPrivateKey(t, dir)
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("watched_repos:\n  - handarbeit/fabrik\n  - verveguy/otherrepo\n"), 0600); err != nil {
 		t.Fatalf("writing initial config: %v", err)
 	}
 
-	args, reconciler, daemon, _, _, closeLog := setupReloadDaemon(t, dir, keyPath, []gh.AppInstallation{
+	args, reconciler, daemon, _, fake, closeLog := setupReloadDaemon(t, dir, keyPath, []gh.AppInstallation{
 		{ID: 111, Account: "handarbeit"},
 		{ID: 222, Account: "verveguy"},
 	})
 	defer closeLog()
 	captureLogf(t)
+	fake.selectedRepos[111] = []string{"handarbeit/fabrik"}
+	fake.selectedRepos[222] = []string{"verveguy/otherrepo"}
+	// Re-derive once now that selectedRepos is populated (setupReloadDaemon's
+	// own initial derivation ran before these fakes were configured).
+	daemon.rederiveRepos(context.Background())
 
 	if _, ok := daemon.client("verveguy"); !ok {
 		t.Fatal("expected verveguy to be servable before the reload")
@@ -637,16 +721,23 @@ func TestHandleReload_RemovedOwnerPrunesClient(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("watched_repos:\n  - handarbeit/fabrik\n"), 0600); err != nil {
 		t.Fatalf("writing updated config: %v", err)
 	}
-	handleReload(context.Background(), args, reconciler, daemon)
+	handleReload(context.Background(), args, daemon)
+	waitForRederivationDone(t, daemon) // must complete (incl. every logf call) before this test returns and closeLog() nils Logf
 
-	if _, ok := daemon.client("verveguy"); ok {
-		t.Error("expected verveguy to no longer be servable through the daemon after its last watched repo was removed")
+	for _, dr := range daemon.derivedSet().Repos {
+		if dr.Repo == "verveguy/otherrepo" {
+			t.Errorf("expected verveguy/otherrepo to no longer be in the reviewed set after being dropped from watched_repos")
+		}
 	}
-	if _, err := reconciler.ClientForRepo(context.Background(), "verveguy", ""); err == nil {
-		t.Error("expected reconciler to no longer have a client for verveguy after the reload")
+
+	if _, ok := daemon.client("verveguy"); !ok {
+		t.Error("expected verveguy to remain servable — its installation is untouched by a watched_repos edit (R3 is a review-scope filter, not containment)")
 	}
-	if got := reconciler.InstallationCount(); got != beforeInstallationCount-1 {
-		t.Errorf("InstallationCount() = %d, want %d (verveguy's dedicated installation dropped)", got, beforeInstallationCount-1)
+	if _, err := reconciler.ClientForRepo(context.Background(), "verveguy", ""); err != nil {
+		t.Errorf("expected reconciler to still have a client for verveguy: %v", err)
+	}
+	if got := reconciler.InstallationCount(); got != beforeInstallationCount {
+		t.Errorf("InstallationCount() = %d, want unchanged %d — a watched_repos edit must never detach an installation", got, beforeInstallationCount)
 	}
 	if _, ok := daemon.client("handarbeit"); !ok {
 		t.Error("expected handarbeit (still watched) to remain servable")

--- a/pruefer/tui/events.go
+++ b/pruefer/tui/events.go
@@ -102,6 +102,45 @@ type DropEvent struct {
 
 func (DropEvent) tuiEvent() {}
 
+// DerivedInstallationSummary is one installation's contribution to a
+// DerivedRepoSetEvent — a plain re-expression of
+// internal/githubauth.DerivedInstallation, kept dependency-free the same
+// way ReviewCompletedEvent.Reason re-expresses pruefer.SkipReason as a
+// string, so this package never imports internal/githubauth.
+type DerivedInstallationSummary struct {
+	Account             string
+	InstallationID      int64
+	RepositorySelection string
+	RepoCount           int
+}
+
+// DerivedRepoSetEvent is emitted whenever the daemon re-derives its repo
+// set from the App's installations (#1641/R4) — at startup and on every
+// subsequent re-derivation trigger (an installation webhook event or the
+// periodic ticker). Repos is the final, filtered (watched_repos), capped
+// (max_derived_repos) set actually being reviewed; Installations describes
+// every installation found regardless of whether any of its repos survived
+// filtering/capping, so an operator can tell "no installation found" apart
+// from "installation found, but every repo was filtered/capped out."
+type DerivedRepoSetEvent struct {
+	Repos         []string // "owner/repo", the final derived+filtered+capped set
+	Installations []DerivedInstallationSummary
+	// FilteredOut lists watched_repos entries not covered by any
+	// installation's grant (R3/AC4) — reported, not silently dropped.
+	FilteredOut []string
+	// Truncated is true when a pagination ceiling was hit while enumerating
+	// installations or an installation's accessible repos — the grant may
+	// be larger than what was actually derived.
+	Truncated bool
+	// Capped is true when max_derived_repos (R5) trimmed the union; CapApplied
+	// is the cap value in effect when Capped is true.
+	Capped     bool
+	CapApplied int
+	At         time.Time
+}
+
+func (DerivedRepoSetEvent) tuiEvent() {}
+
 // SignatureDriftEvent reports a transition in whether an event source's
 // signature verification is currently failing on every delivery over a
 // sustained window — see hookdeck.Config.OnSignatureDrift and ADR-1563.

--- a/pruefer/tui/events.go
+++ b/pruefer/tui/events.go
@@ -114,6 +114,15 @@ type DerivedInstallationSummary struct {
 	RepoCount           int
 }
 
+// DerivedRepoEntry pairs one derived repo with the installation ID that
+// granted it — the per-repo half of R4's "exactly which repos it derived
+// and from which installation" requirement (DerivedInstallationSummary
+// above is the per-installation half).
+type DerivedRepoEntry struct {
+	Repo           string // "owner/repo"
+	InstallationID int64
+}
+
 // DerivedRepoSetEvent is emitted whenever the daemon re-derives its repo
 // set from the App's installations (#1641/R4) — at startup and on every
 // subsequent re-derivation trigger (an installation webhook event or the
@@ -123,7 +132,7 @@ type DerivedInstallationSummary struct {
 // filtering/capping, so an operator can tell "no installation found" apart
 // from "installation found, but every repo was filtered/capped out."
 type DerivedRepoSetEvent struct {
-	Repos         []string // "owner/repo", the final derived+filtered+capped set
+	Repos         []DerivedRepoEntry
 	Installations []DerivedInstallationSummary
 	// FilteredOut lists watched_repos entries not covered by any
 	// installation's grant (R3/AC4) — reported, not silently dropped.

--- a/pruefer/tui/model.go
+++ b/pruefer/tui/model.go
@@ -135,6 +135,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.repos = comp.(RepoPaneComponent)
 		return m, nil
 
+	case DerivedRepoSetEvent:
+		comp, _ := m.repos.Update(msg)
+		m.repos = comp.(RepoPaneComponent)
+		return m, nil
+
 	case ReviewStartedEvent:
 		comp, _ := m.active.Update(msg)
 		m.active = comp.(ActivePaneComponent)

--- a/pruefer/tui/model_test.go
+++ b/pruefer/tui/model_test.go
@@ -84,6 +84,20 @@ func TestModel_RepoPollEventRoutesToRepoPane(t *testing.T) {
 	}
 }
 
+// TestModel_DerivedRepoSetEventRoutesToRepoPane covers #1641/R4's TUI
+// plumbing: a DerivedRepoSetEvent must reach the repos pane through the
+// same Model.Update dispatch every other daemon event uses.
+func TestModel_DerivedRepoSetEventRoutesToRepoPane(t *testing.T) {
+	m := New(nil, time.Now())
+	next, _ := m.Update(DerivedRepoSetEvent{
+		Repos: []DerivedRepoEntry{{Repo: "handarbeit/fabrik", InstallationID: 111}},
+	})
+	m = next.(Model)
+	if _, ok := m.repos.repos["handarbeit/fabrik"]; !ok {
+		t.Fatalf("repos pane = %+v, want handarbeit/fabrik present after DerivedRepoSetEvent", m.repos.repos)
+	}
+}
+
 func TestModel_ReviewLifecycleRoutesToActiveHistoryAndFooter(t *testing.T) {
 	m := New(nil, time.Now())
 	start := time.Now()

--- a/pruefer/tui/repos.go
+++ b/pruefer/tui/repos.go
@@ -16,6 +16,10 @@ type repoStatus struct {
 	LastPollAt time.Time
 	PRCount    int
 	LastErr    string
+	// InstallationID is the installation that granted this repo, populated
+	// by the most recent DerivedRepoSetEvent (#1641/R4) — zero until then
+	// (e.g. before the daemon's first derivation completes).
+	InstallationID int64
 }
 
 // RepoPaneComponent renders the watched-repositories pane.
@@ -24,6 +28,15 @@ type RepoPaneComponent struct {
 	order   []string // insertion order, seeded from Config.WatchedRepos
 	now     time.Time
 	focused bool
+
+	// The remaining fields are populated by the most recent
+	// DerivedRepoSetEvent (#1641/R4) — the installation-derived set's own
+	// provenance, distinct from any individual repo's poll status above.
+	installations []DerivedInstallationSummary
+	filteredOut   []string
+	truncated     bool
+	capped        bool
+	capApplied    int
 }
 
 func (r RepoPaneComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
@@ -43,6 +56,38 @@ func (r RepoPaneComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
 		st.LastPollAt = ev.At
 		st.PRCount = ev.PRCount
 		st.LastErr = ev.Err
+	case DerivedRepoSetEvent:
+		if r.repos == nil {
+			r.repos = make(map[string]*repoStatus)
+		}
+		wanted := make(map[string]bool, len(ev.Repos))
+		for _, entry := range ev.Repos {
+			wanted[entry.Repo] = true
+			st, ok := r.repos[entry.Repo]
+			if !ok {
+				st = &repoStatus{Repo: entry.Repo}
+				r.repos[entry.Repo] = st
+				r.order = append(r.order, entry.Repo)
+			}
+			st.InstallationID = entry.InstallationID
+		}
+		// Drop repos the derived set no longer grants/includes — an
+		// installation lost, or newly excluded by a watched_repos filter
+		// change — preserving poll status for every repo still present.
+		newOrder := make([]string, 0, len(r.order))
+		for _, repo := range r.order {
+			if wanted[repo] {
+				newOrder = append(newOrder, repo)
+				continue
+			}
+			delete(r.repos, repo)
+		}
+		r.order = newOrder
+		r.installations = ev.Installations
+		r.filteredOut = ev.FilteredOut
+		r.truncated = ev.Truncated
+		r.capped = ev.Capped
+		r.capApplied = ev.CapApplied
 	}
 	return r, nil
 }
@@ -52,7 +97,11 @@ func (r RepoPaneComponent) View(width int) string {
 	if r.focused {
 		focusIndicator = "▸"
 	}
-	title := activeStyle.Render(fmt.Sprintf("%s Watched Repos (%d)", focusIndicator, len(r.order)))
+	titleText := fmt.Sprintf("%s Watched Repos (%d)", focusIndicator, len(r.order))
+	if n := len(r.installations); n > 0 {
+		titleText += fmt.Sprintf(" — %d installation(s)", n)
+	}
+	title := activeStyle.Render(titleText)
 
 	maxWidth := width - 6
 	if maxWidth < 20 {
@@ -65,7 +114,11 @@ func (r RepoPaneComponent) View(width int) string {
 		if !st.LastPollAt.IsZero() {
 			age = fmtDuration(r.now.Sub(st.LastPollAt)) + " ago"
 		}
-		line := fmt.Sprintf("%-30s %2d PR(s)  polled %s", repo, st.PRCount, age)
+		provenance := ""
+		if st.InstallationID != 0 {
+			provenance = fmt.Sprintf(" [installation %d]", st.InstallationID)
+		}
+		line := fmt.Sprintf("%-30s %2d PR(s)  polled %s%s", repo, st.PRCount, age, provenance)
 		if st.LastErr != "" {
 			line += "  " + failStyle.Render("error: "+st.LastErr)
 		}
@@ -77,8 +130,31 @@ func (r RepoPaneComponent) View(width int) string {
 	if len(lines) == 0 {
 		lines = append(lines, dimStyle.Render("no repos configured"))
 	}
+	for _, note := range r.provenanceNotes() {
+		lines = append(lines, note)
+	}
 	content := title + "\n" + strings.Join(lines, "\n")
 	return borderStyle.Width(width - 4).Render(content)
+}
+
+// provenanceNotes renders the derived set's provenance/warning lines (R4):
+// a truncated-enumeration warning, a max_derived_repos cap warning, and a
+// count of watched_repos entries not covered by any installation. Absent
+// (no DerivedRepoSetEvent received yet, or nothing to report) yields no
+// lines — this pane must never claim provenance it hasn't actually been
+// told.
+func (r RepoPaneComponent) provenanceNotes() []string {
+	var notes []string
+	if r.truncated {
+		notes = append(notes, failStyle.Render("⚠ pagination ceiling hit while enumerating installations/repos — the derived set may be incomplete"))
+	}
+	if r.capped {
+		notes = append(notes, failStyle.Render(fmt.Sprintf("⚠ capped at %d repos (max_derived_repos) — raise the cap or narrow watched_repos to review the rest", r.capApplied)))
+	}
+	if len(r.filteredOut) > 0 {
+		notes = append(notes, dimStyle.Render(fmt.Sprintf("%d watched_repos entr(ies) not covered by any installation: %s", len(r.filteredOut), strings.Join(r.filteredOut, ", "))))
+	}
+	return notes
 }
 
 func (r RepoPaneComponent) Height() int {
@@ -86,7 +162,7 @@ func (r RepoPaneComponent) Height() int {
 	if n == 0 {
 		n = 1
 	}
-	return n + 3
+	return n + 3 + len(r.provenanceNotes())
 }
 
 // SetFocused updates the focused state.

--- a/pruefer/tui/repos_test.go
+++ b/pruefer/tui/repos_test.go
@@ -60,3 +60,95 @@ func TestRepoPane_UnseenRepoFromPollEventIsAdded(t *testing.T) {
 		t.Fatalf("order = %v, want 1 entry", r.order)
 	}
 }
+
+// TestRepoPane_DerivedRepoSetEvent_AddsAndRemovesRepos is #1641/R4's core
+// live-update regression test: a re-derivation that gains a repo must add
+// it, one that loses a repo must remove it, and neither operation may
+// disturb an already-present repo's poll status (the Risk this pane's
+// plumbing is explicitly called out for: "a poorly-designed event could
+// race the initial seed or double-count repos").
+func TestRepoPane_DerivedRepoSetEvent_AddsAndRemovesRepos(t *testing.T) {
+	var r RepoPaneComponent
+	r.SetWatchedRepos([]string{"handarbeit/fabrik"})
+	now := time.Now()
+	comp, _ := r.Update(RepoPollEvent{Repo: "handarbeit/fabrik", At: now, PRCount: 3})
+	r = comp.(RepoPaneComponent)
+
+	// First derivation: gains handarbeit/other alongside the already-seeded
+	// (and already-polled) handarbeit/fabrik.
+	comp, _ = r.Update(DerivedRepoSetEvent{
+		Repos: []DerivedRepoEntry{
+			{Repo: "handarbeit/fabrik", InstallationID: 111},
+			{Repo: "handarbeit/other", InstallationID: 111},
+		},
+	})
+	r = comp.(RepoPaneComponent)
+	if len(r.order) != 2 {
+		t.Fatalf("order after gaining a repo = %v, want 2 entries", r.order)
+	}
+	if got := r.repos["handarbeit/fabrik"].PRCount; got != 3 {
+		t.Errorf("handarbeit/fabrik's PRCount = %d, want 3 preserved across the derivation event, not reset", got)
+	}
+
+	// Second derivation: loses handarbeit/other (e.g. the installation's
+	// repository_selection narrowed, or it was dropped from watched_repos).
+	comp, _ = r.Update(DerivedRepoSetEvent{
+		Repos: []DerivedRepoEntry{{Repo: "handarbeit/fabrik", InstallationID: 111}},
+	})
+	r = comp.(RepoPaneComponent)
+	if len(r.order) != 1 || r.order[0] != "handarbeit/fabrik" {
+		t.Fatalf("order after losing a repo = %v, want [handarbeit/fabrik] only", r.order)
+	}
+	if _, ok := r.repos["handarbeit/other"]; ok {
+		t.Error("handarbeit/other should have been dropped from repos, not just order")
+	}
+	if got := r.repos["handarbeit/fabrik"].PRCount; got != 3 {
+		t.Errorf("handarbeit/fabrik's PRCount = %d, want 3 still preserved", got)
+	}
+}
+
+// TestRepoPane_DerivedRepoSetEvent_ShowsInstallationProvenance covers R4's
+// per-repo "from which installation" half.
+func TestRepoPane_DerivedRepoSetEvent_ShowsInstallationProvenance(t *testing.T) {
+	var r RepoPaneComponent
+	comp, _ := r.Update(DerivedRepoSetEvent{
+		Repos:         []DerivedRepoEntry{{Repo: "handarbeit/fabrik", InstallationID: 111}},
+		Installations: []DerivedInstallationSummary{{Account: "handarbeit", InstallationID: 111, RepositorySelection: "all", RepoCount: 1}},
+	})
+	r = comp.(RepoPaneComponent)
+
+	view := r.View(120)
+	if !strings.Contains(view, "installation 111") {
+		t.Errorf("View() does not show the granting installation ID:\n%s", view)
+	}
+	if !strings.Contains(view, "1 installation(s)") {
+		t.Errorf("View() does not show the installation count in the title:\n%s", view)
+	}
+}
+
+// TestRepoPane_DerivedRepoSetEvent_SurfacesProvenanceWarnings covers R4/R5's
+// TUI-visible warnings: a truncated enumeration, a max_derived_repos cap,
+// and a watched_repos entry not covered by any installation must all be
+// surfaced, not silently absorbed.
+func TestRepoPane_DerivedRepoSetEvent_SurfacesProvenanceWarnings(t *testing.T) {
+	var r RepoPaneComponent
+	comp, _ := r.Update(DerivedRepoSetEvent{
+		Repos:       []DerivedRepoEntry{{Repo: "handarbeit/fabrik", InstallationID: 111}},
+		FilteredOut: []string{"handarbeit/uninstalled-repo"},
+		Truncated:   true,
+		Capped:      true,
+		CapApplied:  200,
+	})
+	r = comp.(RepoPaneComponent)
+
+	view := r.View(120)
+	if !strings.Contains(view, "pagination ceiling") {
+		t.Errorf("View() does not surface the truncation warning:\n%s", view)
+	}
+	if !strings.Contains(view, "capped at 200") {
+		t.Errorf("View() does not surface the cap warning:\n%s", view)
+	}
+	if !strings.Contains(view, "handarbeit/uninstalled-repo") {
+		t.Errorf("View() does not surface the filtered-out watched_repos entry:\n%s", view)
+	}
+}

--- a/pruefer/tui_run.go
+++ b/pruefer/tui_run.go
@@ -40,7 +40,7 @@ func runTUI(ctx context.Context, d *Daemon) error {
 		}
 	}
 
-	tuiModel := ptui.New(d.config().WatchedRepos, time.Now())
+	tuiModel := ptui.New(derivedRepoNames(d.derivedSet()), time.Now())
 	p := tea.NewProgram(tuiModel, tea.WithAltScreen(), tea.WithoutSignalHandler())
 
 	go func() {


### PR DESCRIPTION
Closes #1641

## What this does

Inverts Pruefer's repo-discovery model: **the GitHub App installation is now the source of truth** for which repos get reviewed, rather than a hand-maintained `watched_repos` list that had to be kept in sync by hand with actual installation state.

- `internal/githubauth.Reconciler` gains a new `Derive` method — discovers every installation of the operator's own App (no owner list needed as input), enumerates each one's accessible repos (now unconditionally, for both `"all"` and `"selected"` installation modes), unions them, applies an optional `watched_repos` intersection filter (reporting any entry not covered rather than silently dropping/including it), and applies a deterministic `max_derived_repos` cap.
- `github/app.go`'s `FetchAppInstallations`/`FetchInstallationRepositories` now paginate for real (up to a 50-page sanity ceiling) instead of silently capping at 100 with only a log line — this became a correctness issue once enumeration is the primary discovery path, not just a verification check.
- `pruefer/daemon.go` gained the re-derivation machinery (`ApplyDerivedRepos`, `rederiveRepos`, `triggerRederivation`, a periodic ticker) that both an `installation`/`installation_repositories` webhook event and a timer (poll-mode's new mechanism) converge on — installing/uninstalling the App is picked up with no restart.
- `pruefer/execute.go`'s SIGHUP reload no longer mints or removes any owner's installation auth (every installation is already minted unconditionally) — it just triggers a fresh re-derivation.
- The TUI's Watched Repos pane now shows per-repo installation provenance and surfaces pagination-ceiling/cap/filtered-out warnings live (`DerivedRepoSetEvent`).
- Containment (an installation belonging to a different App is never contacted) is structural — `GET /app/installations` is JWT-scoped to the calling App's identity — verified by a regression test simulating two distinct App identities against one fake server.

`watched_repos` remains the config key but is now an **optional narrowing filter**: absent means "everything the App's installations grant"; present means the intersection, never wider.

## Key decisions (see ADR-1641 for full rationale)

- `watched_repos` kept as the config key rather than renamed — deeply threaded through config/reload machinery/README, redefining its semantics was judged lower-risk than a migration.
- `max_derived_repos` (default 200) bounds a single derivation's result, separate from pagination; `<= 0` disables it.
- `MintOwnerAuth`/`verifyRepoAccess` have no remaining production caller after this change but are deliberately retained (not deleted) — still compiled, still tested, a scoped and explicitly-documented deferral rather than in-scope cleanup.
- SIGHUP `watched_repos` reload now makes a live GitHub call (via the same re-derivation path every other trigger uses) rather than a purely local re-intersection — accepted cost for reusing one code path instead of a second, divergent one.

Also amends ADR-1233 (marks the old `watched_repos`-as-containment-boundary claim superseded by #1253's per-operator App identity) and ADR-1253 (documents the new TUI-observability exception and the SIGHUP behavior change).

## How to test

- `go build ./...`, `go vet ./...`, `go test -race ./...` all pass (confirmed excluding one pre-existing, unrelated network-dependent flake in `cmd`'s `TestExecute_ConfigYAMLApplied`, which doesn't import anything this PR touches).
- New coverage: `internal/githubauth/derive_test.go` (future-repo pickup, the R5 cap's determinism, the containment regression test), `pruefer/config_test.go` (new field precedence), `pruefer/reload_test.go` (the inverted SIGHUP behavior), `pruefer/tui/repos_test.go` + `model_test.go` (live TUI updates).
- `cmd/pruefer/README.md` rewritten throughout — First run, Installation-derived repo discovery (new section), Config reload table, Configuration reference table, Terminal UI.