### PR TITLE
fix(release): harden release-gate against bed accumulation, uncapped -race, narrow parallelism band, dead pre-gate guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,19 @@ jobs:
       - name: go test
         # TestExecute_ConfigYAMLApplied is a timing-sensitive SIGINT integration
         # test that fails intermittently on CI; it is tracked separately.
-        run: go test -race -timeout 5m -skip TestExecute_ConfigYAMLApplied ./...
+        #
+        # -parallel capped via scripts/lib/parallel.sh's default_race_parallel
+        # (REQ4, #1677): this invocation includes the same git-forking
+        # tests/sim package that scripts/sim/run.sh's own SIM_PARALLEL caps
+        # locally — capping it here too keeps both entry points coherent
+        # rather than one being a no-op protection. CI's runners are 2-4
+        # cores (well below the min(4, cores) ceiling), so this is a no-op
+        # in practice today and exists for future-proofing / consistency,
+        # not because CI has ever reproduced the fork/exec SIGSEGV this cap
+        # guards against — see scripts/lib/parallel.sh's own header comment.
+        run: |
+          source scripts/lib/parallel.sh
+          go test -race -timeout 5m -parallel "$(default_race_parallel)" -skip TestExecute_ConfigYAMLApplied ./...
 
       # Compile the e2e suite without running it. The scenarios are behind the
       # `e2e` build tag and drive a real Fabrik bed against real repos, so they

--- a/adrs/1677-release-gate-hardening.md
+++ b/adrs/1677-release-gate-hardening.md
@@ -21,10 +21,17 @@ released — every one was the release harness itself. Four distinct, independen
    ./...` run the exact same git-forking `tests/sim` package as part of `./...`, uncapped —
    reproducing the identical crash via a different entry point.
 3. **The viable parallelism band was narrower than #1624 assumed.** Measured on the 28-core
-   host that produced both #1624 and #1677: `-parallel 8` (#1624's own default) still
-   SIGSEGVs roughly 1 run in 5 — not reliable for a release gate. `-parallel 4` showed zero
-   SIGSEGVs across multiple consecutive runs, but took ~661s — over `go test`'s undocumented
-   10-minute default `-timeout`, which nobody had ever made explicit.
+   host that produced both #1624 and #1677:
+
+   | `-parallel` | outcome |
+   |---|---|
+   | 28 (default, uncapped) | TSan fork/exec SIGSEGV, frequent |
+   | 8 (#1624's own default) | ~130s, SIGSEGV roughly **1 run in 5** — not reliable for a release gate |
+   | 4 | ~661s, zero SIGSEGVs across multiple consecutive runs — but over `go test`'s undocumented 10-minute default `-timeout`, which nobody had ever made explicit |
+
+   This data cost a full release cycle (ten attempts) to obtain, which is why it's recorded
+   here in full rather than summarized — re-deriving it requires the same multi-run,
+   high-core-count validation methodology described in Consequences below.
 4. **The pre-gate SHA dedup guard (#1624's R5) never actually engaged.** `run_pregate`'s
    `FABRIK_PREGATE_VERIFIED_SHA` check requires both a HEAD match and a clean working tree.
    `cut-release.sh` step 4's "Record embedded plugin hash" step writes

--- a/adrs/1677-release-gate-hardening.md
+++ b/adrs/1677-release-gate-hardening.md
@@ -1,0 +1,127 @@
+# ADR 1677: Release-Gate Hardening — Bed Reset, Unified Parallelism Cap, Pre-Gate Dedup Fix
+
+**Date**: 2026-08-29
+**Status**: Accepted
+**Issue**: #1677 — four release-gate defects found cutting v0.0.81 — bed accumulation,
+uncapped `-race`, unreachable parallelism band, dead pre-gate guard
+
+## Context
+
+Cutting v0.0.81 took ten attempts. None of the failures were defects in the code being
+released — every one was the release harness itself. Four distinct, independent root causes:
+
+1. **Bed accumulation.** `cut-release.sh`'s invocation of `scripts/e2e/run.sh` never passed
+   `--clean`, so the shared test bed's board/label state (and local session/log trees)
+   accrued release over release, until `TestSwitchTrainMode`'s fixed 30s lock-release wait
+   was no longer enough margin — killing two of the ten attempts outright, with a bare
+   `"did not release lock within 30s"` giving no clue why.
+2. **Uncapped repo-wide `-race`.** #1624 capped `scripts/sim/run.sh`'s own `-parallel`
+   (`SIM_PARALLEL`, default `min(8, host cores)`) specifically to avoid a TSan fork/exec
+   SIGSEGV on high-core-count hosts, but both `cut-release.sh` step 4 and CI's `go test -race
+   ./...` run the exact same git-forking `tests/sim` package as part of `./...`, uncapped —
+   reproducing the identical crash via a different entry point.
+3. **The viable parallelism band was narrower than #1624 assumed.** Measured on the 28-core
+   host that produced both #1624 and #1677: `-parallel 8` (#1624's own default) still
+   SIGSEGVs roughly 1 run in 5 — not reliable for a release gate. `-parallel 4` showed zero
+   SIGSEGVs across multiple consecutive runs, but took ~661s — over `go test`'s undocumented
+   10-minute default `-timeout`, which nobody had ever made explicit.
+4. **The pre-gate SHA dedup guard (#1624's R5) never actually engaged.** `run_pregate`'s
+   `FABRIK_PREGATE_VERIFIED_SHA` check requires both a HEAD match and a clean working tree.
+   `cut-release.sh` step 4's "Record embedded plugin hash" step writes
+   `plugin/known_embedded_versions.go` on disk, uncommitted, between the SHA being captured
+   (end of step 3) and step 5's dirty-tree check — so on essentially every real release the
+   tree was dirty by the time the guard ran, and the sim + wire-contract pre-gate paid for
+   itself twice on every one of the ten attempts, doubling the odds of losing an attempt to
+   the very SIGSEGV described above.
+
+## Decision
+
+**1. `cut-release.sh` step 5 now passes `--clean` unconditionally.** `scripts/e2e/reset.sh`
+already existed and was already destructive by design (closes open PRs/issues, deletes
+`fabrik/*` branches, drains the board) — this was a missing call site, not new capability.
+The trade-off (a release cut and concurrent manual e2e testing on the shared bed can no
+longer safely overlap) is accepted and documented in the step's own header comment; it is
+the correct trade given the alternative is a release-gate failure mode that recurs "every
+few releases by construction."
+
+**2. `tests/e2e/lifecycle.go`'s `StopFabrikTestBed`/`StartFabrikTestBed` get a shared,
+generous 90s timeout (up from a hardcoded 30s/40s) with periodic progress logging and
+failure diagnostics.** Rejected deriving the timeout from the engine's own
+`--drain-deadline` config — more precise, but couples the test harness to engine internals
+for a marginal gain. 90s matches the convention `scripts/e2e/run.sh`'s own
+`preflight_bed_start` already uses for bed startup. On timeout, the failure message now
+includes `bedDiagnostics`: process liveness plus a tail of the bed's own `fabrik.log` — the
+exact janitor/scan activity the original incident's evidence block showed at the moment of
+failure, previously discarded entirely by the bare `"did not release lock within 30s"`
+message.
+
+**3. One shared parallelism-cap helper (`scripts/lib/parallel.sh`'s `default_race_parallel`),
+ceiling lowered from `min(8, cores)` to `min(4, cores)`, used by all three invocations that
+exercise the same git-forking `tests/sim` package under `-race`: `scripts/sim/run.sh`
+(`SIM_PARALLEL`'s default), `cut-release.sh` step 4's repo-wide `go test -race ./...`, and
+CI's equivalent step.** Treating the three independently was rejected — they exercise
+overlapping concurrency, so a coherent single cap is required or one of the three caps
+becomes pointless (confirmed during Research: capping only `scripts/sim/run.sh` left the
+other two free to reproduce the exact SIGSEGV the cap exists to prevent, which is exactly
+what happened during the v0.0.81 cut). Lowering the ceiling to 4 (rather than merely
+plumbing 8 through to all three sites) follows directly from the measured ~20%-per-run
+SIGSEGV rate at 8 — not reliable enough for a release gate. CI's 2–4-core runners are
+unaffected in practice (the cap is a no-op there); this reverses #1624's own explicit
+decision to scope the cap away from a bare `go test -race ./...` invocation, because that
+reasoning held for CI specifically, not for a high-core-count release-cutting workstation
+running the identical command locally via `cut-release.sh`.
+
+**4. `scripts/sim/run.sh` and `cut-release.sh` step 4 both add an explicit `-timeout 20m`
+(`SIM_TIMEOUT`, overridable).** This is what makes the lower, reliable `-parallel 4` value
+actually viable rather than merely "less likely to SIGSEGV but liable to time out instead" —
+the previous absence of an explicit `-timeout` meant `-parallel 4`'s ~661s runtime was
+silently racing an undocumented 10-minute Go default. Rejected the alternative mechanism
+(excluding git-forking scenarios from `-race` entirely) as more invasive — per-scenario
+build-tag/skip machinery — for a problem the lower cap + explicit timeout combination already
+resolves per the issue's own measured data (zero SIGSEGVs at `-parallel 4` across multiple
+runs).
+
+**5. `run_pregate`'s dirty-tree check now accepts a caller-declared allowlist
+(`FABRIK_PREGATE_ALLOWED_DIRTY_REGEX`), generated by a single `allowed_dirty_regex()`
+function in `cut-release.sh` shared with step 1's own preflight dirty-tree filter, instead of
+hardcoding the one known offending filename inside `run_pregate` itself.** Hardcoding
+`plugin/known_embedded_versions.go` directly in `run.sh` was rejected: a future change adding
+a second such self-write pattern to `cut-release.sh` (as `plugin/*/.claude-plugin/plugin.json`
+already is, for step 6b) would silently defeat the guard again in the same way, and step 1's
+preflight already maintains exactly this list — two independently-maintained "files this
+script expects to leave dirty" lists is the drift risk this closes, not just the one instance
+found during Research. Anything **not** matching the caller-declared allowlist still counts
+as dirty and still falls through to the full pre-gate, exactly as before — this does **not**
+reopen the TOCTOU gap the clean-tree check exists to close (see #1624's R5): only
+already-known, already-declared self-writes are ever disregarded, never a blanket "ignore all
+dirty files" loosening. A standalone `scripts/e2e/run.sh` invocation never sets
+`FABRIK_PREGATE_ALLOWED_DIRTY_REGEX`, so its own dirty-tree check is unchanged and exactly as
+strict as before this existed.
+
+## Consequences
+
+- A release cut is now always preceded by a full bed reset — a stale bed from a prior release
+  (or from interrupted manual testing) cannot fail the mode-switch lock-timeout check, closing
+  the failure mode that killed two of v0.0.81's ten attempts. The cost is that a release cut
+  and concurrent manual e2e testing on the shared bed are now mutually exclusive by
+  construction, not just by convention.
+- The repo-wide `go test -race ./...` gate (`cut-release.sh` step 4 and CI) is parallelism-capped
+  identically to `scripts/sim/run.sh`, closing the gap that let the exact SIGSEGV #1624 was
+  meant to prevent recur via an uncapped entry point.
+- The sim suite's viable configuration (`-parallel 4`, `-timeout 20m`) is validated the same
+  way the original incident was diagnosed — multiple consecutive runs on a high-core-count
+  host, not a single clean CI pass, since CI's 2–4-core runners cannot reproduce the
+  fork/exec contention this addresses. This is a process obligation for future changes to
+  this area, not something CI enforces automatically.
+- The pre-gate SHA dedup guard (#1624's R5) now actually engages on a real release cut: the
+  sim + wire-contract pre-gate runs exactly once per release instead of twice, removing the
+  doubled odds of losing an attempt to a flake that affected all ten v0.0.81 attempts.
+- `scripts/lib/parallel.sh` and `allowed_dirty_regex()` are now the two canonical,
+  single-source-of-truth mechanisms for "parallelism cap" and "expected self-write allowlist"
+  respectively — future call sites should extend these rather than reintroducing a third,
+  independently-tuned copy of either.
+
+See also: adrs/1624-sim-suite-concurrency-and-pregate-dedup.md (the direct predecessor this
+issue extends and partially reverses — specifically its CI-scoping decision for the
+parallelism cap), adrs/1454-sim-pre-gate-not-replacement.md (establishes the sim suite as a
+pre-gate that never substitutes for the live e2e suite — unaffected by this issue).

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -27,9 +27,14 @@
 #   3. Sim suite + github wire-contract tests — unconditional pre-gate (R1/R2, #1454).
 #      Exports FABRIK_PREGATE_VERIFIED_SHA on success so step 5 doesn't pay for the
 #      identical pre-gate a second time (R5, #1624) — see export_pregate_verified_sha.
-#   4. go build + go test -race (skippable with --skip-tests; the pre-gate above never is)
+#   4. go build + go test -race, -parallel capped via scripts/lib/parallel.sh
+#      (REQ3, #1677 — same cap scripts/sim/run.sh uses, since this run covers
+#      the same git-forking tests/sim package; skippable with --skip-tests,
+#      the pre-gate above never is)
 #   5. Live e2e integration gate — mandatory by default; --skip-integration=<reason> is the
-#      one sanctioned, loud, release-notes-recorded escape hatch (R2, #1454).
+#      one sanctioned, loud, release-notes-recorded escape hatch (R2, #1454). Always
+#      passes --clean (REQ1, #1677) to reset the shared bed first — a release cut and
+#      concurrent manual e2e testing on the bed can no longer safely overlap.
 #      FIDELITY-DRIFT CHECK (R4, #1454): if this step fails on something step 3's
 #      pre-gate passed, that's a fidelity bug in the sim, not just a live regression —
 #      file it and fix it in tests/sim too (procedure: tests/sim/README.md's
@@ -68,6 +73,9 @@ BOT_EMAIL="handarbeit@handarbeit.io"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
+
+# shellcheck source=lib/parallel.sh
+source "$REPO_ROOT/scripts/lib/parallel.sh"
 
 step() { printf '\n\033[1;34m▶ %s\033[0m\n' "$*"; }
 ok()   { printf '  \033[1;32m✓\033[0m %s\n' "$*"; }
@@ -113,27 +121,68 @@ insert_notes_line() {
   fi
 }
 
-# export_pregate_verified_sha exports FABRIK_PREGATE_VERIFIED_SHA as the
-# exact commit this invocation's own sim + wire-contract pre-gate (step 3,
-# below) just verified. Called right after that step passes, while HEAD is
-# still guaranteed unchanged (this script commits nothing until step 6, well
+# allowed_dirty_regex prints the single grep -E pattern of tracked-file
+# changes this script itself is expected to leave uncommitted at various
+# points in a run, parameterized on $1 (VERSION). Two call sites share this
+# one definition rather than maintaining two separate lists (#1677):
+#   - step 1's own pre-flight DIRTY check (below) — unchanged behavior,
+#     just no longer a second, hand-copied regex.
+#   - run_pregate's dirty-tree check (scripts/e2e/run.sh), via the exported
+#     FABRIK_PREGATE_ALLOWED_DIRTY_REGEX — see export_pregate_verified_sha.
+#
+# release-notes/<version>.md is written before step 1 even runs (a
+# prerequisite, not a self-write) but is still expected dirty on a repeat
+# invocation; plugin/known_embedded_versions.go is step 4's own conditional
+# write (only when a new plugin hash isn't already recorded); the
+# plugin/*/.claude-plugin/plugin.json pattern covers step 6b's marketplace
+# version bumps (not yet run when this fires for run_pregate's purposes,
+# but a retry after a partial step 6b could legitimately see it dirty too).
+# Nothing outside this declared, named set is ever treated as expected —
+# any other dirty file still fails both checks exactly as before this was
+# extracted (see run_pregate's own comment on the TOCTOU gap this
+# preserves).
+allowed_dirty_regex() {
+  local version="$1"
+  printf '%s' "^\\?\\? release-notes/${version}\\.md\$| M release-notes/${version}\\.md\$|^M  release-notes/${version}\\.md\$| M plugin/known_embedded_versions\\.go\$|^M  plugin/known_embedded_versions\\.go\$| M plugin/[^/]+/\\.claude-plugin/plugin\\.json\$|^M  plugin/[^/]+/\\.claude-plugin/plugin\\.json\$"
+}
+
+# export_pregate_verified_sha exports FABRIK_PREGATE_VERIFIED_SHA (and
+# FABRIK_PREGATE_ALLOWED_DIRTY_REGEX, REQ7 #1677 — see below) as the exact
+# commit this invocation's own sim + wire-contract pre-gate (step 3, below)
+# just verified. Called right after that step passes, while HEAD is still
+# guaranteed unchanged (this script commits nothing until step 6, well
 # after step 5's live e2e gate runs) — so the value names the exact tree
 # that was checked, not merely "some release."
 #
-# scripts/e2e/run.sh's own pre-gate (run_pregate) checks this against a
-# freshly-resolved `git rev-parse HEAD` of its own before deciding whether
-# to re-run the identical sim + wire-contract checks (R5, #1624) — see that
-# function's own comment. An exported env var, not a file marker: run.sh is
-# invoked as this script's direct child process (step 5), so there is no
-# on-disk staleness/cleanup concern, and the value is naturally scoped to
-# exactly this invocation (env vars do not outlive the child process) —
-# unlike E2E_SKIP_PREGATE, a blanket opt-out this script deliberately never
-# sets (see step 5's own comment), this is a narrow, tree-scoped signal that
-# a standalone `scripts/e2e/run.sh` invocation never sees and so still pays
-# the full pre-gate price, exactly as before this existed.
+# scripts/e2e/run.sh's own pre-gate (run_pregate) checks FABRIK_PREGATE_VERIFIED_SHA
+# against a freshly-resolved `git rev-parse HEAD` of its own before deciding
+# whether to re-run the identical sim + wire-contract checks (R5, #1624) —
+# see that function's own comment. An exported env var, not a file marker:
+# run.sh is invoked as this script's direct child process (step 5), so
+# there is no on-disk staleness/cleanup concern, and the value is naturally
+# scoped to exactly this invocation (env vars do not outlive the child
+# process) — unlike E2E_SKIP_PREGATE, a blanket opt-out this script
+# deliberately never sets (see step 5's own comment), this is a narrow,
+# tree-scoped signal that a standalone `scripts/e2e/run.sh` invocation
+# never sees and so still pays the full pre-gate price, exactly as before
+# this existed.
+#
+# REQ7 (#1677): the SHA match alone was never sufficient on a real release —
+# step 4's "Record embedded plugin hash" write to
+# plugin/known_embedded_versions.go lands on disk, uncommitted, between
+# this function running (end of step 3) and run_pregate's own dirty-tree
+# check (step 5), so the tree was dirty on essentially every real release
+# and the SHA guard never actually engaged. FABRIK_PREGATE_ALLOWED_DIRTY_REGEX
+# tells run_pregate which specific, already-known-benign self-writes to
+# disregard when deciding "dirty" — the same allowlist step 1's own
+# preflight already trusts, not a new or wider one. A standalone
+# scripts/e2e/run.sh invocation never sets this var, so its dirty-tree
+# check remains exactly as strict as before this existed.
 export_pregate_verified_sha() {
   FABRIK_PREGATE_VERIFIED_SHA="$(git rev-parse HEAD)"
   export FABRIK_PREGATE_VERIFIED_SHA
+  FABRIK_PREGATE_ALLOWED_DIRTY_REGEX="$(allowed_dirty_regex "$VERSION")"
+  export FABRIK_PREGATE_ALLOWED_DIRTY_REGEX
 }
 
 # interpret_e2e_exit_code prints the operator-facing message for a given
@@ -237,7 +286,7 @@ ok "on main"
 # does not need to be tightened; the built-artifact VCS check lives in
 # .goreleaser.yaml/release.yml instead (see
 # adrs/071-release-artifact-vcs-verification.md).
-DIRTY=$(git status --porcelain | grep -Ev "^\?\? release-notes/${VERSION}\.md$| M release-notes/${VERSION}\.md$|^M  release-notes/${VERSION}\.md$| M plugin/known_embedded_versions\.go$|^M  plugin/known_embedded_versions\.go$| M plugin/[^/]+/\.claude-plugin/plugin\.json$|^M  plugin/[^/]+/\.claude-plugin/plugin\.json$" || true)
+DIRTY=$(git status --porcelain | grep -Ev "$(allowed_dirty_regex "$VERSION")" || true)
 [ -z "$DIRTY" ] || die "working tree dirty:
 $DIRTY"
 ok "working tree acceptable"
@@ -341,11 +390,23 @@ if [ "$SKIP_TESTS" -eq 1 ]; then
   warn "--skip-tests was passed; go test -race ./... was NOT run (the sim + wire-contract pre-gate above still ran unconditionally)"
 else
   step "Race-tested suite"
-  if ! go test -race ./... >/tmp/cut-release-test.log 2>&1; then
+  # -parallel capped (REQ3, #1677): this repo-wide invocation includes the
+  # same git-forking tests/sim package that scripts/sim/run.sh's own
+  # SIM_PARALLEL caps — left uncapped here, it inherits GOMAXPROCS (28 on
+  # the host that produced #1677) and reliably reproduces the TSan
+  # fork/exec SIGSEGV #1624's cap was meant to prevent, just via a
+  # different entry point. FABRIK_RACE_PARALLEL is a narrow override (for
+  # experimentation); default_race_parallel (scripts/lib/parallel.sh) is
+  # the same helper scripts/sim/run.sh uses, so the two never drift into
+  # incoherent caps for overlapping concurrency. -timeout matches
+  # scripts/sim/run.sh's own SIM_TIMEOUT rationale — see that script's
+  # header comment.
+  RACE_PARALLEL="${FABRIK_RACE_PARALLEL:-$(default_race_parallel)}"
+  if ! go test -race -parallel "$RACE_PARALLEL" -timeout 20m ./... >/tmp/cut-release-test.log 2>&1; then
     tail -40 /tmp/cut-release-test.log >&2
     die "go test -race ./... failed (full log: /tmp/cut-release-test.log)"
   fi
-  ok "all tests pass with -race"
+  ok "all tests pass with -race (-parallel $RACE_PARALLEL)"
 fi
 
 # Capture the previous release tag now, before this release's tag exists,
@@ -370,6 +431,19 @@ PREV_TAG="$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || true)"
 # the SAME release-notes commit rather than needing a second push, and (c)
 # since scripts/e2e/run.sh fetches origin/main by default, this tests
 # exactly the commit about to ship, right before it ships.
+#
+# --clean (REQ1, #1677): every invocation now resets the shared bed via
+# scripts/e2e/reset.sh before the gate runs — this was previously never
+# passed, so bed state (closed-but-still-labeled board items, stale
+# branches, accumulated sessions/logs) accrued release over release until
+# TestSwitchTrainMode's lock-timeout check failed against a bed slow enough
+# from that accumulated backlog to blow its wait window (#1677's own
+# ten-attempt v0.0.81 incident). scripts/e2e/reset.sh is already destructive
+# by design (closes all open PRs/issues, deletes fabrik/* branches, drains
+# the board) — this is not new destructive capability, just the missing
+# call site — but it does mean a release cut and any concurrent manual e2e
+# testing on this shared bed can no longer safely overlap. Do not run this
+# script while someone else is using ~/dev/fabrik-test by hand.
 step "Live e2e integration gate"
 if [ "$SKIP_INTEGRATION" -eq 1 ]; then
   cat >&2 <<EOF
@@ -386,9 +460,9 @@ EOF
   insert_notes_line "$NOTES_FILE" "- ⚠️ Live e2e integration suite SKIPPED for this release: $INTEGRATION_SKIP_REASON"
   warn "live e2e integration suite SKIPPED — reason recorded in $NOTES_FILE"
 else
-  echo "   running scripts/e2e/run.sh against origin/main (this can take hours — see tests/e2e/README.md)"
+  echo "   running scripts/e2e/run.sh --clean against origin/main (this can take hours — see tests/e2e/README.md)"
   E2E_RC=0
-  "$REPO_ROOT/scripts/e2e/run.sh" || E2E_RC=$?
+  "$REPO_ROOT/scripts/e2e/run.sh" --clean || E2E_RC=$?
   E2E_MSG="$(interpret_e2e_exit_code "$E2E_RC")"
   if [ "$E2E_RC" -eq 0 ]; then
     ok "$E2E_MSG"

--- a/scripts/cut_release_gate_test.sh
+++ b/scripts/cut_release_gate_test.sh
@@ -158,6 +158,64 @@ assert_eq "export_pregate_verified_sha sets FABRIK_PREGATE_VERIFIED_SHA to HEAD"
 CHILD_VISIBLE="$(bash -c 'echo "$FABRIK_PREGATE_VERIFIED_SHA"')"
 assert_eq "export_pregate_verified_sha's value is visible to a child process" "$EXPECTED_SHA" "$CHILD_VISIBLE"
 
+# --- allowed_dirty_regex (REQ7, #1677): a single grep -E pattern shared by
+# step 1's own DIRTY preflight filter and, exported as
+# FABRIK_PREGATE_ALLOWED_DIRTY_REGEX, scripts/e2e/run.sh's run_pregate — so
+# there's exactly one place this "files this script itself is expected to
+# leave dirty" list is maintained, not two hand-copied ones that can drift.
+# Asserted against a sample VERSION by piping representative git-status
+# -porcelain lines through it, mirroring how both real call sites use it. ---
+SAMPLE_VERSION="v0.0.77"
+REGEX="$(allowed_dirty_regex "$SAMPLE_VERSION")"
+
+allowed_line_survives() {
+  # Returns "kept" if $1 (a porcelain line) is NOT filtered out by the
+  # allowlist (i.e. grep -Ev finds it, so it would still count as dirty),
+  # "filtered" if the allowlist swallows it.
+  local line="$1"
+  if printf '%s\n' "$line" | grep -Eqv "$REGEX"; then
+    echo "kept"
+  else
+    echo "filtered"
+  fi
+}
+
+assert_eq "allowed_dirty_regex: untracked release-notes/<version>.md is filtered (allowed)" \
+  "filtered" "$(allowed_line_survives "?? release-notes/${SAMPLE_VERSION}.md")"
+assert_eq "allowed_dirty_regex: modified release-notes/<version>.md is filtered (allowed)" \
+  "filtered" "$(allowed_line_survives " M release-notes/${SAMPLE_VERSION}.md")"
+assert_eq "allowed_dirty_regex: modified plugin/known_embedded_versions.go is filtered (allowed)" \
+  "filtered" "$(allowed_line_survives " M plugin/known_embedded_versions.go")"
+assert_eq "allowed_dirty_regex: modified plugin/*/.claude-plugin/plugin.json is filtered (allowed)" \
+  "filtered" "$(allowed_line_survives " M plugin/entwurf/.claude-plugin/plugin.json")"
+assert_eq "allowed_dirty_regex: an unrelated dirty file is NOT filtered (still counts as dirty)" \
+  "kept" "$(allowed_line_survives " M engine/poll.go")"
+assert_eq "allowed_dirty_regex: a different version's release-notes is NOT filtered" \
+  "kept" "$(allowed_line_survives "?? release-notes/v0.0.1.md")"
+
+# export_pregate_verified_sha must also export FABRIK_PREGATE_ALLOWED_DIRTY_REGEX
+# (alongside FABRIK_PREGATE_VERIFIED_SHA, asserted above) so run_pregate can
+# apply the same allowlist without a second, separately-maintained copy.
+unset FABRIK_PREGATE_ALLOWED_DIRTY_REGEX
+VERSION="$SAMPLE_VERSION"
+export_pregate_verified_sha
+assert_eq "export_pregate_verified_sha sets FABRIK_PREGATE_ALLOWED_DIRTY_REGEX" \
+  "$(allowed_dirty_regex "$SAMPLE_VERSION")" "$FABRIK_PREGATE_ALLOWED_DIRTY_REGEX"
+CHILD_REGEX_VISIBLE="$(bash -c 'echo "$FABRIK_PREGATE_ALLOWED_DIRTY_REGEX"')"
+assert_eq "FABRIK_PREGATE_ALLOWED_DIRTY_REGEX is visible to a child process" \
+  "$(allowed_dirty_regex "$SAMPLE_VERSION")" "$CHILD_REGEX_VISIBLE"
+
+# --- Static check (REQ1, #1677): step 5 must invoke scripts/e2e/run.sh with
+# --clean, unconditionally, on the non-skip path — this is what resets the
+# shared bed before the live gate runs. A plain grep rather than exercising
+# main() (which would require a real bed, network, and publish path). ---
+if grep -Eq '"\$REPO_ROOT/scripts/e2e/run\.sh"[[:space:]]+--clean([[:space:]]|$)' "$REPO_ROOT/scripts/cut-release.sh"; then
+  echo "PASS: step 5 invokes scripts/e2e/run.sh with --clean"
+else
+  echo "FAIL: step 5 does not invoke scripts/e2e/run.sh with --clean"
+  FAILED=1
+fi
+
 # --- insert_notes_line: exercised directly against a scratch file, proving
 # the helper both call sites (plugin-bump changelog, --skip-integration
 # recorded-skip line) now share behaves identically to the pre-refactor

--- a/scripts/e2e/pregate_test.sh
+++ b/scripts/e2e/pregate_test.sh
@@ -137,6 +137,38 @@ rm -f "$DIRTY_TREE_FILE"
 assert_eq "matching SHA + dirty tree exits 0 (full pre-gate ran and passed)" "0" "$rc"
 assert_eq "matching SHA + dirty tree runs the full pre-gate (2 go calls), not a skip" "2" "$(marker_count)"
 
+# --- Case 7 (REQ7, #1677): a matching FABRIK_PREGATE_VERIFIED_SHA DOES skip
+# the pre-gate when the only dirty file matches a caller-declared
+# FABRIK_PREGATE_ALLOWED_DIRTY_REGEX — this is the mechanism that makes
+# cut-release.sh's own step 4 self-write (plugin/known_embedded_versions.go)
+# stop defeating the dedup guard on every real release. Zero go calls, exit
+# 0, same as Case 4's clean-tree skip. ---
+reset_marker
+: > "$DIRTY_TREE_FILE"
+CURRENT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+ALLOWED_REGEX='^\?\? \.pregate_test_dirty_tree_scratch$'
+( FAKE_GO_EXIT=1 FABRIK_PREGATE_VERIFIED_SHA="$CURRENT_SHA" FABRIK_PREGATE_ALLOWED_DIRTY_REGEX="$ALLOWED_REGEX" run_pregate ) >/dev/null 2>&1
+rc=$?
+rm -f "$DIRTY_TREE_FILE"
+assert_eq "matching SHA + only-allowlisted dirt exits 0 (skipped)" "0" "$rc"
+assert_eq "matching SHA + only-allowlisted dirt makes no go call" "0" "$(marker_count)"
+
+# --- Case 8 (REQ7, #1677 — preserves the TOCTOU protection): a matching
+# FABRIK_PREGATE_VERIFIED_SHA does NOT skip when a dirty file does NOT match
+# the declared allowlist, even though the same allowlist var is set — an
+# unvetted change must still fall through to the full pre-gate exactly like
+# Case 6's unscoped-dirty-tree case. This is what proves the allowlist
+# narrows rather than replaces the dirty-tree check. ---
+reset_marker
+: > "$DIRTY_TREE_FILE"
+CURRENT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+UNRELATED_REGEX='^\?\? some/other/file\.go$'
+( FAKE_GO_EXIT=0 FABRIK_PREGATE_VERIFIED_SHA="$CURRENT_SHA" FABRIK_PREGATE_ALLOWED_DIRTY_REGEX="$UNRELATED_REGEX" run_pregate ) >/dev/null 2>&1
+rc=$?
+rm -f "$DIRTY_TREE_FILE"
+assert_eq "matching SHA + non-allowlisted dirt exits 0 (full pre-gate ran and passed)" "0" "$rc"
+assert_eq "matching SHA + non-allowlisted dirt runs the full pre-gate (2 go calls), not a skip" "2" "$(marker_count)"
+
 # --- Structural check: run_pregate must precede prepare_bed_and_reset inside
 # the dispatch guard, textually — this is what makes "no live call is made"
 # true by construction rather than by accident of today's implementation.

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -54,6 +54,28 @@
 #                           full price, exactly as before this existed. See
 #                           export_pregate_verified_sha in cut-release.sh.
 #
+#   FABRIK_PREGATE_ALLOWED_DIRTY_REGEX=<grep -E pattern>   caller-declared
+#                           dirty-tree allowlist (REQ7, #1677): only
+#                           meaningful alongside FABRIK_PREGATE_VERIFIED_SHA
+#                           above. On a real cut-release.sh run, its own
+#                           step 4 rewrites plugin/known_embedded_versions.go
+#                           on disk between the SHA being captured and this
+#                           check, which made the clean-tree requirement
+#                           above fail on essentially every release and the
+#                           dedup guard never actually engage. This var lets
+#                           the caller declare, up front, the specific
+#                           self-writes it knows are benign — anything NOT
+#                           matching still counts as dirty. cut-release.sh
+#                           exports this to the exact same allowlist its own
+#                           step-1 preflight already trusts (see that
+#                           script's allowed_dirty_regex), so this does not
+#                           reopen the TOCTOU gap the clean-tree check exists
+#                           to close — it only recognizes already-known,
+#                           already-declared writes. A standalone
+#                           `scripts/e2e/run.sh` invocation never sets this,
+#                           so its dirty-tree check stays exactly as strict
+#                           as before this existed.
+#
 # Bed preflight (on by default — see preflight_bed below for the full rationale):
 #   Before anything runs, the bed checkout is fast-forwarded to the ref under
 #   test, its binary is rebuilt IN PLACE, stage-config drift is reported, and the
@@ -361,10 +383,30 @@ run_pregate() {
   # also requires a clean working tree (`git status --porcelain` empty) —
   # any uncommitted change, tracked or untracked, falls through to the full
   # pre-gate exactly like a SHA mismatch does.
+  #
+  # REQ7 (#1677): on a real cut-release.sh run, step 4's plugin-hash write
+  # lands here on essentially every release, so an unconditionally-strict
+  # "empty means clean" check meant this guard never actually engaged in
+  # practice — it always saw a dirty tree and fell through. Rather than
+  # loosening the check to accept ANY dirty tree (which would reopen the
+  # exact TOCTOU gap this check exists to close — an unvetted change between
+  # the SHA being captured and this check could then slip through unnoticed),
+  # FABRIK_PREGATE_ALLOWED_DIRTY_REGEX lets the caller declare, up front,
+  # the specific self-writes it knows are benign (cut-release.sh sets this
+  # to the same allowlist its own step-1 preflight already trusts — see
+  # allowed_dirty_regex there). Anything NOT matching that declared
+  # allowlist still counts as dirty and still falls through to the full
+  # pre-gate below, exactly as before. A standalone `scripts/e2e/run.sh`
+  # invocation never sets this var, so `dirty` there is the full,
+  # unfiltered porcelain output — unchanged, still as strict as ever.
   if [ -n "${FABRIK_PREGATE_VERIFIED_SHA:-}" ]; then
     local current_sha dirty
     current_sha="$(git rev-parse HEAD)"
-    dirty="$(git status --porcelain)"
+    if [ -n "${FABRIK_PREGATE_ALLOWED_DIRTY_REGEX:-}" ]; then
+      dirty="$(git status --porcelain | grep -Ev "$FABRIK_PREGATE_ALLOWED_DIRTY_REGEX" || true)"
+    else
+      dirty="$(git status --porcelain)"
+    fi
     if [ "$FABRIK_PREGATE_VERIFIED_SHA" = "$current_sha" ] && [ -z "$dirty" ]; then
       echo "== pre-gate skipped (already verified for $current_sha in this invocation, R5 #1624) =="
       return 0
@@ -372,7 +414,7 @@ run_pregate() {
     if [ "$FABRIK_PREGATE_VERIFIED_SHA" != "$current_sha" ]; then
       echo "== pre-gate: FABRIK_PREGATE_VERIFIED_SHA ($FABRIK_PREGATE_VERIFIED_SHA) does not match HEAD ($current_sha) — running the full pre-gate =="
     else
-      echo "== pre-gate: FABRIK_PREGATE_VERIFIED_SHA matches HEAD ($current_sha) but the working tree has uncommitted changes since it was verified — running the full pre-gate =="
+      echo "== pre-gate: FABRIK_PREGATE_VERIFIED_SHA matches HEAD ($current_sha) but the working tree has uncommitted changes (beyond any declared allowlist) since it was verified — running the full pre-gate =="
     fi
   fi
 

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -1,0 +1,52 @@
+# scripts/lib/parallel.sh — shared `-parallel` cap for every `-race`
+# invocation that exercises tests/sim's real-git-spawning scenarios (#1677).
+#
+# Meant to be `source`d, not executed. Defines one function,
+# default_race_parallel, and nothing else — no side effects on source.
+#
+# Background (#1624, extended by #1677): go test's default `-parallel` is
+# GOMAXPROCS — every core the host has. On a high-core-count machine (28
+# cores, the one that produced both #1624 and #1677) that means dozens of
+# concurrent t.Parallel() scenarios each spawning real `git` children at
+# once — high-concurrency fork/exec from a heavily multi-threaded Go
+# process, which reliably reproduces a ThreadSanitizer (-race) fork/exec
+# SIGSEGV. None of that is proportional to how much real work the suite is
+# doing — it's purely a function of host core count — so leaving `-parallel`
+# at its default makes the gate's reliability depend on which machine
+# happens to run it, which is backwards: a bigger machine should never make
+# the same suite *less* reliable.
+#
+# #1624 originally capped this at min(8, host cores), scoped only to
+# scripts/sim/run.sh. #1677's own measurement on the 28-core host that
+# produced it found 8 still SIGSEGVs roughly 1 run in 5 — not reliable
+# enough for a release gate — while 4 showed zero SIGSEGVs across multiple
+# consecutive runs. So the ceiling here is 4, not 8, and this helper is now
+# shared by every invocation that exercises the same git-forking scenarios
+# under -race: scripts/sim/run.sh (SIM_PARALLEL's default), cut-release.sh
+# step 4's repo-wide `go test -race ./...` (which runs the identical
+# tests/sim package as part of `./...`), and the CI workflow's equivalent
+# step. One number, one algorithm, all three coherent — see #1677's own
+# Research findings on why capping only some of the three left the others
+# free to reproduce the exact crash the cap exists to prevent.
+#
+# getconf _NPROCESSORS_ONLN is POSIX and portable across macOS and Linux;
+# nproc is a GNU-coreutils fallback for the rare shell where getconf lacks
+# that variable, and 4 itself is the last-resort fallback if neither reports
+# a usable count. Capping at the host's own core count when that's lower
+# than 4 preserves the "never worse than before" property (a flat 4 would
+# *increase* concurrent git-spawning on a host with fewer than 4 cores)
+# while still bounding every host at 4 regardless of how many cores it has
+# above that — mirrors #1624's own min(8,cores)-not-flat-8 reasoning,
+# just with a lower ceiling.
+default_race_parallel() {
+  local cores
+  cores="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+  if ! [ "${cores:-}" -gt 0 ] 2>/dev/null; then
+    cores="$(nproc 2>/dev/null || true)"
+  fi
+  if [ "${cores:-}" -gt 0 ] 2>/dev/null && [ "$cores" -lt 4 ]; then
+    echo "$cores"
+  else
+    echo 4
+  fi
+}

--- a/scripts/sim/run.sh
+++ b/scripts/sim/run.sh
@@ -35,31 +35,43 @@
 # run, and this script also prints its own total wall-clock time below — ask
 # the runner, not a comment, if you want to know how long it currently takes.
 #
-# Parallelism cap (R1, #1624): `go test`'s default `-parallel` is
-# `GOMAXPROCS`, i.e. every core the host has. On a high-core-count machine
-# (28 cores, the one that produced #1624) that means dozens of concurrent
-# `t.Parallel()` scenarios each spawning real `git` children at once —
-# high-concurrency `fork/exec` from a heavily multi-threaded Go process,
-# which #1624 documents causing three distinct failure modes: a wedged
-# fork/exec that strands a scenario's `gitMu` until the suite-wide test
-# timeout, a child `git` killed outright (SIGSEGV), and even a `-race`
-# (ThreadSanitizer) runtime abort. None of that is proportional to how much
-# real work the suite is doing — it's purely a function of host core count —
-# so leaving `-parallel` at its default makes the gate's reliability depend
-# on which machine happens to run it, which is backwards: a bigger machine
-# should never make the same suite *less* reliable. SIM_PARALLEL therefore
-# pins an explicit cap rather than inheriting GOMAXPROCS uncapped — but the
-# default is `min(8, host cores)`, not a flat 8 (found during Review,
-# #1624): a flat 8 would *increase* concurrent git-spawning, versus the
-# previous GOMAXPROCS-derived default, on any host with fewer than 8 cores
-# (a modest laptop or CI runner) — the exact mechanism this cap exists to
-# guard against, just at smaller absolute scale. Capping at the host's own
-# core count when that's lower than 8 preserves the "never worse than
-# before" property while still bounding every host at 8 regardless of how
-# many cores it has above that. Override via the environment for
-# experimentation, but the pre-gate (scripts/e2e/run.sh's run_pregate, and
-# scripts/cut-release.sh transitively) always goes through this one script,
-# so there is exactly one place this number lives.
+# Parallelism cap (R1, #1624; ceiling lowered and extended repo-wide, #1677):
+# `go test`'s default `-parallel` is `GOMAXPROCS`, i.e. every core the host
+# has. On a high-core-count machine (28 cores, the one that produced both
+# #1624 and #1677) that means dozens of concurrent `t.Parallel()` scenarios
+# each spawning real `git` children at once — high-concurrency `fork/exec`
+# from a heavily multi-threaded Go process, which #1624 documents causing
+# three distinct failure modes: a wedged fork/exec that strands a
+# scenario's `gitMu` until the suite-wide test timeout, a child `git`
+# killed outright (SIGSEGV), and even a `-race` (ThreadSanitizer) runtime
+# abort. None of that is proportional to how much real work the suite is
+# doing — it's purely a function of host core count — so leaving
+# `-parallel` at its default makes the gate's reliability depend on which
+# machine happens to run it, which is backwards: a bigger machine should
+# never make the same suite *less* reliable. SIM_PARALLEL therefore pins an
+# explicit cap rather than inheriting GOMAXPROCS uncapped.
+#
+# The default comes from scripts/lib/parallel.sh's default_race_parallel
+# (`min(4, host cores)`) — lowered from #1624's original `min(8, host
+# cores)` after #1677's own measurement on the 28-core host found 8 still
+# reproduces the TSan fork/exec SIGSEGV roughly 1 run in 5, not reliable
+# enough for a release gate, while 4 showed zero SIGSEGVs across multiple
+# consecutive runs (only exceeding the previously-undeclared 10-minute `go
+# test` default timeout, hence SIM_TIMEOUT below). That helper is shared —
+# not duplicated — with cut-release.sh step 4's repo-wide `go test -race
+# ./...` and the CI workflow's equivalent step, since both exercise the
+# same git-forking tests/sim package `./...` includes; see that file's own
+# header comment. Override via the environment for experimentation, but the
+# pre-gate (scripts/e2e/run.sh's run_pregate, and scripts/cut-release.sh
+# transitively) always goes through this one script, so there is exactly
+# one place the sim suite's own number lives.
+#
+# Suite timeout (R4/REQ6, #1677): `-parallel 4` measured ~661s (~11m) on the
+# 28-core host — over Go's undocumented 10-minute default `-timeout`, which
+# is what made `-parallel 4` look nonviable before this was made explicit.
+# SIM_TIMEOUT (default 20m) gives the lower, reliable parallelism value
+# enough headroom to actually finish, rather than raising parallelism back
+# into SIGSEGV territory to chase a hidden default.
 #
 # Process-group reap (R3, #1624): `go test` is launched as a backgrounded job
 # (not via `exec`, which would replace this shell and leave nothing able to
@@ -80,24 +92,17 @@ set -m
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-# Default is min(8, host cores) — see the "Parallelism cap" comment above
-# for why a flat 8 is wrong on a sub-8-core host. getconf _NPROCESSORS_ONLN
-# is POSIX and portable across macOS and Linux; nproc is a GNU-coreutils
-# fallback for the rare shell where getconf lacks that variable, and 8
-# itself is the last-resort fallback if neither reports a usable count.
-sim_default_parallel() {
-  local cores
-  cores="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
-  if ! [ "${cores:-}" -gt 0 ] 2>/dev/null; then
-    cores="$(nproc 2>/dev/null || true)"
-  fi
-  if [ "${cores:-}" -gt 0 ] 2>/dev/null && [ "$cores" -lt 8 ]; then
-    echo "$cores"
-  else
-    echo 8
-  fi
-}
-SIM_PARALLEL="${SIM_PARALLEL:-$(sim_default_parallel)}"
+# shellcheck source=../lib/parallel.sh
+source "$REPO_ROOT/scripts/lib/parallel.sh"
+
+# Default is min(4, host cores) — see the "Parallelism cap" comment above,
+# and scripts/lib/parallel.sh's own header, for the full rationale and why
+# this helper is shared rather than duplicated per call site.
+SIM_PARALLEL="${SIM_PARALLEL:-$(default_race_parallel)}"
+
+# See the "Suite timeout" comment above for why this is no longer left at
+# go test's undocumented 10-minute default.
+SIM_TIMEOUT="${SIM_TIMEOUT:-20m}"
 
 TARGET="./tests/sim"
 if [ "${1:-}" = "--all" ]; then
@@ -105,7 +110,7 @@ if [ "${1:-}" = "--all" ]; then
   shift
 fi
 
-echo "== sim suite: go test -race -count=1 -parallel $SIM_PARALLEL $TARGET $* =="
+echo "== sim suite: go test -race -count=1 -parallel $SIM_PARALLEL -timeout $SIM_TIMEOUT $TARGET $* =="
 
 START_TS=$(date +%s)
 # GO_TEST_PID is declared and the trap installed BEFORE backgrounding, not
@@ -118,7 +123,7 @@ START_TS=$(date +%s)
 # `|| true`.
 GO_TEST_PID=""
 trap 'kill -TERM -"$GO_TEST_PID" 2>/dev/null || true' EXIT INT TERM
-go test -race -count=1 -parallel "$SIM_PARALLEL" "$TARGET" "$@" &
+go test -race -count=1 -parallel "$SIM_PARALLEL" -timeout "$SIM_TIMEOUT" "$TARGET" "$@" &
 GO_TEST_PID=$!
 
 set +e

--- a/tests/e2e/lifecycle.go
+++ b/tests/e2e/lifecycle.go
@@ -49,6 +49,74 @@ func lockedPID(env *Env) int {
 	return pid
 }
 
+// bedLifecycleTimeout bounds both StopFabrikTestBed's wait for the lock to
+// clear and StartFabrikTestBed's wait for the lock to be acquired (#1677,
+// REQ2). Previously these were hardcoded at 30s/40s respectively — fine
+// against an empty bed, but #1677's own incident showed a bed with enough
+// accumulated state (stale board labels, a large tests/sim session/log
+// backlog) can make the engine's own startup janitors and shutdown drain
+// consume close to their full budget, leaving those short, fixed waits with
+// no margin. 90s is deliberately generous — mirroring the 90s convention
+// scripts/e2e/run.sh's own preflight_bed_start already uses for bed
+// startup — rather than deriving a value from the engine's own
+// --drain-deadline config, which would couple this test harness to engine
+// internals for a precision gain that a fixed-but-generous timeout plus
+// real diagnostics (bedDiagnostics below) doesn't need.
+const bedLifecycleTimeout = 90 * time.Second
+
+// bedLifecyclePollInterval is how often StopFabrikTestBed/StartFabrikTestBed
+// re-check the lock and log progress while waiting.
+const bedLifecyclePollInterval = 500 * time.Millisecond
+
+// bedLifecycleLogEvery caps how often progress is logged while polling —
+// every 500ms would flood test output over a 90s wait.
+const bedLifecycleLogEvery = 10 * time.Second
+
+// bedDiagnostics reports what the bed appears to be doing, for inclusion in
+// a StopFabrikTestBed/StartFabrikTestBed timeout failure (#1677, REQ2): the
+// issue's own evidence showed session-janitor/log-janitor/transient-label
+// scan activity in fabrik.log at the moment of a lock-timeout failure, so a
+// bare "did not release lock within 30s" message discarded exactly the
+// information needed to diagnose a recurrence. Reports process liveness
+// (kill -0 equivalent) for pid, if pid > 0, plus a tail of the bed's own
+// fabrik.log.
+func bedDiagnostics(env *Env, pid int) string {
+	var b strings.Builder
+	if pid > 0 {
+		if err := syscallSignalZero(pid); err != nil {
+			fmt.Fprintf(&b, "process pid %d: not alive (%v)\n", pid, err)
+		} else {
+			fmt.Fprintf(&b, "process pid %d: alive\n", pid)
+		}
+	} else {
+		b.WriteString("process pid: unknown (not yet captured)\n")
+	}
+	fmt.Fprintf(&b, "tail of %s:\n%s", env.LogPath, tailFile(env.LogPath, 20))
+	return b.String()
+}
+
+// tailFile returns the last n lines of path, or a placeholder describing why
+// it couldn't be read (missing file, empty file) — never an error, since
+// this is diagnostic-only output attached to an already-failing test.
+func tailFile(path string, n int) string {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Sprintf("  (could not read %s: %v)\n", path, err)
+	}
+	lines := strings.Split(strings.TrimRight(string(contents), "\n"), "\n")
+	if len(lines) == 0 || (len(lines) == 1 && lines[0] == "") {
+		return "  (empty)\n"
+	}
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	var b strings.Builder
+	for _, line := range lines {
+		fmt.Fprintf(&b, "  %s\n", line)
+	}
+	return b.String()
+}
+
 // StopFabrikTestBed stops the running bed (SIGTERM to the locked pid) and waits
 // for the lock to clear (graceful shutdown unlinks it). No-op if not running.
 func StopFabrikTestBed(t *testing.T, env *Env) {
@@ -63,16 +131,24 @@ func StopFabrikTestBed(t *testing.T, env *Env) {
 			t.Fatalf("SIGTERM pid %d: %v", pid, serr)
 		}
 	}
-	deadline := time.Now().Add(30 * time.Second)
+	start := time.Now()
+	deadline := start.Add(bedLifecycleTimeout)
+	lastLog := start
 	for {
 		if lockedPID(env) == 0 {
-			t.Logf("StopFabrikTestBed: bed pid %d stopped, lock cleared", pid)
+			t.Logf("StopFabrikTestBed: bed pid %d stopped, lock cleared after %s", pid, time.Since(start).Round(time.Second))
 			return
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("bed pid %d did not release lock within 30s", pid)
+		now := time.Now()
+		if now.After(deadline) {
+			t.Fatalf("bed pid %d did not release lock within %s — bed diagnostics:\n%s",
+				pid, bedLifecycleTimeout, bedDiagnostics(env, pid))
 		}
-		time.Sleep(500 * time.Millisecond)
+		if now.Sub(lastLog) >= bedLifecycleLogEvery {
+			t.Logf("StopFabrikTestBed: still waiting for pid %d to release lock (%s elapsed)", pid, now.Sub(start).Round(time.Second))
+			lastLog = now
+		}
+		time.Sleep(bedLifecyclePollInterval)
 	}
 }
 
@@ -103,19 +179,28 @@ func StartFabrikTestBed(t *testing.T, env *Env) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start bed Fabrik (%s): %v", bin, err)
 	}
+	launchedPID := cmd.Process.Pid
 	// Release so the test never becomes its reaper; the OS reparents it on exit.
 	_ = cmd.Process.Release()
 
-	deadline := time.Now().Add(40 * time.Second)
+	start := time.Now()
+	deadline := start.Add(bedLifecycleTimeout)
+	lastLog := start
 	for {
 		if pid := lockedPID(env); pid != 0 {
-			t.Logf("StartFabrikTestBed: bed up (pid %d)", pid)
+			t.Logf("StartFabrikTestBed: bed up (pid %d) after %s", pid, time.Since(start).Round(time.Second))
 			return
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("bed Fabrik did not acquire lock within 40s of launch")
+		now := time.Now()
+		if now.After(deadline) {
+			t.Fatalf("bed Fabrik did not acquire lock within %s of launch (launched pid %d) — bed diagnostics:\n%s",
+				bedLifecycleTimeout, launchedPID, bedDiagnostics(env, launchedPID))
 		}
-		time.Sleep(500 * time.Millisecond)
+		if now.Sub(lastLog) >= bedLifecycleLogEvery {
+			t.Logf("StartFabrikTestBed: still waiting for launched pid %d to acquire lock (%s elapsed)", launchedPID, now.Sub(start).Round(time.Second))
+			lastLog = now
+		}
+		time.Sleep(bedLifecyclePollInterval)
 	}
 }
 

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -446,7 +446,7 @@ and why `mergeTrainSlots` caps concurrent merge-train git activity
 independently of `-parallel`. See `adrs/1452-mergetrain-sim-harness-seams.md`
 and `adrs/1624-sim-suite-concurrency-and-pregate-dedup.md`.
 
-### Parallelism cap (R1, #1624)
+### Parallelism cap (R1, #1624; ceiling lowered and extended repo-wide, #1677)
 
 `go test`'s default `-parallel` is `GOMAXPROCS` — every core the host has.
 On the 28-core machine that produced #1624, that meant dozens of concurrent
@@ -462,18 +462,38 @@ suite *less* reliable, backwards from the intended relationship.
 
 `scripts/sim/run.sh` (the sole entry point both manual runs and
 `scripts/e2e/run.sh`'s pre-gate go through — see that script's own header
-comment) now passes an explicit `-parallel "$SIM_PARALLEL"` (default
-**`min(8, host cores)`**, overridable via the environment — not a flat 8:
-review caught that a flat 8 would *increase* concurrent git-spawning on any
-host with fewer than 8 cores, versus the previous `GOMAXPROCS`-derived
-default, so a low-core host is never worse off than before this change,
-while every host still caps at 8 regardless of how many cores it has above
-that) instead of leaving `go test` to inherit `GOMAXPROCS` uncapped. This
-does not apply to a bare `go test -race ./...` invoked directly (CI's own
-gate, or a developer running the whole tree by hand) — only to invocations
-that go through `scripts/sim/run.sh`. CI's own runners are 2–4 cores, well
-below where this class of contention appears, which is part of why the
-flake was essentially unreproducible there.
+comment) passes an explicit `-parallel "$SIM_PARALLEL"`, defaulting to
+`scripts/lib/parallel.sh`'s `default_race_parallel` — **`min(4, host
+cores)`**, overridable via the environment — not a flat number: a flat cap
+would *increase* concurrent git-spawning on any host with fewer cores than
+the cap, versus the previous `GOMAXPROCS`-derived default, so a low-core
+host is never worse off than before this change, while every host still
+caps at the ceiling regardless of how many cores it has above that.
+
+The ceiling was **lowered from 8 to 4 by #1677**, after #1624's original
+`min(8, host cores)` default turned out to still reproduce the TSan
+fork/exec SIGSEGV roughly **1 run in 5** on the 28-core host — not reliable
+enough for a release gate. `-parallel 4` showed zero SIGSEGVs across
+multiple consecutive runs on that same host, at the cost of a longer run
+(~661s, over `go test`'s undocumented 10-minute default `-timeout`) — which
+is why `scripts/sim/run.sh` now also passes an explicit `-timeout
+"$SIM_TIMEOUT"` (default `20m`), so the lower, reliable parallelism value
+has room to actually finish instead of looking nonviable against a hidden
+default.
+
+**This now also applies to a bare `go test -race ./...`** (both
+`scripts/cut-release.sh` step 4 and CI's own `go test` step, REQ3/REQ4,
+#1677) — the previous version of this section stated the cap did *not*
+apply there, reasoning that CI's 2–4-core runners never hit this class of
+contention. That reasoning still holds for CI (the cap is a no-op there in
+practice), but not for a bare `go test -race ./...` run by hand on a
+high-core-count release-cutting workstation, which exercises the exact same
+`tests/sim` package as `scripts/sim/run.sh` and is just as capable of
+reproducing the SIGSEGV — confirmed during the same v0.0.81 release cut
+that motivated #1677. Both invocations now source
+`scripts/lib/parallel.sh` and pass `default_race_parallel`'s value
+explicitly, so there is one shared cap, not three drifting ones, across
+`scripts/sim/run.sh`, `cut-release.sh`, and CI.
 
 Measured before/after on the 28-core machine that produced #1624
 (`scripts/sim/run.sh --all`, `-race`): capping `-parallel` at 8 (from an


### PR DESCRIPTION
Closes #1677

## What this does

Fixes four independent release-infrastructure defects surfaced across ten attempts to cut v0.0.81 (#1677). None of them were defects in the code being released — all four are in the release/test harness itself.

### 1. Bed accumulation (REQ1/REQ2)
- `cut-release.sh` step 5 now passes `--clean` to `scripts/e2e/run.sh` unconditionally, resetting the shared bed (via the existing, already-destructive `scripts/e2e/reset.sh`) before every live e2e gate run. Documented as an operational behavior change: a release cut and concurrent manual e2e testing on the shared bed can no longer safely overlap.
- `tests/e2e/lifecycle.go`'s `StopFabrikTestBed`/`StartFabrikTestBed` timeouts raised from a hardcoded 30s/40s to a shared, generous 90s, with periodic progress logging and, on timeout, `bedDiagnostics` (process liveness + a tail of `fabrik.log`) instead of a bare failure message.

### 2 & 3. Uncapped repo-wide `-race` + narrow parallelism band (REQ3/REQ4/REQ5/REQ6)
- New `scripts/lib/parallel.sh` with `default_race_parallel()` — a single, shared `min(4, host cores)` helper (ceiling lowered from #1624's `min(8, cores)`, since 8 still reproduced the TSan fork/exec SIGSEGV ~1 run in 5 on the 28-core host that produced both #1624 and #1677).
- This one helper now backs `scripts/sim/run.sh`'s `SIM_PARALLEL` default, `cut-release.sh` step 4's `go test -race ./...`, and CI's `go test -race ./...` step — no more caps that only cover some of the invocations exercising the same git-forking `tests/sim` package.
- `scripts/sim/run.sh` and `cut-release.sh` step 4 both gained an explicit `-timeout 20m` (`SIM_TIMEOUT`), since `-parallel 4` measured ~661s — over Go's previously-undocumented 10-minute default.
- `tests/sim/README.md` corrected: the claim that the cap "does not apply to a bare `go test -race ./...`" is now false and has been updated to reflect the extension.

### 4. Dead pre-gate SHA guard (REQ7/REQ8)
- Root cause confirmed: `cut-release.sh` step 4's conditional write to `plugin/known_embedded_versions.go` landed between `export_pregate_verified_sha` (step 3) and `run_pregate`'s dirty-tree check (step 5), making the tree dirty on essentially every release and defeating the guard.
- Fix: a new `allowed_dirty_regex()` function in `cut-release.sh` (reused by both step 1's existing preflight dirty-tree filter and a new `FABRIK_PREGATE_ALLOWED_DIRTY_REGEX` export) lets `run_pregate` filter out only cut-release.sh's own known, declared self-writes before deciding "dirty" — anything else still fails the check exactly as before, preserving the TOCTOU protection the check exists for.

### New ADR
`adrs/1677-release-gate-hardening.md` documents all four decisions, including the explicit reversal of ADR-1624's CI-only scoping decision for the parallelism cap.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt -s -l .` — clean.
- `go test -race ./...` (mirroring CI's own invocation, including its pre-existing `-skip TestExecute_ConfigYAMLApplied` for an unrelated, already-tracked flaky SIGINT test) — clean, both isolated and combined runs.
- `scripts/e2e/pregate_test.sh` and `scripts/cut_release_gate_test.sh` — all cases pass, including new coverage for `FABRIK_PREGATE_ALLOWED_DIRTY_REGEX` and the `--clean` wiring.
- `go test -tags e2e -run '^$' ./tests/e2e/...` (CI's e2e-compile-only check) — clean.
- **Manual multi-run validation on the 28-core host that originally reproduced the SIGSEGV** (per the issue's own Risks section — CI's 2–4 core runners can't reproduce this): ran `scripts/sim/run.sh --all` three consecutive times. Zero SIGSEGVs across all three runs (227s, 225s, 285s — all comfortably under the new 20m `SIM_TIMEOUT`).

## How to test

```
go build ./... && go vet ./... && gofmt -s -l .
go test -race ./...
bash scripts/e2e/pregate_test.sh
bash scripts/cut_release_gate_test.sh
scripts/sim/run.sh --all   # run 2-3x on a high-core-count host to confirm no SIGSEGV
```