### PR TITLE
fix(e2e): run.sh can hang forever after go test exits — unguarded network probe, no watchdog, no stall detection

### DIFF
--- a/adrs/1676-e2e-runner-hang-watchdogs.md
+++ b/adrs/1676-e2e-runner-hang-watchdogs.md
@@ -1,0 +1,161 @@
+# ADR 1676: `scripts/e2e/run.sh` Hang Hardening — Timeouts, Post-Suite Watchdog, Stall Detector
+
+**Date**: 2026-08-29
+**Status**: Accepted
+**Issue**: #1676 — run.sh can hang forever after go test exits — unguarded network probe, no
+watchdog, no stall detection
+
+## Context
+
+During the v0.0.81 cut, `scripts/e2e/run.sh` hung for **17 hours 19 minutes**, with its log
+untouched for the last ~19 of them, while the `e2e.test` binary was long gone (`go test` had
+already exited). Nothing in the log indicated a failure — the suite had completed 71 passes;
+the script simply never proceeded past the test invocation. Cost containment was luck (the
+bed happened to go idle around 04:30, ~$28) rather than design.
+
+The root cause: `switch_and_run` calls `gh api rate_limit` twice per leg — once before the
+suite invocation (`budget_before`) and once after (`budget_after`) — to report GraphQL budget
+consumption (A3 of #1527). Both calls had **no timeout**:
+
+```sh
+budget_after=$(GH_TOKEN="$BED_TOKEN" gh api rate_limit --jq '...' 2>/dev/null || echo "")
+```
+
+`|| echo ""` guards a *failing* call, not a *hanging* one — exactly the distinction that
+mattered here. These were confirmed the only two `gh api`/`curl`/`wget` calls in the script
+outside the `go test -tags=e2e` invocations themselves.
+
+This script gates every release cut (`scripts/cut-release.sh` invokes it) — any fix must be
+conservative about false positives, since a spurious abort blocks a release exactly as
+effectively as a real hang would, just faster.
+
+## Decision
+
+Three independent layers, matching the issue's own R1–R3:
+
+### R1 — `with_timeout <seconds> <cmd...>`, wrapping both `gh api rate_limit` calls
+
+A new helper near `run_reaped` (the file's existing "background job, reap on kill"
+precedent), implemented as portable bash job control — background the guarded command under
+`set -m` (which gives it its own process group), background a `sleep <seconds>` watcher that
+group-kills it on expiry, `wait`, then report a marker-file-detected timeout as exit 124
+(matching GNU `timeout(1)`'s convention). Chosen over `perl`/`python3` (the issue's own
+Prior Art lead): both are confirmed present, but the file has zero existing interpreter
+dependency, and this is exactly the idiom `run_reaped`/`stop_bed_instance` already establish.
+`E2E_GH_API_TIMEOUT` (default 30s) controls the deadline — generous for what are lightweight
+REST metadata calls.
+
+**Critical correctness constraint, found empirically during Implement: `with_timeout` must
+never be invoked via `$(with_timeout ...)`.** Command substitution always runs its command
+list in a subshell, and `set -m` job control's one-process-group-per-background-job behavior
+does not apply inside that subshell — a job backgrounded there keeps the *substitution
+subshell's own* process group instead of getting one of its own. The deadline watcher's
+group-kill (`kill -TERM -"$pid"`, a negative PGID) then silently targets a process group that
+was never created (`kill` exits 1, "No such process"), the guarded command is never actually
+killed, and it just runs to completion — or hangs forever — entirely unbounded, with no
+visible error. This would have silently defeated R1 at both of its only two real call sites
+(`budget_before=$(with_timeout ...)`, `budget_after=$(with_timeout ...)`), reproducing the
+exact class of hang this issue exists to fix, in code that looked correct and passed a
+timeout test invoked outside a subshell. The fix: both call sites capture output via a temp
+file instead —
+
+```sh
+budget_before_tmp="$(mktemp)"
+if with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '...' \
+    > "$budget_before_tmp" 2>/dev/null; then
+  budget_before="$(cat "$budget_before_tmp" 2>/dev/null || echo "")"
+fi
+rm -f "$budget_before_tmp"
+```
+
+— invoked as a plain foreground statement, `with_timeout` runs in the caller's own shell
+(never a substitution subshell), where `set -m` correctly assigns each backgrounded job its
+own process group and the group-kill works as designed. `scripts/e2e/hang_hardening_test.sh`
+carries a permanent regression guard (Case 4b) asserting `$(with_timeout ...)` genuinely does
+NOT enforce its deadline, so a future refactor back to that pattern at a real call site fails
+this test instead of silently reintroducing the hang.
+
+### R2 — post-suite watchdog
+
+A background watchdog is armed the instant `go test` exits (right after `wait "$suite_pid"`)
+and disarmed at every one of `switch_and_run`'s own exit points (both normal returns and the
+`BUDGET_EXHAUSTED_EXIT` path). Mechanism: a checkpoint file, updated as the post-suite tail
+progresses (consumer drain → `budget_after` probe → `report_test_timings` → failure
+classification → `detect_rate_limit_backoff`), and a deadline watcher armed inline (not
+through a shared "arm" helper returning a PID via `$(...)` — the same subshell/job-control
+hazard as R1 applies) that signals the *script's own PID* (`$$`) via `SIGTERM` on expiry. A
+`TERM` trap installed for this window checks a `fired` marker at signal-delivery time: if
+present, this was the watchdog, and it prints a diagnostic (elapsed time since `go test`
+exited, the last checkpoint reached, the last engine-log line) and exits
+`POST_SUITE_WATCHDOG_EXIT` (6, extending the file's existing distinct-exit-code convention:
+`BUDGET_EXHAUSTED_EXIT`=3, `PREFLIGHT_FAILED_EXIT`=4, `PREGATE_FAILED_EXIT`=5); if absent,
+this was some other `TERM` (e.g. an external kill) landing in the same window, and it falls
+through to the pre-existing suite/consumer group-kill-then-exit-143 behavior unchanged.
+`E2E_POST_SUITE_WATCHDOG` (default 300s) controls the window — generous relative to what the
+watched tail actually does (a couple of REST calls plus `jq` parsing, normally seconds).
+
+**Chosen over a foreground per-step elapsed check.** A foreground check can only observe
+elapsed time *between* statements — it cannot detect or interrupt a single statement that is
+itself hung, which is precisely the incident's failure mode. Only an independently-scheduled
+background process can enforce a deadline against a stuck foreground statement.
+
+**Known, accepted gap:** by the time the watchdog could fire, R1 has already removed the only
+two calls this issue identifies as hang-capable in this tail — so in the common case R2
+should never actually fire. It exists as a backstop for a future regression (a call added to
+this tail without routing through `with_timeout`), and cannot group-kill a hypothetical
+stuck *foreground* statement it doesn't itself own a process group for — it can only
+terminate the whole script via `SIGTERM $$`. This is an intentional trade-off: building full
+group-kill machinery for a step that, by construction once R1 lands, should never need it,
+was judged not worth the added complexity. See the "KNOWN GAP" precedent elsewhere in this
+file for the same documented-not-solved convention.
+
+### R3 — stall detector on suite output
+
+Independently of R2, a background loop (started alongside the existing `tee`/`jq` consumer,
+torn down immediately once `go test` exits rather than waiting out its own ~60s poll
+interval) polls the JSON log's mtime — not the terminal/tee output a human might be watching,
+since the incident's own `ps` evidence shows the run was backgrounded with no one watching a
+terminal. On `E2E_STALL_WARN_MINUTES` (default 15) of no mtime change while `go test` is
+still alive, it logs a warning naming the last completed scenario (`last_completed_test_name`,
+reusing `report_test_timings`'s own terminal-action `jq` filter) and the silence duration,
+then resets its own counter so a long-quiet run warns once per window rather than once ever.
+Purely advisory — never touches `$rc`, never aborts (R4).
+
+The isolated `TestMergeTrainRunawayGuardPausesBatch` leg (runs alone, deliberately idle for
+long stretches while a 1-hour-windowed runaway guard is armed) is expected to trigger this
+warning on every healthy run — documented in `tests/e2e/README.md` so it doesn't read as a
+regression.
+
+### R4 — non-gating, for free
+
+The budget probe is a report, never a gate: a timeout under R1 degrades exactly like the
+pre-existing "call failed" case (the `budget_before=""`/`budget_after=""` fallback plus the
+existing `[ -n "$budget_before" ] && [ -n "$budget_after" ]` gate), never affecting the
+suite's own exit code. R3's warning is likewise purely advisory.
+
+### Defaults kept at the issue's proposed starting points
+
+30s / 5m / 15m, not further tuned: nothing in the post-suite tail plausibly approaches
+minutes, and the one measured real-world inter-event gap on record (5½ minutes,
+`TestReviewAuthorityClearsOnApproval`, multi-scenario "on" leg) sits comfortably under the
+15-minute R3 default. See `tests/e2e/README.md`'s "Hang hardening" section for the full
+derivation and rationale for keeping rather than changing these values.
+
+## Consequences
+
+- A hung `gh api rate_limit` call can no longer block the script indefinitely — it is killed,
+  whole process group, within `E2E_GH_API_TIMEOUT` (default 30s), and degrades to a skipped
+  budget report exactly as a failed call already did.
+- A future regression in `switch_and_run`'s post-suite tail (a new call that forgets to route
+  through `with_timeout`) fails loudly with a diagnostic naming the stuck step within
+  `E2E_POST_SUITE_WATCHDOG` (default 5m), instead of hanging silently for hours.
+- Prolonged silence in the suite's own output, while `go test` is still running, is now
+  surfaced (not gated) — an operator watching a long run can distinguish "still working" from
+  "gone quiet with no signal either way."
+- `with_timeout` must never be called via `$(...)` — this is now a load-bearing, tested
+  constraint (`hang_hardening_test.sh` Case 4b), not just a comment. Both real call sites use
+  the temp-file-capture pattern instead.
+- `scripts/e2e/hang_hardening_test.sh` provides permanent regression coverage for `with_timeout`
+  (including the group-kill discipline and the `$(...)` hazard), the deadline-watcher/marker
+  pattern R2 uses, and `last_completed_test_name` — mirroring `backoff_detection_test.sh`'s and
+  `pregate_test.sh`'s existing precedent for shell-level verification of this file.

--- a/scripts/e2e/hang_hardening_test.sh
+++ b/scripts/e2e/hang_hardening_test.sh
@@ -278,6 +278,41 @@ else
   fail "last_completed_test_name reported '$name', expected 'TestBeta' (skip should count as the most recent completion)"
 fi
 
+# ---------------------------------------------------------------------------
+# _post_suite_watchdog_signal (R2 fix, found during Review, #1676)
+# ---------------------------------------------------------------------------
+
+# Case 12: the "external signal" fallback branch (the $watchdog_dir/fired
+# marker absent — i.e. this signal was NOT the watchdog itself firing) must
+# disarm the watchdog's own background timer job too, not just the
+# suite/consumer jobs — an earlier revision's TERM-only trap left the
+# watchdog job running in exactly this branch, and never wired INT to any
+# watchdog-aware handler at all (see the function's own comment in run.sh
+# for the full account). This exercises the shared handler directly against
+# stand-in jobs for suite_pid/consumer_pid/watchdog_pid, run in a subshell
+# since the handler itself calls `exit`. The function reads these as
+# ordinary variables (this test sets them as globals rather than switch_and_
+# run's own locals) — equivalent from the function's own point of view,
+# since bash trap/function execution doesn't distinguish the two.
+watchdog_dir="$(mktemp -d)"
+fifo_dir="$(mktemp -d)"
+mode="test"
+suite_exit_epoch=$(date +%s)
+( sleep 30 ) &
+suite_pid=$!
+( sleep 30 ) &
+consumer_pid=$!
+( sleep 30 ) &
+watchdog_pid=$!
+( _post_suite_watchdog_signal 143 ) >/dev/null 2>&1
+sleep 1
+if ! kill -0 "$watchdog_pid" 2>/dev/null && ! kill -0 "$suite_pid" 2>/dev/null && ! kill -0 "$consumer_pid" 2>/dev/null; then
+  pass "_post_suite_watchdog_signal's external-signal fallback disarms the watchdog job (not just suite/consumer) — no orphaned timer left running"
+else
+  fail "_post_suite_watchdog_signal left a job running (watchdog=$(kill -0 "$watchdog_pid" 2>/dev/null && echo alive || echo gone), suite=$(kill -0 "$suite_pid" 2>/dev/null && echo alive || echo gone), consumer=$(kill -0 "$consumer_pid" 2>/dev/null && echo alive || echo gone)) — orphan leak"
+fi
+rm -rf "$watchdog_dir" "$fifo_dir" 2>/dev/null
+
 if [ "$FAILED" -ne 0 ]; then
   echo "=== hang_hardening_test.sh: FAILED ==="
   exit 1

--- a/scripts/e2e/hang_hardening_test.sh
+++ b/scripts/e2e/hang_hardening_test.sh
@@ -293,11 +293,12 @@ fi
 # since the handler itself calls `exit`. The function reads these as
 # ordinary variables (this test sets them as globals rather than switch_and_
 # run's own locals) — equivalent from the function's own point of view,
-# since bash trap/function execution doesn't distinguish the two.
+# since bash trap/function execution doesn't distinguish the two. $mode and
+# $suite_exit_epoch are only read by the function's OTHER branch (the
+# watchdog's own "fired" diagnostic, not exercised by this fallback-focused
+# case), so they're deliberately not set here.
 watchdog_dir="$(mktemp -d)"
 fifo_dir="$(mktemp -d)"
-mode="test"
-suite_exit_epoch=$(date +%s)
 ( sleep 30 ) &
 suite_pid=$!
 ( sleep 30 ) &

--- a/scripts/e2e/hang_hardening_test.sh
+++ b/scripts/e2e/hang_hardening_test.sh
@@ -161,14 +161,17 @@ rm -rf "$child_marker"
 # ---------------------------------------------------------------------------
 # Deadline-watcher-plus-marker-file pattern (R2) — supports AC2
 #
-# R2's post-suite watchdog is inline in switch_and_run (armed directly in
-# the caller's own function body, not through a shared "arm" function — see
-# run.sh's own comment on why command substitution's subshell semantics rule
-# that out), so it isn't itself an extractable, independently-callable
-# function. What IS shared and directly testable is disarm_deadline_signal
-# (the teardown half) and the marker-file-on-timeout pattern both
-# with_timeout and the watchdog use — exercised here standalone, without
-# needing a live bed or an actual switch_and_run invocation.
+# R2's post-suite watchdog TIMER is armed inline in switch_and_run (directly
+# in the caller's own function body, not through a shared "arm" function —
+# see run.sh's own comment on why command substitution's subshell semantics
+# rule that out), so arming it isn't itself an extractable, independently-
+# callable step. What IS shared and directly testable: disarm_deadline_signal
+# (the teardown half), the marker-file-on-timeout pattern both with_timeout
+# and the watchdog use, and — since Review, #1676 — the watchdog's own
+# TERM/INT signal handler, extracted into _post_suite_watchdog_signal
+# specifically so it's independently testable (see Case 13 below). All
+# exercised here standalone, without needing a live bed or an actual
+# switch_and_run invocation.
 # ---------------------------------------------------------------------------
 
 # Case 6: the pattern fires (marker written, main process signaled) when the
@@ -313,6 +316,83 @@ else
   fail "_post_suite_watchdog_signal left a job running (watchdog=$(kill -0 "$watchdog_pid" 2>/dev/null && echo alive || echo gone), suite=$(kill -0 "$suite_pid" 2>/dev/null && echo alive || echo gone), consumer=$(kill -0 "$consumer_pid" 2>/dev/null && echo alive || echo gone)) — orphan leak"
 fi
 rm -rf "$watchdog_dir" "$fifo_dir" 2>/dev/null
+
+# Case 13 (found during external review, #1676): the FIRED branch (the
+# watchdog's own "actually stuck" case — the $watchdog_dir/fired marker
+# present) must ALSO group-kill suite_pid/consumer_pid before exiting, not
+# just print its diagnostic. An earlier revision skipped this specifically
+# in the fired branch, which is backwards: the fired branch is the
+# realistic case this watchdog exists to catch (a wedged tee/jq consumer
+# drain — every other step in the tail is either with_timeout-bounded or a
+# fast local jq/grep call), so consumer_pid is exactly the process most
+# likely to still be alive and wedged at the moment this branch runs, and
+# skipping its group-kill orphaned it. Mirrors Case 12's structure but
+# creates the $watchdog_dir/fired marker first so the OTHER branch runs;
+# $mode/$suite_exit_epoch ARE needed here since the fired branch's own
+# diagnostic reads them.
+watchdog_dir="$(mktemp -d)"
+fifo_dir="$(mktemp -d)"
+# shellcheck disable=SC2034 # read by _post_suite_watchdog_signal's fired
+# branch (defined in the sourced run.sh), invisible to shellcheck's static
+# analysis — same false positive run.sh's own suite_exit_epoch assignment
+# disables.
+mode="test"
+# shellcheck disable=SC2034
+suite_exit_epoch=$(date +%s)
+: > "$watchdog_dir/fired"
+( sleep 30 ) &
+suite_pid=$!
+( sleep 30 ) &
+consumer_pid=$!
+( sleep 30 ) &
+watchdog_pid=$!
+( _post_suite_watchdog_signal 143 ) >/dev/null 2>&1
+watchdog_signal_rc=$?
+sleep 1
+if [ "$watchdog_signal_rc" -eq "$POST_SUITE_WATCHDOG_EXIT" ] \
+  && ! kill -0 "$suite_pid" 2>/dev/null && ! kill -0 "$consumer_pid" 2>/dev/null && ! kill -0 "$watchdog_pid" 2>/dev/null; then
+  pass "_post_suite_watchdog_signal's FIRED branch group-kills suite_pid/consumer_pid (not just watchdog_pid) before exiting \$POST_SUITE_WATCHDOG_EXIT — no orphaned tee/jq consumer left running"
+else
+  fail "_post_suite_watchdog_signal's fired branch left a job running or returned the wrong code (rc=$watchdog_signal_rc, expected $POST_SUITE_WATCHDOG_EXIT; suite=$(kill -0 "$suite_pid" 2>/dev/null && echo alive || echo gone), consumer=$(kill -0 "$consumer_pid" 2>/dev/null && echo alive || echo gone), watchdog=$(kill -0 "$watchdog_pid" 2>/dev/null && echo alive || echo gone)) — orphan leak in the realistic 'actually stuck' case"
+fi
+rm -rf "$watchdog_dir" "$fifo_dir" 2>/dev/null
+
+# ---------------------------------------------------------------------------
+# _report_gh_probe_failure (found during external review, #1676)
+# ---------------------------------------------------------------------------
+
+# Case 14: with_timeout's own "command exceeded Ns, killed: ..." diagnostic
+# must survive to an operator's view when a real call site captures stderr
+# to a file (the pattern budget_before/budget_after now use) rather than
+# discarding it via `2>/dev/null` — the old pattern silently swallowed that
+# diagnostic too, since a redirect on a function-call command applies to
+# everything the function's body does, not just the wrapped subprocess.
+# Exercises the real call-site pattern end to end: with_timeout against a
+# genuinely hanging command, stderr captured to a file, then relayed via
+# _report_gh_probe_failure, and asserts the ORIGINAL with_timeout diagnostic
+# text is present in what gets printed — not just that something was
+# printed.
+probe_err="$(mktemp)"
+with_timeout 2 sleep 30 > /dev/null 2>"$probe_err"
+relayed="$(_report_gh_probe_failure "$probe_err" "test probe" 2>&1)"
+if printf '%s' "$relayed" | grep -q "with_timeout: command exceeded 2s, killed: sleep 30"; then
+  pass "_report_gh_probe_failure relays with_timeout's own timeout diagnostic (previously swallowed by the call site's 2>/dev/null) — output: $relayed"
+else
+  fail "_report_gh_probe_failure did not relay with_timeout's diagnostic (got: '$relayed') — the exact signal an operator needs to tell a caught hang apart from an ordinary gh failure is being lost again"
+fi
+rm -f "$probe_err"
+
+# Case 15: the normal (empty stderr) case emits nothing — this warning
+# relay must not add noise to a probe that simply succeeds.
+probe_err="$(mktemp)"
+: > "$probe_err"
+relayed="$(_report_gh_probe_failure "$probe_err" "test probe" 2>&1)"
+if [ -z "$relayed" ]; then
+  pass "_report_gh_probe_failure emits nothing for an empty (no-error) stderr capture — no spurious noise on a healthy probe"
+else
+  fail "_report_gh_probe_failure emitted unexpected output for an empty stderr file: '$relayed'"
+fi
+rm -f "$probe_err"
 
 if [ "$FAILED" -ne 0 ]; then
   echo "=== hang_hardening_test.sh: FAILED ==="

--- a/scripts/e2e/hang_hardening_test.sh
+++ b/scripts/e2e/hang_hardening_test.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# scripts/e2e/hang_hardening_test.sh — regression coverage for #1676's hang
+# hardening in scripts/e2e/run.sh: the v0.0.81 cut hung for 17h19m AFTER
+# `go test` had already exited, because the two `gh api rate_limit`
+# budget-probe calls had no timeout at all (`|| echo ""` only guards a
+# *failing* call, not a *hanging* one).
+#
+# These are shell-level behaviors (per the issue's own scope), so this
+# mirrors backoff_detection_test.sh/pregate_test.sh's precedent: source
+# run.sh for its real function definitions and exercise them directly
+# against constructed fixtures, rather than running an actual multi-hour
+# gate. Covers:
+#   - with_timeout (R1) — AC1, including a non-vacuous demonstration that
+#     the guarded command genuinely hangs past the timeout window on its
+#     own, so the PASS above isn't just the command finishing fast anyway.
+#   - disarm_deadline_signal plus the background-watcher-with-marker-file
+#     pattern R2's post-suite watchdog uses (inline in switch_and_run, not
+#     itself an extractable function — see run.sh's own comment on why the
+#     watcher is armed inline rather than through a shared "arm" helper) —
+#     supports AC2 by exercising the same deadline-detection mechanism in
+#     isolation, without requiring a live bed.
+#   - last_completed_test_name (R3) — supports AC3 by exercising the
+#     go-test-json parse a real stall warning would use to name the last
+#     completed scenario.
+#
+# Usage: scripts/e2e/hang_hardening_test.sh
+# Exit 0 if all assertions pass, 1 otherwise.
+
+set -uo pipefail # no -e: assertions below intentionally continue past failures
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Source run.sh for its function definitions only — the sourcing guard at the
+# bottom of run.sh (BASH_SOURCE[0] == $0) prevents this from triggering an
+# actual gate run. Mirrors backoff_detection_test.sh's precedent.
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/e2e/run.sh"
+set +e
+
+FAILED=0
+
+pass() { echo "PASS: $1"; }
+fail() {
+  echo "FAIL: $1"
+  FAILED=1
+}
+
+# ---------------------------------------------------------------------------
+# with_timeout (R1) — AC1
+# ---------------------------------------------------------------------------
+
+# Case 1: a genuinely hanging command is killed at the deadline, not left to
+# run to completion. Uses a 2s timeout against a 30s sleep — if with_timeout
+# were a no-op (or the deadline math were broken), this would take ~30s and
+# blow well past the bound checked below.
+start=$(date +%s)
+with_timeout 2 sleep 30
+rc=$?
+end=$(date +%s)
+elapsed=$((end - start))
+if [ "$rc" -eq 124 ] && [ "$elapsed" -le 10 ]; then
+  pass "with_timeout kills a hanging command at its deadline (rc=124, elapsed=${elapsed}s, bound 10s)"
+else
+  fail "with_timeout did not enforce its deadline (rc=$rc, elapsed=${elapsed}s, expected rc=124 within 10s)"
+fi
+
+# Case 2 (non-vacuous, per AC1): prove the same underlying command genuinely
+# hangs past the timeout window on its own — i.e. Case 1's fast return is
+# with_timeout's doing, not the guarded command quietly finishing quickly
+# regardless. Backgrounds the SAME command unwrapped, waits past the
+# timeout used above, and confirms it is still alive.
+( sleep 30 ) &
+unwrapped_pid=$!
+sleep 2
+if kill -0 "$unwrapped_pid" 2>/dev/null; then
+  pass "non-vacuous: the same command run WITHOUT with_timeout is still running past the 2s bound used in Case 1 (proves Case 1's early return is the timeout firing, not the command finishing on its own — 'removing the timeout' returns the hang)"
+else
+  fail "non-vacuous check failed: the unwrapped command finished on its own within 2s — Case 1 above would pass vacuously"
+fi
+kill -TERM "$unwrapped_pid" 2>/dev/null
+wait "$unwrapped_pid" 2>/dev/null
+
+# Case 3: a command that finishes well within the deadline returns its own
+# exit code untouched, not a false 124.
+with_timeout 5 true
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "with_timeout passes through a fast command's own exit code (0) unmodified"
+else
+  fail "with_timeout returned $rc for a fast, successful command (expected 0)"
+fi
+
+with_timeout 5 false
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "with_timeout passes through a fast command's own non-zero exit code (1) unmodified, not a false timeout"
+else
+  fail "with_timeout returned $rc for a fast, failing command (expected 1)"
+fi
+
+# Case 4: the REQUIRED output-capture pattern (temp file, not `$(...)`) — the
+# same pattern the real budget_before/budget_after call sites use — actually
+# enforces the deadline against a hanging command while still letting the
+# caller capture its output.
+capture_tmp="$(mktemp)"
+start=$(date +%s)
+with_timeout 2 sleep 30 > "$capture_tmp" 2>/dev/null
+rc=$?
+end=$(date +%s)
+elapsed=$((end - start))
+if [ "$rc" -eq 124 ] && [ "$elapsed" -le 10 ]; then
+  pass "with_timeout enforces its deadline when output is captured via a temp file (rc=124, elapsed=${elapsed}s) — the pattern the real gh api call sites use"
+else
+  fail "with_timeout via temp-file capture did not enforce its deadline (rc=$rc, elapsed=${elapsed}s, expected rc=124 within 10s)"
+fi
+rm -f "$capture_tmp"
+
+# Case 4b (regression guard, mirrors backoff_detection_test.sh's
+# "neutralization" precedent): capturing with_timeout's output via
+# `$(with_timeout ...)` instead of a temp file must NOT be reintroduced —
+# confirmed empirically during Implement that command substitution always
+# runs its command list in a subshell where `set -m`'s one-process-group-
+# per-background-job behavior does not apply, so the deadline watcher's
+# group-kill silently targets a process group that doesn't exist and never
+# actually kills the guarded command — it just runs to completion (or hangs
+# forever) unbounded, defeating with_timeout's entire purpose with no
+# visible error. This asserts that hazard is real (not a theoretical
+# concern) so a future refactor back to `$(with_timeout ...)` at a real call
+# site fails THIS test instead of silently reintroducing the exact class of
+# hang #1676 exists to fix.
+start=$(date +%s)
+captured=$(with_timeout 2 sleep 5)
+end=$(date +%s)
+elapsed=$((end - start))
+if [ "$elapsed" -ge 4 ]; then
+  pass "regression guard: \$(with_timeout ...) does NOT enforce its deadline (elapsed=${elapsed}s, ran the full underlying sleep) — confirms this pattern is genuinely unsafe and must never be reintroduced at a real call site; captured='$captured'"
+else
+  fail "regression guard: \$(with_timeout ...) unexpectedly enforced its deadline (elapsed=${elapsed}s) — if this pattern has become safe, with_timeout's own comment and the temp-file-capture call sites should be revisited"
+fi
+
+# Case 5: process-group discipline — a timed-out command's own child
+# processes are killed too, not left orphaned (mirrors run_reaped's R3,
+# #1624 discipline). Guards a small shell script that forks a background
+# child sleep and then waits on it; both parent and child must be gone
+# shortly after with_timeout's own deadline fires.
+child_marker="$(mktemp -d)"
+with_timeout 2 bash -c '
+  sleep 30 &
+  echo $! > "'"$child_marker"'/child_pid"
+  wait
+'
+sleep 1 # give the group-kill a moment to land
+child_pid="$(cat "$child_marker/child_pid" 2>/dev/null || echo "")"
+if [ -n "$child_pid" ] && ! kill -0 "$child_pid" 2>/dev/null; then
+  pass "with_timeout group-kills a timed-out command's own background children (no orphaned sleep left running)"
+else
+  fail "with_timeout left a child process (pid=$child_pid) running after its own deadline fired — orphan leak"
+fi
+rm -rf "$child_marker"
+
+# ---------------------------------------------------------------------------
+# Deadline-watcher-plus-marker-file pattern (R2) — supports AC2
+#
+# R2's post-suite watchdog is inline in switch_and_run (armed directly in
+# the caller's own function body, not through a shared "arm" function — see
+# run.sh's own comment on why command substitution's subshell semantics rule
+# that out), so it isn't itself an extractable, independently-callable
+# function. What IS shared and directly testable is disarm_deadline_signal
+# (the teardown half) and the marker-file-on-timeout pattern both
+# with_timeout and the watchdog use — exercised here standalone, without
+# needing a live bed or an actual switch_and_run invocation.
+# ---------------------------------------------------------------------------
+
+# Case 6: the pattern fires (marker written, main process signaled) when the
+# guarded process outlives the deadline — the watchdog's "stuck" case.
+wdir="$(mktemp -d)"
+( sleep 30 ) &
+main_pid=$!
+(
+  sleep 1
+  if kill -0 "$main_pid" 2>/dev/null; then
+    : > "$wdir/fired"
+    kill -TERM "$main_pid" 2>/dev/null
+  fi
+) >/dev/null 2>&1 &
+watcher_pid=$!
+wait "$main_pid" 2>/dev/null
+disarm_deadline_signal "$watcher_pid"
+if [ -f "$wdir/fired" ]; then
+  pass "deadline-watcher pattern fires its marker when the guarded process outlives the deadline (R2's 'stuck' case)"
+else
+  fail "deadline-watcher pattern did not fire its marker for a genuinely-stuck guarded process"
+fi
+rm -rf "$wdir"
+
+# Case 7: the pattern does NOT fire when the guarded process finishes before
+# the deadline — the watchdog's normal, expected case (R2 should never fire
+# on a healthy run).
+wdir="$(mktemp -d)"
+( sleep 1 ) &
+main_pid=$!
+(
+  sleep 5
+  if kill -0 "$main_pid" 2>/dev/null; then
+    : > "$wdir/fired"
+  fi
+) >/dev/null 2>&1 &
+watcher_pid=$!
+wait "$main_pid" 2>/dev/null
+disarm_deadline_signal "$watcher_pid"
+if [ ! -f "$wdir/fired" ]; then
+  pass "deadline-watcher pattern does NOT fire when the guarded process finishes before the deadline (R2's normal, healthy-run case)"
+else
+  fail "deadline-watcher pattern fired its marker even though the guarded process finished well within the deadline — would produce a false abort on a healthy run"
+fi
+rm -rf "$wdir"
+
+# ---------------------------------------------------------------------------
+# last_completed_test_name (R3) — supports AC3
+# ---------------------------------------------------------------------------
+
+jsonlog="$(mktemp)"
+trap 'rm -f "$jsonlog"' EXIT
+
+# Case 8: empty/nonexistent log -> "(none yet)"
+: > "$jsonlog"
+name=$(last_completed_test_name "$jsonlog")
+if [ "$name" = "(none yet)" ]; then
+  pass "last_completed_test_name on an empty log reports '(none yet)'"
+else
+  fail "last_completed_test_name on an empty log reported '$name', expected '(none yet)'"
+fi
+
+# Case 9: a realistic go test -json stream — run/pause/cont actions carry no
+# "completed" signal and must be ignored; the most recent terminal
+# (pass/fail/skip) top-level test name wins, in stream order (not sorted by
+# elapsed).
+{
+  echo '{"Action":"run","Test":"TestAlpha"}'
+  printf '%s\n' '{"Action":"output","Test":"TestAlpha","Output":"=== RUN TestAlpha\n"}'
+  echo '{"Action":"pass","Test":"TestAlpha","Elapsed":1.2}'
+  echo '{"Action":"run","Test":"TestBeta"}'
+  echo '{"Action":"pause","Test":"TestBeta"}'
+  echo '{"Action":"cont","Test":"TestBeta"}'
+  echo '{"Action":"fail","Test":"TestBeta","Elapsed":3.4}'
+  echo '{"Action":"run","Test":"TestGamma"}'
+} > "$jsonlog"
+name=$(last_completed_test_name "$jsonlog")
+if [ "$name" = "TestBeta" ]; then
+  pass "last_completed_test_name reports the most recent terminal (pass/fail/skip) test — TestGamma is still running (only 'run', no terminal action) and correctly excluded"
+else
+  fail "last_completed_test_name reported '$name', expected 'TestBeta' (the last completed test; TestGamma never completed)"
+fi
+
+# Case 10: subtests (Test names containing "/") are excluded — only
+# top-level test completions are reported, matching report_test_timings'
+# own filter.
+{
+  echo '{"Action":"pass","Test":"TestAlpha","Elapsed":1.0}'
+  echo '{"Action":"pass","Test":"TestAlpha/subcase","Elapsed":0.5}'
+} > "$jsonlog"
+name=$(last_completed_test_name "$jsonlog")
+if [ "$name" = "TestAlpha" ]; then
+  pass "last_completed_test_name excludes subtests (containing '/'), reporting only the top-level completion"
+else
+  fail "last_completed_test_name reported '$name', expected 'TestAlpha' (subtest completion should be excluded)"
+fi
+
+# Case 11: skip is treated as a completion, same as pass/fail.
+{
+  echo '{"Action":"pass","Test":"TestAlpha","Elapsed":1.0}'
+  echo '{"Action":"skip","Test":"TestBeta","Elapsed":0.0}'
+} > "$jsonlog"
+name=$(last_completed_test_name "$jsonlog")
+if [ "$name" = "TestBeta" ]; then
+  pass "last_completed_test_name treats 'skip' as a completion, same as pass/fail"
+else
+  fail "last_completed_test_name reported '$name', expected 'TestBeta' (skip should count as the most recent completion)"
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "=== hang_hardening_test.sh: FAILED ==="
+  exit 1
+fi
+echo "=== hang_hardening_test.sh: all checks passed ==="

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -494,6 +494,40 @@ with_timeout() {
   return "$rc"
 }
 
+# _report_gh_probe_failure <stderr_file> <label> (#1676, found during
+# Review, external feedback): relay a failed gh-api-rate_limit probe's
+# captured stderr as a warning, one line at a time — including
+# with_timeout's own "command exceeded Ns, killed: ..." diagnostic when the
+# failure was an enforced R1 timeout rather than an ordinary gh error.
+#
+# Exists because both real call sites below route with_timeout's entire
+# invocation through a caller-side stderr redirect (previously `2>/dev/null`,
+# now a captured temp file passed in as $1 here): a redirect on a
+# function-call command applies to everything the function's body does, not
+# just the wrapped subprocess it backgrounds — confirmed empirically:
+# `f() { echo diag >&2; return 1; }; f 2>/dev/null` produces no stderr
+# output at all. So the old `2>/dev/null` didn't just suppress a failing
+# `gh`'s own error text (the original, intended behavior, unchanged since
+# before this issue) — it also silently discarded with_timeout's OWN
+# diagnostic on an actual timeout, degrading the one case this whole PR
+# exists to make loud (a `gh api rate_limit` call that genuinely hung and
+# got killed by the deadline watcher) into the exact same generic "could not
+# read GraphQL rate_limit" message as an ordinary API failure, with nothing
+# in the log distinguishing a caught hang from a normal error — defeating
+# this mechanism's diagnosability goal at the only two call sites that exist
+# today.
+#
+# Never touches $rc — this is visibility only (R4, #1676: these probes
+# remain purely a report, never a gate, whether they fail via an ordinary
+# error or a with_timeout-enforced kill).
+_report_gh_probe_failure() {
+  local errfile="$1"
+  local label="$2"
+  if [ -s "$errfile" ]; then
+    sed "s/^/warning: ${label} probe: /" "$errfile" >&2
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # Pre-gate (R1, #1454): refuse to spend live budget until the free, fast
 # layers pass.
@@ -1064,24 +1098,46 @@ stop_post_suite_watchdog() {
 #
 # Distinguishes "this is our own watchdog firing" (the $watchdog_dir/fired
 # marker is present) from "some other signal landed in this window" (marker
-# absent — a real Ctrl-C, or an external `kill` of the whole script) and
-# reacts accordingly. Both branches disarm $watchdog_pid (found during
-# Review, #1676): an earlier revision's TERM-only trap left the still-
-# sleeping watchdog timer running whenever its "external signal" branch
-# fired (its own kill target is this script's now-exiting PID, so the leaked
-# job would eventually no-op after its own sleep rather than misfire, but it
-# was still an unreaped background job for up to $POST_SUITE_WATCHDOG
-# seconds) — and was never wired to INT at all, so a Ctrl-C landing in this
-# exact window fell through to switch_and_run's EARLIER INT trap (installed
-# before the consumer wait, for the suite/consumer-drain phase), which has no
-# idea $watchdog_pid or $watchdog_dir exist and left both behind. Installed
-# for both signals below so INT and TERM behave identically here, matching
-# this whole mechanism's own "process-group discipline should extend to any
-# new backgrounded watcher job" design constraint (see with_timeout's and
-# disarm_deadline_signal's own comments).
+# absent — a real Ctrl-C, or an external `kill` of the whole script), but
+# BOTH branches now tear down the same set of resources before exiting
+# (found during Review, #1676 — two rounds of external review feedback, see
+# below): $suite_pid/$consumer_pid are group-killed, $watchdog_pid is
+# disarmed, and $fifo_dir/$watchdog_dir are removed, regardless of which
+# branch is taken. Earlier revisions diverged on this:
+#
+#   - The FIRED branch alone used to skip the suite/consumer group-kill
+#     entirely, just printing the diagnostic and exiting. That is backwards:
+#     the fired branch is the realistic "actually stuck" case this watchdog
+#     exists to catch — the checkpoint file's own text ("waiting for tee/jq
+#     consumer to drain") shows the most likely stuck step is the tee/jq
+#     consumer drain itself, and every OTHER step in this tail is either
+#     already timeout-bounded via with_timeout or a fast local jq/grep call —
+#     so $consumer_pid is exactly the process most likely to still be alive
+#     and wedged at the moment this branch runs, and leaving it running
+#     headless after the script exits is precisely the orphan class
+#     run_reaped's own R3 (#1624) discipline exists to avoid.
+#   - Neither branch used to disarm $watchdog_pid itself: an earlier
+#     revision's TERM-only trap left the still-sleeping watchdog timer
+#     running whenever its "external signal" branch fired (its own kill
+#     target is this script's now-exiting PID, so the leaked job would
+#     eventually no-op after its own sleep rather than misfire, but it was
+#     still an unreaped background job for up to $POST_SUITE_WATCHDOG
+#     seconds) — and was never wired to INT at all, so a Ctrl-C landing in
+#     this exact window fell through to switch_and_run's EARLIER INT trap
+#     (installed before the consumer wait, for the suite/consumer-drain
+#     phase), which has no idea $watchdog_pid or $watchdog_dir exist and left
+#     both behind.
+#
+# Installed for both signals below so INT and TERM behave identically here,
+# matching this whole mechanism's own "process-group discipline should
+# extend to any new backgrounded watcher job" design constraint (see
+# with_timeout's and disarm_deadline_signal's own comments).
 _post_suite_watchdog_signal() {
   local external_exit="$1"
-  if [ -f "$watchdog_dir/fired" ]; then
+  local fired=0
+  [ -f "$watchdog_dir/fired" ] && fired=1
+
+  if [ "$fired" -eq 1 ]; then
     {
       echo ""
       echo "############################################################"
@@ -1092,14 +1148,17 @@ _post_suite_watchdog_signal() {
       echo "## Last engine log line: $(tail -n1 "$ENGINE_LOG" 2>/dev/null || echo "(unavailable)")"
       echo "############################################################"
     } >&2
-    rm -rf "$watchdog_dir" 2>/dev/null || true
-    exit "$POST_SUITE_WATCHDOG_EXIT"
   fi
+
   kill -TERM -"$suite_pid" 2>/dev/null || true
   kill -TERM -"$consumer_pid" 2>/dev/null || true
   disarm_deadline_signal "$watchdog_pid"
   rm -rf "$fifo_dir" 2>/dev/null || true
   rm -rf "$watchdog_dir" 2>/dev/null || true
+
+  if [ "$fired" -eq 1 ]; then
+    exit "$POST_SUITE_WATCHDOG_EXIT"
+  fi
   exit "$external_exit"
 }
 
@@ -1140,17 +1199,24 @@ switch_and_run() {
   # silently defeat its group-kill entirely. A failed `with_timeout` (gh
   # error OR an enforced kill) both degrade to a skipped report rather than
   # aborting the script under `set -e` (R4, #1676: this probe is a report,
-  # never a gate).
+  # never a gate) — but, unlike stdout, stderr is captured to a temp file
+  # rather than discarded (`2>/dev/null` would also silently swallow
+  # with_timeout's own timeout diagnostic — see _report_gh_probe_failure's
+  # own comment, found during Review, #1676) and relayed as a warning on
+  # failure.
   local budget_before budget_after
   budget_before=""
   if [ -n "$BED_TOKEN" ]; then
-    local budget_before_tmp
+    local budget_before_tmp budget_before_err
     budget_before_tmp="$(mktemp)"
+    budget_before_err="$(mktemp)"
     if with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' \
-        > "$budget_before_tmp" 2>/dev/null; then
+        > "$budget_before_tmp" 2>"$budget_before_err"; then
       budget_before="$(cat "$budget_before_tmp" 2>/dev/null || echo "")"
+    else
+      _report_gh_probe_failure "$budget_before_err" "budget_before (leg: ${mode})"
     fi
-    rm -f "$budget_before_tmp"
+    rm -f "$budget_before_tmp" "$budget_before_err"
   fi
 
   # The consumer (tee | jq) is fed via a named pipe and backgrounded as its
@@ -1276,22 +1342,32 @@ switch_and_run() {
   # there's nothing group-shaped to kill here, just this function's own trap
   # to invoke. The TERM and INT traps installed for this window (both routed
   # through the shared _post_suite_watchdog_signal, defined above) check
-  # `fired` at fire time: if present, this was our own watchdog, and it
-  # prints a diagnostic naming the elapsed time and the last checkpoint
-  # reached, then exits $POST_SUITE_WATCHDOG_EXIT. If absent, this was some
-  # other TERM/INT (e.g. an external kill, or Ctrl-C) landing in this same
-  # window, and it falls through to the same suite/consumer-group-kill
-  # behavior this function already had here before this watchdog existed —
-  # also now disarming $watchdog_pid itself in that fallback branch (found
-  # during Review, #1676: neither the original TERM-only trap's fallback
-  # branch nor, for INT specifically, any trap in this window at all used to
-  # do this, leaking the watchdog's background timer job) — an external
-  # signal during this window behaves exactly as it did before, it just also
-  # gets diagnosed correctly against a genuine watchdog firing, and no longer
-  # leaks the watchdog job doing so. These traps stay installed for the whole
-  # remaining tail (unlike the old suite/consumer traps they replace, which
-  # were cleared right after the consumer wait) — by design, since the
-  # watched window is the whole tail, not just the consumer drain.
+  # `fired` at fire time: if present, this was our own watchdog — it prints
+  # a diagnostic naming the elapsed time and the last checkpoint reached,
+  # THEN (found during Review, #1676, second round of external feedback)
+  # group-kills $suite_pid/$consumer_pid exactly like the non-watchdog branch
+  # below, before exiting $POST_SUITE_WATCHDOG_EXIT: an earlier revision
+  # skipped that teardown specifically in the fired branch, which is
+  # backwards — the checkpoint text ("waiting for tee/jq consumer to drain")
+  # and every other step in this tail being either with_timeout-bounded or a
+  # fast local jq/grep call means $consumer_pid is exactly the process most
+  # likely to still be alive and wedged at the moment this branch actually
+  # runs, so skipping its group-kill left the one realistic "stuck" case
+  # orphaning the very pipeline the watchdog was built to catch. If `fired`
+  # is absent, this was some other TERM/INT (e.g. an external kill, or
+  # Ctrl-C) landing in this same window, and it runs the identical
+  # suite/consumer-group-kill teardown this function already had here before
+  # this watchdog existed — both branches now also disarm $watchdog_pid
+  # itself (found during Review, #1676, first round: neither the original
+  # TERM-only trap's fallback branch nor, for INT specifically, any trap in
+  # this window at all used to do this, leaking the watchdog's background
+  # timer job). An external signal during this window behaves exactly as it
+  # did before, it just also gets diagnosed correctly against a genuine
+  # watchdog firing, and neither branch leaks a background job doing so.
+  # These traps stay installed for the whole remaining tail (unlike the old
+  # suite/consumer traps they replace, which were cleared right after the
+  # consumer wait) — by design, since the watched window is the whole tail,
+  # not just the consumer drain.
   local watchdog_dir
   watchdog_dir="$(mktemp -d)"
   echo "waiting for tee/jq consumer to drain" > "$watchdog_dir/checkpoint"
@@ -1334,14 +1410,19 @@ switch_and_run() {
   budget_after=""
   if [ -n "$BED_TOKEN" ]; then
     # Captured via a temp file, NOT `$(with_timeout ...)` — same rationale
-    # as budget_before above; see with_timeout's own comment.
-    local budget_after_tmp
+    # as budget_before above; see with_timeout's own comment. stderr is also
+    # captured (not discarded) and relayed on failure — same rationale as
+    # budget_before above; see _report_gh_probe_failure's own comment.
+    local budget_after_tmp budget_after_err
     budget_after_tmp="$(mktemp)"
+    budget_after_err="$(mktemp)"
     if with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' \
-        > "$budget_after_tmp" 2>/dev/null; then
+        > "$budget_after_tmp" 2>"$budget_after_err"; then
       budget_after="$(cat "$budget_after_tmp" 2>/dev/null || echo "")"
+    else
+      _report_gh_probe_failure "$budget_after_err" "budget_after (leg: ${mode})"
     fi
-    rm -f "$budget_after_tmp"
+    rm -f "$budget_after_tmp" "$budget_after_err"
   fi
   if [ -n "$budget_before" ] && [ -n "$budget_after" ]; then
     if [ "$budget_after" -le "$budget_before" ]; then

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -265,6 +265,15 @@ readonly PREFLIGHT_FAILED_EXIT=4
 # run" apart from "live e2e itself failed" or "GraphQL budget exhausted."
 readonly PREGATE_FAILED_EXIT=5
 
+# Distinct exit code for R2's post-suite watchdog (#1676) firing — go test
+# exited but switch_and_run's own post-suite bookkeeping (budget probe,
+# timing/outcome reports, backoff scan) stalled past E2E_POST_SUITE_WATCHDOG.
+# Distinct from every code above so a caller (e.g. cut-release.sh) can tell
+# "the runner itself hung after the suite finished" apart from a real
+# regression, a budget exhaustion, or a preflight/pre-gate failure. See
+# switch_and_run's own comment and "Hang hardening" in the header above.
+readonly POST_SUITE_WATCHDOG_EXIT=6
+
 # ---------------------------------------------------------------------------
 # run_reaped (R3, #1624): run "$@" as a backgrounded job in its own process
 # group and reap that whole group if this script is killed while it's in
@@ -313,6 +322,113 @@ run_reaped() {
   local rc=0
   wait "$pid" || rc=$?
   trap - INT TERM
+  return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# disarm_deadline_signal <watcher_pid> (#1676): group-kill and reap a
+# still-pending deadline-watcher job (the backgrounded `sleep <n>` + a
+# conditional `kill`, as armed inline by with_timeout and switch_and_run's
+# post-suite watchdog below), so it can't fire a stale, late signal against
+# a since-recycled PID once the thing it was guarding has already finished
+# or been otherwise handled — the same class of leak run_reaped's own
+# comment (above) documents for its single backgrounded job, applied here to
+# this second kind of backgrounded job.
+#
+# NOTE: the watcher itself is armed inline at each call site (`( sleep ...;
+# if ...; then ...; fi ) &`), NOT via a shared "arm" function that returns
+# the watcher's PID through `$(...)`: command substitution always runs in a
+# subshell, and — confirmed empirically during Implement — a subshell
+# created for command substitution does not let a job it backgrounds run
+# concurrently with the substitution's own completion; the whole `(...) &`
+# body (sleep included) executes to completion INSIDE the substitution
+# before it returns, which would make with_timeout block for the full
+# timeout on every call, defeating it entirely. Backgrounding directly in
+# the caller's own function body (as both call sites below do) doesn't have
+# this problem — only the teardown half (an already-known PID, no
+# substitution needed to obtain it) is safely shareable, hence this
+# function exists but its counterpart does not.
+disarm_deadline_signal() {
+  local watcher_pid="$1"
+  kill -TERM -"$watcher_pid" 2>/dev/null || true
+  wait "$watcher_pid" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# with_timeout <seconds> <cmd...> (R1, #1676): run "$@", killing it (and its
+# whole process group) if it hasn't finished within <seconds>. Returns 124
+# (matching GNU timeout(1)'s own convention) if the deadline was hit,
+# otherwise the command's own exit code.
+#
+# THIS IS THE REQUIRED ROUTING POINT for any future network call added to
+# the release/e2e script path (this file, or any script it sources). The
+# v0.0.81 cut hung for 17h19m — with `go test` long gone — because the two
+# `gh api rate_limit` budget-probe calls below had no timeout at all; `||
+# echo ""` only guards a *failing* call, not a *hanging* one. A bare `gh
+# api`/`curl`/`wget` call added later without this wrapper can reproduce that
+# exact incident. See the header comment's "Hang hardening" section.
+#
+# Implemented as portable bash job control (background the command under
+# `set -m`, which gives it its own process group; a second backgrounded
+# `sleep <seconds>` watcher enforces the deadline) rather than via
+# perl/python3 or GNU coreutils' timeout(1) — the latter isn't shipped on
+# macOS (confirmed: `command not found` on the release-cut machine) and the
+# former would introduce this script's first interpreter dependency where
+# run_reaped/stop_bed_instance already establish this same "background job +
+# deadline" idiom without one.
+#
+# A marker file (inside a `mktemp -d` scratch dir, not `mktemp -u` — same
+# race-avoidance rationale as switch_and_run's $fifo_dir) is how the deadline
+# watcher tells the main path "I actually fired" rather than inferring it
+# from the guarded command's own exit status: a command that happens to exit
+# with a raw 128+signum status of its own (unusual, but not impossible) must
+# not be misreported as a timeout it didn't actually hit.
+#
+# Group-kills on timeout (`kill -TERM -"$pid"`): the guarded command may fork
+# its own children (e.g. `gh`'s underlying transport), and a plain `kill`
+# would leave such a child running headless — the exact orphan class
+# run_reaped's own R3 (#1624) discipline exists to avoid, applied here to a
+# second kind of backgrounded job. The watcher itself is torn down via
+# disarm_deadline_signal (above) once no longer needed.
+# ---------------------------------------------------------------------------
+with_timeout() {
+  local timeout_secs="$1"
+  shift
+  local marker_dir
+  marker_dir="$(mktemp -d)"
+  "$@" &
+  local pid=$!
+  # The watcher's own stdout is explicitly redirected away (>/dev/null),
+  # NOT left to inherit with_timeout's — with_timeout's real call sites
+  # capture its output via command substitution (e.g. `budget_before=$(
+  # with_timeout ... gh api ...)`), and command substitution only resolves
+  # once EVERY process holding its pipe's write end open has closed it.
+  # Without this redirect, the watcher (which inherits that same fd) would
+  # keep the pipe open for its own full `sleep timeout_secs` regardless of
+  # how fast the guarded command itself finishes — silently forcing every
+  # with_timeout call to take the FULL timeout even on the fast path.
+  # Confirmed empirically during Implement: omitting this made
+  # `with_timeout 30 echo hello` (captured via `$(...)`) take a full 30s
+  # instead of returning instantly. The watcher never produces real output
+  # of its own anyway (its `kill` is already `2>/dev/null`), so nothing is
+  # lost by closing this fd.
+  (
+    sleep "$timeout_secs"
+    if kill -0 "$pid" 2>/dev/null; then
+      : > "$marker_dir/fired"
+      kill -TERM -"$pid" 2>/dev/null
+    fi
+  ) >/dev/null 2>&1 &
+  local watcher_pid=$!
+  local rc=0
+  wait "$pid" 2>/dev/null || rc=$?
+  disarm_deadline_signal "$watcher_pid"
+  if [ -f "$marker_dir/fired" ]; then
+    echo "with_timeout: command exceeded ${timeout_secs}s, killed: $*" >&2
+    rm -rf "$marker_dir"
+    return 124
+  fi
+  rm -rf "$marker_dir"
   return "$rc"
 }
 
@@ -622,6 +738,29 @@ PARALLEL="${E2E_PARALLEL:-4}"
 # header comment's "on"-leg-specific parallelism cap section (#1527).
 PARALLEL_ON="${E2E_PARALLEL_ON:-2}"
 
+# Timeout for the ancillary `gh api rate_limit` budget-report calls (R1,
+# #1676) — see with_timeout's own comment above. These are lightweight REST
+# metadata calls (see "GraphQL budget exhaustion detection" above), so 30s is
+# generous, not tight; override with E2E_GH_API_TIMEOUT.
+GH_API_TIMEOUT="${E2E_GH_API_TIMEOUT:-30}"
+
+# Window for R2's post-suite watchdog (#1676) — see switch_and_run's own
+# comment for the full mechanism. Everything the watchdog covers (draining
+# the tee/jq consumer, the now-with_timeout-bounded budget probe, the
+# timing/outcome reports, the backoff scan) is normally seconds, not
+# minutes, so 5 minutes is a generous backstop; override with
+# E2E_POST_SUITE_WATCHDOG.
+POST_SUITE_WATCHDOG="${E2E_POST_SUITE_WATCHDOG:-300}"
+
+# Window for R3's stall detector (#1676), converted from minutes to seconds
+# — E2E_STALL_WARN_MINUTES is documented in minutes, matching the issue's own
+# phrasing. The one measured real-world inter-event gap on record (5.5
+# minutes, TestReviewAuthorityClearsOnApproval, multi-scenario "on" leg — see
+# "How the timeout/parallelism defaults are derived" in tests/e2e/README.md)
+# sits comfortably under this 15-minute default; override with
+# E2E_STALL_WARN_MINUTES.
+STALL_WARN_SECS=$(( ${E2E_STALL_WARN_MINUTES:-15} * 60 ))
+
 # report_test_outcomes prints a completed/still-running/never-started
 # breakdown of every top-level test from a `go test -json` log, so a killed
 # run's partial state is legible instead of a bare FAIL indistinguishable
@@ -695,6 +834,29 @@ report_test_timings() {
         | [(.elapsed | tostring) + "s", .result, .test] | @tsv
       ' \
     | { column -t -s "$(printf '\t')" 2>/dev/null || cat; }
+}
+
+# last_completed_test_name prints the most recently observed pass/fail/skip
+# top-level test name from $1 (a `go test -json` log), or "(none yet)" if
+# none have completed (or the log doesn't exist/parse). Reuses the same
+# terminal-action jq filter as report_test_timings (pass/fail/skip only —
+# run/cont/pause carry no useful "completed" signal), but keeps stream order
+# rather than sorting by elapsed, so `.[-1]` is the chronologically last
+# completion. Extracted into its own function — mirroring
+# detect_rate_limit_backoff's precedent — specifically so
+# scripts/e2e/hang_hardening_test.sh can exercise it directly against
+# fixtures, independent of an actual gate run.
+#
+# Used by R3's stall detector (#1676) to name what the suite was last making
+# progress on when its own output went quiet — see switch_and_run below.
+last_completed_test_name() {
+  local jsonlog="$1"
+  jq -R 'fromjson? // empty' "$jsonlog" 2>/dev/null \
+    | jq -s -r '
+        [ .[] | select(.Test != null and (.Test | contains("/") | not)
+            and (.Action == "pass" or .Action == "fail" or .Action == "skip")) ]
+        | if length == 0 then "(none yet)" else .[-1].Test end
+      ' 2>/dev/null || echo "(unknown — log parse error)"
 }
 
 # detect_rate_limit_backoff scans $1 (a fabrik.log path) for the engine's
@@ -803,6 +965,32 @@ detect_rate_limit_backoff() {
 # short-circuit any remaining leg immediately rather than let the two-mode
 # gate continue on to a second leg against a bed whose GraphQL budget is
 # already compromised for the current hour.
+#
+# Hang hardening (R1-R3, #1676): the two `gh api rate_limit` budget-probe
+# calls below are wrapped in with_timeout; a background stall detector warns
+# (never aborts) if the suite's own output goes quiet for too long while go
+# test is still alive; and a background post-suite watchdog aborts loudly,
+# naming the stuck step, if go test has exited but this function's own
+# bookkeeping tail stalls past its own window. See each mechanism's own
+# comment further down for the full detail, and the header comment's "Hang
+# hardening" section for the incident this all exists to prevent.
+
+# stop_post_suite_watchdog tears down R2's background watcher (see
+# switch_and_run below, arm_deadline_signal above) and clears the INT/TERM
+# trap it (temporarily) owns for the post-suite tail. Called at every one of
+# switch_and_run's own exit points (both normal returns and the
+# BUDGET_EXHAUSTED_EXIT path) so a not-yet-fired watcher from one leg can
+# never survive into, and misfire against, a later leg's unrelated activity
+# — switch_and_run runs once per leg, up to 3x per invocation (off, on-main,
+# on-isolated).
+stop_post_suite_watchdog() {
+  local wpid="$1"
+  local wdir="$2"
+  trap - INT TERM
+  disarm_deadline_signal "$wpid"
+  rm -rf "$wdir" 2>/dev/null || true
+}
+
 switch_and_run() {
   local mode="$1"
   local parallel="$2"
@@ -833,13 +1021,16 @@ switch_and_run() {
   # purely for the A3 cost report, which should reflect the suite's own
   # consumption, not the restart step's (unlike the backoff scan below, which
   # deliberately covers the restart too — see its own comment for why the two
-  # have different windows). Guarded with `|| echo ...` so a transient `gh`
-  # failure degrades to a skipped report rather than aborting the script
-  # under `set -e`.
+  # have different windows). Wrapped in with_timeout (R1, #1676) so a hung
+  # `gh api` call can never block the script — see with_timeout's own
+  # comment above. Guarded with `|| echo ...` so a transient `gh` failure OR
+  # a with_timeout-enforced kill both degrade to a skipped report rather
+  # than aborting the script under `set -e` (R4, #1676: this probe is a
+  # report, never a gate).
   local budget_before budget_after
   budget_before=""
   if [ -n "$BED_TOKEN" ]; then
-    budget_before=$(GH_TOKEN="$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+    budget_before=$(with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
   fi
 
   # The consumer (tee | jq) is fed via a named pipe and backgrounded as its
@@ -863,7 +1054,8 @@ switch_and_run() {
   # this a signal landing between `mkfifo` and the unconditional `rm -f
   # "$fifo"` below (normal-path cleanup, after the writer end opens) would
   # leave a stray named pipe behind in $TMPDIR — a minor leak, not a process
-  # orphan, but avoidable the same way.
+  # orphan, but avoidable the same way. $stall_pid (R3, #1676 — see below) is
+  # declared and added to the same trap for the identical reason.
   #
   # $fifo lives inside its own `mktemp -d` directory rather than being named
   # directly by `mktemp -u` (found during Review): `-u` only reserves a
@@ -878,10 +1070,11 @@ switch_and_run() {
   fifo="$fifo_dir/fifo"
   mkfifo "$fifo"
   local suite_pid=""
+  local stall_pid=""
   { tee "$jsonlog" | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; }; } < "$fifo" &
   local consumer_pid=$!
-  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; rm -rf "$fifo_dir" 2>/dev/null || true; exit 130' INT
-  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; rm -rf "$fifo_dir" 2>/dev/null || true; exit 143' TERM
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; kill -TERM -"$stall_pid" 2>/dev/null || true; rm -rf "$fifo_dir" 2>/dev/null || true; exit 130' INT
+  trap 'kill -TERM -"$suite_pid" 2>/dev/null || true; kill -TERM -"$consumer_pid" 2>/dev/null || true; kill -TERM -"$stall_pid" 2>/dev/null || true; rm -rf "$fifo_dir" 2>/dev/null || true; exit 143' TERM
   exec 3> "$fifo"
   rm -rf "$fifo_dir"
 
@@ -889,18 +1082,147 @@ switch_and_run() {
       ./tests/e2e/... "$@" >&3 2>&1 &
   suite_pid=$!
   exec 3>&-
-  wait "$suite_pid" || rc=$?
-  # Wait for the consumer to drain and finish writing $jsonlog before any of
-  # it is read below — see the comment above. Still under the INT/TERM trap
-  # (not cleared until after this), so a kill of this script while the
-  # consumer is draining reaps its whole group too, rather than leaving this
-  # wait unbounded with no signal path.
-  wait "$consumer_pid" 2>/dev/null || true
-  trap - INT TERM
 
+  # R3 (#1676): stall detector. Independently of whether go test itself has
+  # exited (that's R2, below), warn if the suite's own combined output has
+  # gone quiet for E2E_STALL_WARN_MINUTES while go test is still running —
+  # a real scenario can legitimately wait on Claude for extended periods
+  # (see the header comment's TIMEOUT derivation), so silence alone must
+  # never be mistaken for either progress or a hang. This only ever warns —
+  # it never touches $rc or aborts anything (R4-adjacent: non-gating,
+  # mirroring the budget probe's own requirement even though R4's text is
+  # written specifically about that probe).
+  #
+  # Polls $jsonlog's mtime (not the terminal/tee output a human might be
+  # watching) every 60s while `kill -0 "$suite_pid"` still succeeds — mtime
+  # is the only reliable "is this still producing output" signal for a
+  # stopped/redirected run (`bash scripts/e2e/run.sh &`, matching the
+  # v0.0.81 incident's own `ps` evidence), where no one is watching a
+  # terminal. On a full E2E_STALL_WARN_MINUTES of no mtime change, logs a
+  # warning naming the last completed scenario (via last_completed_test_name)
+  # and the silence duration, then resets its own counter — so a run that
+  # stays quiet for a long time (e.g. the isolated
+  # TestMergeTrainRunawayGuardPausesBatch leg — see tests/e2e/README.md)
+  # warns once per window rather than once ever or on every single poll.
+  (
+    prev_mtime=0
+    stall_secs=0
+    check_interval=60
+    while kill -0 "$suite_pid" 2>/dev/null; do
+      sleep "$check_interval"
+      kill -0 "$suite_pid" 2>/dev/null || break
+      cur_mtime=$(stat -f %m "$jsonlog" 2>/dev/null || stat -c %Y "$jsonlog" 2>/dev/null || echo 0)
+      if [ "$cur_mtime" = "$prev_mtime" ]; then
+        stall_secs=$((stall_secs + check_interval))
+      else
+        stall_secs=0
+      fi
+      prev_mtime="$cur_mtime"
+      if [ "$stall_secs" -ge "$STALL_WARN_SECS" ]; then
+        echo "== STALL WARNING (leg: ${mode}): no new suite output for ${stall_secs}s (E2E_STALL_WARN_MINUTES=$((STALL_WARN_SECS / 60))) — go test is still running. Last completed scenario: $(last_completed_test_name "$jsonlog") ==" >&2
+        stall_secs=0
+      fi
+    done
+  ) &
+  stall_pid=$!
+
+  wait "$suite_pid" || rc=$?
+  # go test has exited — stop the stall detector immediately (its own scope
+  # is "while go test is still running", nothing further for it to watch)
+  # rather than waiting up to 60s for its own loop condition to notice.
+  kill -TERM -"$stall_pid" 2>/dev/null || true
+  wait "$stall_pid" 2>/dev/null || true
+
+  # R2 (#1676): post-suite watchdog. go test itself has now exited — from
+  # here through this function's return/exit is bookkeeping (draining the
+  # consumer, the now-with_timeout-bounded budget probe, timing/outcome
+  # reports, the backoff scan) that should normally take seconds. The
+  # v0.0.81 cut hung for ~17 hours inside exactly this tail (the unwrapped
+  # `gh api rate_limit` calls, fixed by R1 above) with go test long gone and
+  # no watchdog to say so. In the common case this should never fire — R1
+  # already removes the only two calls known to cause it — it exists as a
+  # backstop against a future regression (a call added to this tail without
+  # routing through with_timeout), not the expected path.
+  #
+  # Mechanism: a scratch dir holds a `checkpoint` file (updated as this tail
+  # progresses below) and a `fired` marker a directly-backgrounded watcher
+  # touches only if it actually times out (armed inline here, NOT via a
+  # shared "arm" function returning a PID through `$(...)` — command
+  # substitution's subshell semantics make a background job started inside
+  # it block the substitution until that job finishes, defeating the whole
+  # point; see disarm_deadline_signal's own comment above for the full
+  # account of this, found empirically during Implement). The watcher
+  # signals the whole running script's PID ($$), not a process group —
+  # there's nothing group-shaped to kill here, just this function's own trap
+  # to invoke. The TERM trap installed for this window checks `fired` at
+  # fire time: if present, this was our own watchdog, and it prints a
+  # diagnostic naming the elapsed time and the last checkpoint reached, then
+  # exits $POST_SUITE_WATCHDOG_EXIT. If absent, this was some other TERM
+  # (e.g. an external kill) landing in this same window, and it falls
+  # through to the same suite/consumer-group-kill-then-exit-143 behavior
+  # this function already had here before this watchdog existed — an
+  # external signal during this window behaves exactly as it did before, it
+  # just also gets diagnosed correctly against a genuine watchdog firing.
+  # This trap stays installed for the whole remaining tail (unlike the old
+  # suite/consumer trap it replaces, which was cleared right after the
+  # consumer wait) — by design, since the watched window is the whole tail,
+  # not just the consumer drain.
+  local watchdog_dir
+  watchdog_dir="$(mktemp -d)"
+  echo "waiting for tee/jq consumer to drain" > "$watchdog_dir/checkpoint"
+  local suite_exit_epoch
+  # Only referenced from inside the single-quoted TERM trap below,
+  # re-expanded at signal-delivery time — invisible to shellcheck's static
+  # analysis, same as $mode/$watchdog_dir in that trap.
+  # shellcheck disable=SC2034
+  suite_exit_epoch=$(date +%s)
+  local watchdog_main_pid=$$
+  # Stdout/stderr explicitly redirected away, mirroring with_timeout's own
+  # watcher (see its comment) — this function isn't currently called via
+  # command substitution, but there's nothing useful in this watcher's own
+  # output anyway (its `kill` is already `2>/dev/null`), so closing these
+  # fds costs nothing and avoids the same class of pipe-holds-open hazard
+  # if that ever changes.
+  (
+    sleep "$POST_SUITE_WATCHDOG"
+    if kill -0 "$watchdog_main_pid" 2>/dev/null; then
+      : > "$watchdog_dir/fired"
+      kill -TERM "$watchdog_main_pid" 2>/dev/null
+    fi
+  ) >/dev/null 2>&1 &
+  local watchdog_pid=$!
+  trap '
+    if [ -f "$watchdog_dir/fired" ]; then
+      {
+        echo ""
+        echo "############################################################"
+        echo "## POST-SUITE WATCHDOG (leg: ${mode}): go test exited $(( $(date +%s) - suite_exit_epoch ))s ago,"
+        echo "## but the script has not progressed past its post-suite steps"
+        echo "## within ${POST_SUITE_WATCHDOG}s (E2E_POST_SUITE_WATCHDOG)."
+        echo "## Stuck in: $(cat "$watchdog_dir/checkpoint" 2>/dev/null || echo "(unknown step)")"
+        echo "## Last engine log line: $(tail -n1 "$ENGINE_LOG" 2>/dev/null || echo "(unavailable)")"
+        echo "############################################################"
+      } >&2
+      rm -rf "$watchdog_dir" 2>/dev/null || true
+      exit "$POST_SUITE_WATCHDOG_EXIT"
+    fi
+    kill -TERM -"$suite_pid" 2>/dev/null || true
+    kill -TERM -"$consumer_pid" 2>/dev/null || true
+    rm -rf "$fifo_dir" 2>/dev/null || true
+    rm -rf "$watchdog_dir" 2>/dev/null || true
+    exit 143
+  ' TERM
+
+  # Wait for the consumer to drain and finish writing $jsonlog before any of
+  # it is read below — see the comment above. Still under a TERM trap (the
+  # post-suite watchdog's, installed just above), so a stuck drain is still
+  # covered by R2 rather than left unbounded with no signal path.
+  wait "$consumer_pid" 2>/dev/null || true
+
+  echo "gh api rate_limit budget_after probe" > "$watchdog_dir/checkpoint"
   budget_after=""
   if [ -n "$BED_TOKEN" ]; then
-    budget_after=$(GH_TOKEN="$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+    budget_after=$(with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
   fi
   if [ -n "$budget_before" ] && [ -n "$budget_after" ]; then
     if [ "$budget_after" -le "$budget_before" ]; then
@@ -912,10 +1234,12 @@ switch_and_run() {
     echo "warning: could not read GraphQL rate_limit before/after leg ${mode} (gh api call failed) — skipping budget report" >&2
   fi
 
+  echo "report_test_timings" > "$watchdog_dir/checkpoint"
   report_test_timings "$jsonlog" "$mode" \
     || echo "warning: failed to compute test timings (jq error) — inspect the raw JSON log directly: $jsonlog" >&2
 
   if [ "$rc" -ne 0 ]; then
+    echo "failure classification / teardown (leg ${mode} failed, rc=${rc})" > "$watchdog_dir/checkpoint"
     echo "== suite FAILED (leg: ${mode}, exit ${rc}) — classifying test outcomes ==" >&2
     echo "JSON log: $jsonlog" >&2
     report_test_outcomes "$jsonlog" >&2 \
@@ -941,15 +1265,18 @@ switch_and_run() {
     fi
   fi
 
-  # R2 (#1527): check whether the engine's own rate-limit backoff engaged at
-  # any point during this leg, regardless of $rc — a throttled run can just
-  # as easily present as a pass (if timeouts happened to land after the
-  # relevant waits already succeeded) as a fail, so this must not be
-  # conditioned on the leg having failed. See detect_rate_limit_backoff's own
-  # comment (above its definition) for why this scans the whole current
-  # fabrik.log rather than a captured byte offset — extracted into its own
-  # function so scripts/e2e/backoff_detection_test.sh can exercise it
-  # directly against fixtures without running an actual gate leg.
+  # R2 (#1527, NOT this issue's #1676 post-suite-watchdog R2 above — the two
+  # numbering schemes collide by coincidence): check whether the engine's own
+  # rate-limit backoff engaged at any point during this leg, regardless of
+  # $rc — a throttled run can just as easily present as a pass (if timeouts
+  # happened to land after the relevant waits already succeeded) as a fail,
+  # so this must not be conditioned on the leg having failed. See
+  # detect_rate_limit_backoff's own comment (above its definition) for why
+  # this scans the whole current fabrik.log rather than a captured byte
+  # offset — extracted into its own function so
+  # scripts/e2e/backoff_detection_test.sh can exercise it directly against
+  # fixtures without running an actual gate leg.
+  echo "detect_rate_limit_backoff scan" > "$watchdog_dir/checkpoint"
   if detect_rate_limit_backoff "$ENGINE_LOG"; then
     {
       echo ""
@@ -965,8 +1292,11 @@ switch_and_run() {
       echo "## (E2E_PARALLEL_ON, splitting the leg across budget windows)."
       echo "############################################################"
     } >&2
+    stop_post_suite_watchdog "$watchdog_pid" "$watchdog_dir"
     exit "$BUDGET_EXHAUSTED_EXIT"
   fi
+
+  stop_post_suite_watchdog "$watchdog_pid" "$watchdog_dir"
 
   if [ "$rc" -ne 0 ]; then
     return "$rc"

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -1053,6 +1053,56 @@ stop_post_suite_watchdog() {
   rm -rf "$wdir" 2>/dev/null || true
 }
 
+# _post_suite_watchdog_signal <exit_code_if_external> (#1676): shared TERM/INT
+# handler for R2's post-suite watchdog window, installed by switch_and_run
+# below for the duration of its own post-suite tail. Relies on bash's dynamic
+# scoping of `local` variables — $mode/$suite_pid/$consumer_pid/$fifo_dir/
+# $watchdog_dir/$watchdog_pid/$suite_exit_epoch are all still in scope from
+# the still-executing switch_and_run call this trap fires inside of, exactly
+# as the inline trap body it replaces already relied on for the same
+# variables.
+#
+# Distinguishes "this is our own watchdog firing" (the $watchdog_dir/fired
+# marker is present) from "some other signal landed in this window" (marker
+# absent — a real Ctrl-C, or an external `kill` of the whole script) and
+# reacts accordingly. Both branches disarm $watchdog_pid (found during
+# Review, #1676): an earlier revision's TERM-only trap left the still-
+# sleeping watchdog timer running whenever its "external signal" branch
+# fired (its own kill target is this script's now-exiting PID, so the leaked
+# job would eventually no-op after its own sleep rather than misfire, but it
+# was still an unreaped background job for up to $POST_SUITE_WATCHDOG
+# seconds) — and was never wired to INT at all, so a Ctrl-C landing in this
+# exact window fell through to switch_and_run's EARLIER INT trap (installed
+# before the consumer wait, for the suite/consumer-drain phase), which has no
+# idea $watchdog_pid or $watchdog_dir exist and left both behind. Installed
+# for both signals below so INT and TERM behave identically here, matching
+# this whole mechanism's own "process-group discipline should extend to any
+# new backgrounded watcher job" design constraint (see with_timeout's and
+# disarm_deadline_signal's own comments).
+_post_suite_watchdog_signal() {
+  local external_exit="$1"
+  if [ -f "$watchdog_dir/fired" ]; then
+    {
+      echo ""
+      echo "############################################################"
+      echo "## POST-SUITE WATCHDOG (leg: ${mode}): go test exited $(( $(date +%s) - suite_exit_epoch ))s ago,"
+      echo "## but the script has not progressed past its post-suite steps"
+      echo "## within ${POST_SUITE_WATCHDOG}s (E2E_POST_SUITE_WATCHDOG)."
+      echo "## Stuck in: $(cat "$watchdog_dir/checkpoint" 2>/dev/null || echo "(unknown step)")"
+      echo "## Last engine log line: $(tail -n1 "$ENGINE_LOG" 2>/dev/null || echo "(unavailable)")"
+      echo "############################################################"
+    } >&2
+    rm -rf "$watchdog_dir" 2>/dev/null || true
+    exit "$POST_SUITE_WATCHDOG_EXIT"
+  fi
+  kill -TERM -"$suite_pid" 2>/dev/null || true
+  kill -TERM -"$consumer_pid" 2>/dev/null || true
+  disarm_deadline_signal "$watchdog_pid"
+  rm -rf "$fifo_dir" 2>/dev/null || true
+  rm -rf "$watchdog_dir" 2>/dev/null || true
+  exit "$external_exit"
+}
+
 switch_and_run() {
   local mode="$1"
   local parallel="$2"
@@ -1224,19 +1274,24 @@ switch_and_run() {
   # account of this, found empirically during Implement). The watcher
   # signals the whole running script's PID ($$), not a process group —
   # there's nothing group-shaped to kill here, just this function's own trap
-  # to invoke. The TERM trap installed for this window checks `fired` at
-  # fire time: if present, this was our own watchdog, and it prints a
-  # diagnostic naming the elapsed time and the last checkpoint reached, then
-  # exits $POST_SUITE_WATCHDOG_EXIT. If absent, this was some other TERM
-  # (e.g. an external kill) landing in this same window, and it falls
-  # through to the same suite/consumer-group-kill-then-exit-143 behavior
-  # this function already had here before this watchdog existed — an
-  # external signal during this window behaves exactly as it did before, it
-  # just also gets diagnosed correctly against a genuine watchdog firing.
-  # This trap stays installed for the whole remaining tail (unlike the old
-  # suite/consumer trap it replaces, which was cleared right after the
-  # consumer wait) — by design, since the watched window is the whole tail,
-  # not just the consumer drain.
+  # to invoke. The TERM and INT traps installed for this window (both routed
+  # through the shared _post_suite_watchdog_signal, defined above) check
+  # `fired` at fire time: if present, this was our own watchdog, and it
+  # prints a diagnostic naming the elapsed time and the last checkpoint
+  # reached, then exits $POST_SUITE_WATCHDOG_EXIT. If absent, this was some
+  # other TERM/INT (e.g. an external kill, or Ctrl-C) landing in this same
+  # window, and it falls through to the same suite/consumer-group-kill
+  # behavior this function already had here before this watchdog existed —
+  # also now disarming $watchdog_pid itself in that fallback branch (found
+  # during Review, #1676: neither the original TERM-only trap's fallback
+  # branch nor, for INT specifically, any trap in this window at all used to
+  # do this, leaking the watchdog's background timer job) — an external
+  # signal during this window behaves exactly as it did before, it just also
+  # gets diagnosed correctly against a genuine watchdog firing, and no longer
+  # leaks the watchdog job doing so. These traps stay installed for the whole
+  # remaining tail (unlike the old suite/consumer traps they replace, which
+  # were cleared right after the consumer wait) — by design, since the
+  # watched window is the whole tail, not just the consumer drain.
   local watchdog_dir
   watchdog_dir="$(mktemp -d)"
   echo "waiting for tee/jq consumer to drain" > "$watchdog_dir/checkpoint"
@@ -1261,27 +1316,13 @@ switch_and_run() {
     fi
   ) >/dev/null 2>&1 &
   local watchdog_pid=$!
-  trap '
-    if [ -f "$watchdog_dir/fired" ]; then
-      {
-        echo ""
-        echo "############################################################"
-        echo "## POST-SUITE WATCHDOG (leg: ${mode}): go test exited $(( $(date +%s) - suite_exit_epoch ))s ago,"
-        echo "## but the script has not progressed past its post-suite steps"
-        echo "## within ${POST_SUITE_WATCHDOG}s (E2E_POST_SUITE_WATCHDOG)."
-        echo "## Stuck in: $(cat "$watchdog_dir/checkpoint" 2>/dev/null || echo "(unknown step)")"
-        echo "## Last engine log line: $(tail -n1 "$ENGINE_LOG" 2>/dev/null || echo "(unavailable)")"
-        echo "############################################################"
-      } >&2
-      rm -rf "$watchdog_dir" 2>/dev/null || true
-      exit "$POST_SUITE_WATCHDOG_EXIT"
-    fi
-    kill -TERM -"$suite_pid" 2>/dev/null || true
-    kill -TERM -"$consumer_pid" 2>/dev/null || true
-    rm -rf "$fifo_dir" 2>/dev/null || true
-    rm -rf "$watchdog_dir" 2>/dev/null || true
-    exit 143
-  ' TERM
+  # Installed for BOTH signals (found during Review, #1676 — see
+  # _post_suite_watchdog_signal's own comment above): an INT (Ctrl-C) landing
+  # in this exact window must be handled identically to a TERM, not silently
+  # fall through to the earlier suite/consumer-drain-phase INT trap installed
+  # above, which knows nothing about $watchdog_pid/$watchdog_dir.
+  trap '_post_suite_watchdog_signal 143' TERM
+  trap '_post_suite_watchdog_signal 130' INT
 
   # Wait for the consumer to drain and finish writing $jsonlog before any of
   # it is read below — see the comment above. Still under a TERM trap (the

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -222,6 +222,56 @@
 # concretely, a compiled `*.test` binary) running headless. See run_reaped's
 # own doc comment for the mechanism and why it traps INT/TERM only, never
 # EXIT.
+#
+# Hang hardening (R1-R3, #1676): the v0.0.81 cut hung for 17h19m AFTER `go
+# test` had already exited — the two `gh api rate_limit` budget-probe calls
+# in switch_and_run had no timeout at all (`|| echo ""` only guards a
+# *failing* call, not a *hanging* one). Three independent layers now guard
+# against this:
+#
+#   E2E_GH_API_TIMEOUT=<secs>     (R1, default 30) — every ancillary network
+#                          call (currently: the two `gh api rate_limit`
+#                          budget-probe calls) is wrapped in the with_timeout
+#                          helper (defined below, near run_reaped) and killed
+#                          — whole process group — if it exceeds this. THIS IS
+#                          THE REQUIRED ROUTING POINT for any future network
+#                          call added to this script or one it sources; see
+#                          with_timeout's own comment.
+#
+#   E2E_POST_SUITE_WATCHDOG=<secs> (R2, default 300) — a background watchdog,
+#                          armed the instant `go test` exits, aborts the
+#                          script loudly (exit $POST_SUITE_WATCHDOG_EXIT, see
+#                          below) with a diagnostic naming the stuck step
+#                          (budget probe / timing report / outcome
+#                          classification / backoff scan) if switch_and_run's
+#                          own post-suite bookkeeping tail — normally seconds,
+#                          not minutes — hasn't finished within this window.
+#                          This is the exact failure mode from the v0.0.81
+#                          incident: go test long gone, no watchdog to say so.
+#                          A backstop against a future regression, not the
+#                          expected path — R1 already removes the only two
+#                          calls known to cause it.
+#
+#   E2E_STALL_WARN_MINUTES=<mins> (R3, default 15) — independently of R2,
+#                          warns (never aborts) if the suite's own combined
+#                          output has gone quiet for this long WHILE go test
+#                          is still running, naming the last completed
+#                          scenario. Purely advisory: a real scenario can
+#                          legitimately wait on Claude for extended periods
+#                          (see the TIMEOUT derivation above), so silence
+#                          alone is never treated as a hang — only surfaced,
+#                          so it's never mistaken for progress either. The
+#                          isolated TestMergeTrainRunawayGuardPausesBatch leg
+#                          (run alone, deliberately idle for long stretches)
+#                          is expected to trigger this on every healthy run —
+#                          see tests/e2e/README.md.
+#
+# R4 (non-gating): the budget probe is a report, never a gate — a timeout
+# under R1 degrades exactly like the pre-existing "call failed" case (the
+# `budget_before=""`/`budget_after=""` fallback), never affecting the suite's
+# own exit code. R3's stall warning is likewise purely advisory and never
+# touches $rc. See switch_and_run's own comments for the full mechanism, and
+# tests/e2e/README.md for the defaults' derivation.
 
 set -euo pipefail
 set -m
@@ -337,17 +387,22 @@ run_reaped() {
 #
 # NOTE: the watcher itself is armed inline at each call site (`( sleep ...;
 # if ...; then ...; fi ) &`), NOT via a shared "arm" function that returns
-# the watcher's PID through `$(...)`: command substitution always runs in a
-# subshell, and — confirmed empirically during Implement — a subshell
-# created for command substitution does not let a job it backgrounds run
-# concurrently with the substitution's own completion; the whole `(...) &`
-# body (sleep included) executes to completion INSIDE the substitution
-# before it returns, which would make with_timeout block for the full
-# timeout on every call, defeating it entirely. Backgrounding directly in
-# the caller's own function body (as both call sites below do) doesn't have
-# this problem — only the teardown half (an already-known PID, no
-# substitution needed to obtain it) is safely shareable, hence this
-# function exists but its counterpart does not.
+# the watcher's PID through `$(...)`: command substitution ALWAYS runs its
+# command list in a subshell, and — confirmed empirically during Implement —
+# `set -m` job control's one-process-group-per-background-job behavior does
+# NOT apply inside that subshell, regardless of `set -m` being active in the
+# calling shell. A job backgrounded there keeps the SUBSHELL's own process
+# group instead of getting one of its own, so a later `kill -TERM -"$pid"`
+# (a negative PGID) targets a process group that was never actually created
+# and silently fails (`kill` exits 1, "No such process") — the guarded
+# command is never killed and just runs to completion (or hangs forever)
+# on its own, defeating the timeout entirely without any visible error. This
+# is *why* with_timeout's own call sites below capture output via a temp
+# file instead of `$(with_timeout ...)` — see with_timeout's own comment.
+# Backgrounding directly in the caller's own (non-substituted) function body,
+# as both call sites below do, doesn't have this problem — only the teardown
+# half (an already-known PID, no substitution needed to obtain it) is safely
+# shareable, hence this function exists but its counterpart does not.
 disarm_deadline_signal() {
   local watcher_pid="$1"
   kill -TERM -"$watcher_pid" 2>/dev/null || true
@@ -367,6 +422,23 @@ disarm_deadline_signal() {
 # echo ""` only guards a *failing* call, not a *hanging* one. A bare `gh
 # api`/`curl`/`wget` call added later without this wrapper can reproduce that
 # exact incident. See the header comment's "Hang hardening" section.
+#
+# CALLERS MUST NOT INVOKE THIS VIA `$(with_timeout ...)` (command
+# substitution). Confirmed empirically during Implement: command
+# substitution always runs its command list in a subshell, and `set -m`
+# job control's one-process-group-per-background-job behavior does not
+# apply inside that subshell — the guarded command backgrounded below keeps
+# the SUBSHELL's own process group rather than getting one of its own, so
+# the deadline watcher's group-kill (`kill -TERM -"$pid"`, a negative PGID)
+# silently fails against a process group that was never created (`kill`
+# exits 1), and the guarded command just runs to completion — or hangs
+# forever — on its own, defeating the timeout entirely with no visible
+# error. Capture output via a temp file instead (see the budget-probe call
+# sites below for the pattern) — invoked as a plain foreground statement,
+# not inside `$(...)`, with_timeout runs in the caller's own shell, where
+# `set -m` correctly assigns each backgrounded job its own process group.
+# See disarm_deadline_signal's own comment above for the full account of
+# this finding.
 #
 # Implemented as portable bash job control (background the command under
 # `set -m`, which gives it its own process group; a second backgrounded
@@ -398,20 +470,10 @@ with_timeout() {
   marker_dir="$(mktemp -d)"
   "$@" &
   local pid=$!
-  # The watcher's own stdout is explicitly redirected away (>/dev/null),
-  # NOT left to inherit with_timeout's — with_timeout's real call sites
-  # capture its output via command substitution (e.g. `budget_before=$(
-  # with_timeout ... gh api ...)`), and command substitution only resolves
-  # once EVERY process holding its pipe's write end open has closed it.
-  # Without this redirect, the watcher (which inherits that same fd) would
-  # keep the pipe open for its own full `sleep timeout_secs` regardless of
-  # how fast the guarded command itself finishes — silently forcing every
-  # with_timeout call to take the FULL timeout even on the fast path.
-  # Confirmed empirically during Implement: omitting this made
-  # `with_timeout 30 echo hello` (captured via `$(...)`) take a full 30s
-  # instead of returning instantly. The watcher never produces real output
-  # of its own anyway (its `kill` is already `2>/dev/null`), so nothing is
-  # lost by closing this fd.
+  # The watcher's own stdout/stderr are redirected away — it never produces
+  # useful output of its own (its `kill` is already `2>/dev/null`), so
+  # nothing is lost by closing these fds, and it keeps the watcher from
+  # holding open anything the caller might itself have redirected.
   (
     sleep "$timeout_secs"
     if kill -0 "$pid" 2>/dev/null; then
@@ -1023,14 +1085,22 @@ switch_and_run() {
   # deliberately covers the restart too — see its own comment for why the two
   # have different windows). Wrapped in with_timeout (R1, #1676) so a hung
   # `gh api` call can never block the script — see with_timeout's own
-  # comment above. Guarded with `|| echo ...` so a transient `gh` failure OR
-  # a with_timeout-enforced kill both degrade to a skipped report rather
-  # than aborting the script under `set -e` (R4, #1676: this probe is a
-  # report, never a gate).
+  # comment above. Captured via a temp file, NOT `$(with_timeout ...)` —
+  # with_timeout's own comment explains why command substitution would
+  # silently defeat its group-kill entirely. A failed `with_timeout` (gh
+  # error OR an enforced kill) both degrade to a skipped report rather than
+  # aborting the script under `set -e` (R4, #1676: this probe is a report,
+  # never a gate).
   local budget_before budget_after
   budget_before=""
   if [ -n "$BED_TOKEN" ]; then
-    budget_before=$(with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+    local budget_before_tmp
+    budget_before_tmp="$(mktemp)"
+    if with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' \
+        > "$budget_before_tmp" 2>/dev/null; then
+      budget_before="$(cat "$budget_before_tmp" 2>/dev/null || echo "")"
+    fi
+    rm -f "$budget_before_tmp"
   fi
 
   # The consumer (tee | jq) is fed via a named pipe and backgrounded as its
@@ -1222,7 +1292,15 @@ switch_and_run() {
   echo "gh api rate_limit budget_after probe" > "$watchdog_dir/checkpoint"
   budget_after=""
   if [ -n "$BED_TOKEN" ]; then
-    budget_after=$(with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+    # Captured via a temp file, NOT `$(with_timeout ...)` — same rationale
+    # as budget_before above; see with_timeout's own comment.
+    local budget_after_tmp
+    budget_after_tmp="$(mktemp)"
+    if with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' \
+        > "$budget_after_tmp" 2>/dev/null; then
+      budget_after="$(cat "$budget_after_tmp" 2>/dev/null || echo "")"
+    fi
+    rm -f "$budget_after_tmp"
   fi
   if [ -n "$budget_before" ] && [ -n "$budget_after" ]; then
     if [ "$budget_after" -le "$budget_before" ]; then

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -993,6 +993,63 @@ oversubscription: it's the GraphQL cost of the ADR-1270/ADR-1208 settle-scan
 pattern, not bed contention. See "The two-mode gate's 'on' leg: a separate,
 larger cost driver (#1527)" above.
 
+#### Hang hardening (#1676): `E2E_GH_API_TIMEOUT`, `E2E_POST_SUITE_WATCHDOG`, `E2E_STALL_WARN_MINUTES`
+
+The v0.0.81 cut hung for **17h19m** — with its log untouched for the last
+~19 of them, and the `e2e.test` binary long gone — because the two `gh api
+rate_limit` budget-probe calls in `switch_and_run` (`budget_before`/
+`budget_after`) had no timeout at all: `|| echo ""` only guards a *failing*
+call, not a *hanging* one. `run.sh` now guards against a repeat at three
+independent layers (see the script's own header comment, "Hang hardening",
+for the full mechanism):
+
+- **`E2E_GH_API_TIMEOUT`** (default `30`, seconds) — every ancillary network
+  call (currently: the two `gh api rate_limit` budget probes) is wrapped in
+  a `with_timeout` helper and killed — whole process group — if it exceeds
+  this. These are lightweight REST metadata calls (see "GraphQL budget
+  exhaustion detection" above), so 30s is generous, not tight.
+- **`E2E_POST_SUITE_WATCHDOG`** (default `300`, seconds) — a background
+  watchdog, armed the instant `go test` exits, aborts the script loudly
+  (a distinct exit code, `POST_SUITE_WATCHDOG_EXIT=6`) with a diagnostic
+  naming the stuck step if `switch_and_run`'s own post-suite bookkeeping
+  (the budget probe, timing/outcome reports, the backoff scan — normally
+  seconds, not minutes) hasn't finished within this window. This is the
+  exact failure mode from the v0.0.81 incident: `go test` long gone, no
+  watchdog to say so.
+- **`E2E_STALL_WARN_MINUTES`** (default `15`, minutes) — independently of
+  the watchdog above, warns (never aborts) if the suite's own combined
+  output has gone quiet for this long *while `go test` is still running*,
+  naming the last completed scenario. Purely advisory: a real scenario can
+  legitimately wait on Claude for extended periods (see the `E2E_TIMEOUT`
+  derivation above), so silence alone is never treated as a hang — it's
+  only surfaced, so it's never mistaken for progress either.
+
+**Defaults kept as proposed, not further tuned.** Nothing in the
+post-`go test` tail this watchdog covers (a couple of REST calls plus `jq`
+parsing over the JSON log) plausibly approaches minutes, so `300s` is a
+generous backstop relative to normal completion time. For the stall
+detector, the one measured real-world inter-event gap already on record in
+this file — **5½ minutes**, `TestReviewAuthorityClearsOnApproval`, in a
+multi-scenario "on" leg (see "How the timeout/parallelism defaults are
+derived" above) — sits comfortably under the 15-minute default, so nothing
+found during Research/Plan indicted the issue's own starting-point values.
+
+**Expected warning on the isolated `TestMergeTrainRunawayGuardPausesBatch`
+leg.** This scenario runs alone (see `run.sh`'s own dispatch-guard comment),
+deliberately queuing poison members until a 1-hour-windowed runaway guard
+fires, with no other parallel scenario keeping the combined output stream
+busy in the meantime. The stall detector is expected to warn during this
+leg on every healthy run — that is not a regression, and the warning text
+is worded to read as informational rather than alarming.
+
+Composition with `E2E_GH_API_TIMEOUT`: a single hung `gh api` call is
+bounded well within the post-suite watchdog's own window (30s default vs.
+300s default), so in the common case the watchdog should never actually
+fire — `E2E_GH_API_TIMEOUT` already removes the only two calls known to
+cause the original hang. The watchdog exists as a backstop against a
+*future* regression (a call added to that tail without routing through
+`with_timeout`), not the expected path.
+
 #### Timeout & failure reporting
 
 On a non-zero exit, `run.sh` classifies every top-level test by the last


### PR DESCRIPTION
Closes #1676

## Summary

Harden `scripts/e2e/run.sh` against hangs at three independent layers: (1) every ancillary
network call gets an explicit, enforced timeout so a hung connection can never block the
script; (2) a watchdog on the suite invocation detects when `go test` has exited but the
script has stopped making progress, and aborts loudly naming the stuck step; (3) a stall
detector flags prolonged silence in the run's own output, even while `go test` is still
alive, so silence is never mistaken for progress.

## Problem

`scripts/e2e/run.sh` can hang **indefinitely** after `go test` has already exited, with no
watchdog, no timeout and no output. Observed during the v0.0.81 cut: the script ran for
**17 hours 19 minutes** with its log untouched for the last ~19 of them, while the `e2e.test`
binary was long gone.

A release gate that fails loudly costs an hour. One that hangs silently costs a night — and is
indistinguishable, from outside, from a suite that is simply still working.

### Evidence

```
ps:   78056  17:19:41  bash scripts/e2e/run.sh      <- still "running"
log:  last modified 00:26                            <- ~19h stale
last line: conjunctive_ci_review_gate_test.go:217: R3 verified: ...
e2e.test binary: absent                              <- go test already exited
```

Nothing in the log indicates a failure. The suite had completed 71 passes; the script simply
never proceeded past the test invocation.

### Root cause (confirmed against current `scripts/e2e/run.sh`)

`switch_and_run` calls `gh api rate_limit` twice per leg — once before the suite invocation
(`budget_before`, ~line 842) and once after (`budget_after`, ~line 903) — to report GraphQL
budget consumption. Both calls have **no timeout**:

```sh
budget_after=$(GH_TOKEN="$BED_TOKEN" gh api rate_limit --jq '...' 2>/dev/null || echo "")
```

`|| echo ""` guards against a *failing* call, not a *hanging* one — which is exactly the
distinction that matters here. These are the only two unguarded network calls in the script
(confirmed: no other `gh api`/`curl`/`wget` calls exist outside the `go test -tags=e2e`
invocations themselves, which are the suite under test, not a probe, and are addressed
separately below by R2/R3).

## Approach

### Approach

Harden `scripts/e2e/run.sh` at the three independent layers the issue specifies, reusing the file's own established idioms rather than introducing new dependencies:

1. **R1 (timeouts):** a new `with_timeout <seconds> <cmd...>` helper, built the same way as `run_reaped` (background the command under `set -m`, which already gives it its own process group; kill on deadline) rather than via `perl`/`python3`. This needs no new interpreter dependency and matches the file's existing "portable bash job control instead of `setsid`" precedent (comment at `run_reaped`, line ~287–289) more closely than the issue's `perl`/`python3` lead suggests — confirmed available in this sandbox, but not needed. Both `gh api rate_limit` calls (`budget_before` ~line 842, `budget_after` ~line 903) route through it.

2. **R2 (post-suite watchdog):** an **elapsed-time-since-`go test`-exit check enforced from a background timer**, not a foreground checkpoint loop (a foreground check can only fire *between* steps, never during a genuinely stuck one). The tail writes its current step name to a small checkpoint file as it progresses; a background timer started the instant `go test` exits sleeps until `E2E_POST_SUITE_WATCHDOG` (default 300s), then — if still alive — prints a diagnostic (elapsed time, last checkpoint reached, last log line) and sends `SIGTERM` to the script's own PID (`$$`), which is unhandled by that point (existing `trap - INT TERM` at line 899 has already cleared the suite/consumer traps), so the script terminates loudly with a non-zero exit. This is deliberately a *backstop*, not a full recovery mechanism — see Risks below for the one honestly-documented gap this leaves.

3. **R3 (stall detector):** a background loop, started alongside the existing `tee`/`jq` consumer job and covered by the same lifecycle management, polling `$jsonlog`'s mtime every ~60s while `kill -0 "$suite_pid"` still succeeds. On `E2E_STALL_WARN_MINUTES` (default 15) of silence, it logs a warning naming the last completed test (via a newly extracted `last_completed_test_name` helper, reusing `report_test_timings`'s own `jq` filter for terminal pass/fail/skip events) and the silence duration. Purely advisory — never touches `$rc`, never `exit`s.

R4 (non-gating) falls out of R1's design for free: `with_timeout`'s call sites keep the existing `budget_before=""`/`budget_after=""` fallback-on-failure pattern, so a timeout is indistinguishable from the pre-existing "call failed" case the `[ -n "$budget_before" ] && [ -n "$budget_after" ]` gate already handles.

### New/Modified Files

| File | Change |
|------|--------|
| `scripts/e2e/run.sh` | Add `with_timeout` helper; add `GH_API_TIMEOUT`/`POST_SUITE_WATCHDOG`/`STALL_WARN_SECS` config vars; add `POST_SUITE_WATCHDOG_EXIT` exit code; wrap both `gh api rate_limit` calls; add R2 watchdog (checkpoint file + background timer) around `switch_and_run`'s post-`wait "$suite_pid"` tail; add R3 stall-detector background loop wired into the existing consumer/`suite_pid` lifecycle; extract `last_completed_test_name`; extend header comment with the three new env vars and the new exit code |
| `scripts/e2e/hang_hardening_test.sh` (new) | `source`s `run.sh` (mirrors `backoff_detection_test.sh`/`pregate_test.sh`); tests `with_timeout` against a PATH-shadowed hanging fake command (AC1, including a bounded non-vacuous demonstration); tests `last_completed_test_name` against `go test -json` fixtures (supports AC3); tests the watchdog's elapsed-check logic directly (supports AC2) |
| `tests/e2e/README.md` | New env var reference entries; a "How the E2E_GH_API_TIMEOUT/E2E_POST_SUITE_WATCHDOG/E2E_STALL_WARN_MINUTES defaults are derived" subsection (matching the existing `E2E_TIMEOUT`/`E2E_PARALLEL` derivation style at line 942) citing the 17h19m incident and the 5½-minute real gap already documented at line 975; a note that the isolated `TestMergeTrainRunawayGuardPausesBatch` leg is expected to trigger R3's warning on every healthy run |
| `adrs/1676-e2e-runner-hang-watchdogs.md` (new) | Documents the `with_timeout` mechanism and the three-layer hardening design — see ADR rationale below |

No changes to `docs/USER_GUIDE.md`, `docs/state-machine.md`, `docs/stage-lifecycle.md`, or `docs/positioning.md` — none reference `run.sh` or any `E2E_*` variable (confirmed in Research); `docs/llms-full.txt` regeneration is not required.

### Key Decisions

- **Pure-bash `with_timeout`, not `perl`/`python3`.** Both interpreters are confirmed present, but the file has zero existing dependency on either, and a backgrounded-command-plus-timer is exactly the idiom `run_reaped` and `stop_bed_instance` already use. Consistency with existing patterns beats the issue's own `perl`/`python3`-first framing, which Research already flagged as a judgment call. `with_timeout` group-kills (`kill -TERM -"$pid"`) rather than a plain `kill`, per the issue's own Prior Art callout that a timed-out call "shouldn't leak a child process either" (ADR-1624 discipline).
- **R2 is a background timer + checkpoint file, not a per-step foreground elapsed check.** A foreground check can only observe elapsed time *between* statements — it cannot detect or interrupt a single statement that is itself hung, which is precisely the incident's failure mode. Only an independently-scheduled background process can enforce a deadline against a stuck foreground statement.
- **R2's abort mechanism is `SIGTERM` to `$$`, with an explicitly documented residual gap.** By the time the watchdog could fire, the tail's own `trap - INT TERM` has already run (line 899), so there is no group-kill machinery active to reap a still-blocked synchronous child of a hypothetical *future* unwrapped network call (R1 already wraps the two calls named by this issue, so this path is a backstop for an as-yet-unknown regression, not the common case). This mirrors the file's own existing "KNOWN GAP" documentation convention (see the `TestSwitchTrainMode` restart step comment, line ~812) rather than pretending to solve it — over-engineering full group-kill machinery for a step that (by construction, once R1 lands) should never actually need it isn't worth the added complexity.
- **A distinct exit code (`POST_SUITE_WATCHDOG_EXIT=6`) for R2**, extending the file's existing `BUDGET_EXHAUSTED_EXIT`(3)/`PREFLIGHT_FAILED_EXIT`(4)/`PREGATE_FAILED_EXIT`(5) convention, so `cut-release.sh` or any future caller can distinguish "hung post-suite step" from every other failure mode programmatically, exactly as those three already allow.
- **R3 warns, never gates**, per R4's explicit non-blocking requirement and the issue's own acknowledgment that a scenario can legitimately wait on Claude for extended periods.
- **Defaults kept at the issue's proposed starting points (30s / 5m / 15m)**, not tuned further: Research found no evidence indicting them — the one measured real-world gap (5½ minutes, multi-scenario leg) sits comfortably under the 15-minute R3 default, and nothing in the post-suite tail (a couple of REST calls plus `jq` parsing) plausibly approaches the 5-minute R2 default. Documented in the README per the issue's "must document the rationale for any change" instruction — here the rationale is *for keeping* the defaults, which the issue's phrasing anticipates as a valid outcome.
- **ADR warranted.** `with_timeout` is a genuinely new mechanism absent anywhere in the repo today (confirmed in Research), and this lineage's precedent (`adrs/1624-...`, `adrs/1454-...`) already writes ADRs for comparable `run.sh` hardening; #1527's own precedent of *not* writing one for the probe calls this issue now has to harden is the counter-example that motivated introducing the timeout guarantee in the first place.

### Task Checklist

- [ ] Add `with_timeout <seconds> <cmd...>` helper near `run_reaped` (~line 307), with a comment establishing it as the required routing point for any future e2e network call (R1)
- [ ] Add `GH_API_TIMEOUT="${E2E_GH_API_TIMEOUT:-30}"`, `POST_SUITE_WATCHDOG="${E2E_POST_SUITE_WATCHDOG:-300}"`, `STALL_WARN_SECS=$(( ${E2E_STALL_WARN_MINUTES:-15} * 60 ))` alongside `TIMEOUT`/`PARALLEL`/`PARALLEL_ON` (~line 615–623); add `readonly POST_SUITE_WATCHDOG_EXIT=6` alongside the other distinct exit codes (~line 253–266)
- [ ] Wrap the `budget_before` call with `with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit ...` (~line 842), preserving the existing `budget_before=""` fallback (R1, R4)
- [ ] Wrap the `budget_after` call the same way (~line 903) (R1, R4)
- [ ] Extract `last_completed_test_name <jsonlog>` as its own function (mirroring `detect_rate_limit_backoff`'s "own function so it's independently testable" precedent), reusing `report_test_timings`'s terminal-action `jq` filter
- [ ] Implement R2: checkpoint file written at the start of each step in `switch_and_run`'s post-`wait "$suite_pid"` tail (budget_after probe, `report_test_timings`, failure classification/teardown, `detect_rate_limit_backoff`); background timer started right after `wait "$suite_pid"`, printing a diagnostic (elapsed time, last checkpoint, last `$ENGINE_LOG`/`$jsonlog` line) and `kill -TERM $$` on expiry; timer explicitly killed before each of `switch_and_run`'s normal-path returns and before the `exit "$BUDGET_EXHAUSTED_EXIT"` path, so it never fires late against a recycled invocation (ADR-1624 discipline)
- [ ] Implement R3: background loop started alongside the existing consumer job (after `exec 3> "$fifo"`), added to the existing INT/TERM trap kill-lists and explicitly killed after `wait "$consumer_pid"` (mirroring `suite_pid`/`consumer_pid`'s own lifecycle exactly, so nothing leaks across the up-to-3 `switch_and_run` calls per invocation); on `STALL_WARN_SECS` of `$jsonlog` mtime silence, logs a warning via `last_completed_test_name` — never touches `$rc`
- [ ] Update the header comment: document `E2E_GH_API_TIMEOUT`, `E2E_POST_SUITE_WATCHDOG`, `E2E_STALL_WARN_MINUTES`, and `POST_SUITE_WATCHDOG_EXIT` in the same style as the existing knobs; note the R2/R3 mechanism briefly near the existing "GraphQL budget exhaustion detection" section (~line 146–209)
- [ ] Write `scripts/e2e/hang_hardening_test.sh`: `with_timeout` against a PATH-shadowed hanging fake `gh` (AC1 — assert prompt return within the configured bound; demonstrate non-vacuousness via a separately-bounded direct invocation of the same fake command showing it does *not* return within that same window when unwrapped); `last_completed_test_name` against constructed `go test -json` fixtures (supports AC3); the watchdog's elapsed-check logic against constructed timestamps (supports AC2)
- [ ] Update `tests/e2e/README.md`: env var reference entries for the three new vars; a "How the E2E_GH_API_TIMEOUT/E2E_POST_SUITE_WATCHDOG/E2E_STALL_WARN_MINUTES defaults are derived" subsection (style-matched to line 942's existing section) documenting the 17h19m incident, the 5½-minute real gap already on record, and the rationale for keeping the issue's proposed defaults as-is; a note that the isolated `TestMergeTrainRunawayGuardPausesBatch` leg is expected to trigger R3's warning on every healthy run
- [ ] Create ADR `adrs/1676-e2e-runner-hang-watchdogs.md` documenting `with_timeout`, the checkpoint-file watchdog design, the stall detector, and the key decisions above (pure-bash vs. `perl`/`python3`; background-timer vs. foreground-checkpoint for R2; the documented residual group-kill gap)
- [ ] Verify: `bash -n scripts/e2e/run.sh` (syntax); run `scripts/e2e/hang_hardening_test.sh`, `scripts/e2e/backoff_detection_test.sh`, and `scripts/e2e/pregate_test.sh` (confirm no regression from sourcing changes); `go build ./...` and `go test ./...` unaffected (this issue touches only shell scripts)

### Risks

- **The R2 backstop cannot group-kill a hypothetical future unwrapped, stuck foreground call** — documented as a known, accepted gap (mirroring the file's existing "KNOWN GAP" convention) rather than solved, since R1 already removes the only two calls this issue identifies as unguarded; a future contributor forgetting the "route through `with_timeout`" convention is the only path that would exercise this gap.
- **R3 will very likely fire on every healthy run's isolated `TestMergeTrainRunawayGuardPausesBatch` leg** (it runs alone, per the dispatch-guard comment at line ~1002–1027) — mitigated by wording the warning clearly as informational and calling this out explicitly in the README so it doesn't read as a regression.
- **A too-tight R2 window would block a real release** — mitigated by keeping the issue's own generous 5-minute default, which Research confirmed is far above the tail's actual normal runtime (seconds, not minutes).
- **`kill -TERM $$` inside a function is a first for this file** (existing traps only ever kill background job PIDs, never the main process) — worth extra care in Implement to confirm it does not interact badly with the outer dispatch guard or leave the terminal in a bad state; the test script's fake-hang scenario should exercise this path directly, not just assert on log text.

---
Used 7/100 turns, 659k input (12 raw + 604k cache-read + 54k cache-write) / 19k output tokens.

## Verification

Implemented all three hang-hardening layers in `scripts/e2e/run.sh` (R1 `with_timeout`, R2 post-suite watchdog, R3 stall detector) per the Plan, plus a new `hang_hardening_test.sh`, README docs, and ADR-1676. Critically, found and fixed a bug where `with_timeout` invoked via `$(with_timeout ...)` silently defeats its own group-kill (command substitution subshells don't get per-job process groups under `set -m`), which would have left the two real `gh api rate_limit` call sites unprotected exactly as before this issue — fixed by capturing output via temp files instead, with a permanent regression test proving the hazard is real. All tests pass (`bash -n`, all three shell test scripts, `go build`/`go vet`); one pre-existing, unrelated Go test flake (`TestExecute_ConfigYAMLApplied`, untouched by this change) was confirmed independent via isolated re-run. Work committed, pushed, and rebased cleanly onto a duplicate remote WIP commit.

---

Closes #1676