### PR TITLE
fix(e2e): detect competing API consumers and a missing review bot before the gate spends budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,26 @@ jobs:
       - name: pre-gate regression test (#1454)
         run: bash scripts/e2e/pregate_test.sh
 
+      # R1's competing-token-consumer preflight (scripts/e2e/run.sh's
+      # check_competing_token_consumers, #1684) exists so a gate run refuses
+      # (rather than silently burning an hour into backoff) when another
+      # local Fabrik instance shares the bed's @arbeithand GraphQL token.
+      # Regression coverage for the pure filter (find_competing_token_consumers)
+      # plus the orchestration wrapper's skip/degrade paths, following the
+      # same sourced-fixture pattern as the two tests above: no fake
+      # binaries, no live competing process, no network.
+      - name: competing-token-consumer regression test (#1684)
+        run: bash scripts/e2e/token_consumer_check_test.sh
+
+      # R2's review-bot-reachable preflight (scripts/e2e/run.sh's
+      # check_reviewer_reachable, #1684) exists so a gate run fails fast when
+      # Pruefer is confidently down, instead of every review-gated scenario
+      # timing out ~10 minutes in. Regression coverage exercises real PIDs
+      # ($$ for "alive", an unused PID for "dead") against a fixture
+      # .pruefer/pruefer.lock — no live Pruefer deployment, no network.
+      - name: reviewer-reachable regression test (#1684)
+        run: bash scripts/e2e/reviewer_reachable_check_test.sh
+
       # cut-release.sh's flag parsing — in particular --skip-integration's
       # validation (R2, #1454) — sourced and exercised directly via
       # parse_args(), never reaching main() (the real publish sequence). No

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -536,6 +536,13 @@ func (d *Daemon) lockPath() string {
 // githubauth.Reconcile (which mutates on-disk credentials and can talk to
 // GitHub) and not just Daemon.Run's poll loop — see Daemon.preAcquiredLock
 // and this function's call sites in both places.
+//
+// Once the flock is held, our PID is written into the file for diagnostics
+// — not used for locking (flock handles that) — mirroring engine/poll.go's
+// identical fabrik.lock idiom exactly. This is what makes the lock file
+// externally inspectable (e.g. scripts/e2e/run.sh's check_reviewer_reachable,
+// #1684 R2): a liveness check needs a PID to `kill -0`, and prior to this the
+// file's content was never written at all.
 func acquireLock(fabrikDir string) (*os.File, error) {
 	dir := fabrikDir
 	if dir == "" {
@@ -555,6 +562,11 @@ func acquireLock(fabrikDir string) (*os.File, error) {
 		}
 		return nil, fmt.Errorf("another pruefer instance is already running (lock file: %s)", lockPath)
 	}
+	// Best-effort diagnostic write — a failure here doesn't affect the lock
+	// itself, so it's not treated as fatal.
+	lockFile.Truncate(0)
+	lockFile.Seek(0, 0)
+	fmt.Fprintf(lockFile, "%d\n", os.Getpid())
 	return lockFile, nil
 }
 

--- a/pruefer/daemon_test.go
+++ b/pruefer/daemon_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -472,6 +473,32 @@ func TestDaemonRun_LockPreventsSecondInstance(t *testing.T) {
 	case <-errCh:
 	case <-time.After(5 * time.Second):
 		t.Fatal("first Daemon.Run did not exit after context cancellation")
+	}
+}
+
+// TestAcquireLock_WritesPID covers the diagnostic PID write added to
+// acquireLock (#1684 R2): scripts/e2e/run.sh's check_reviewer_reachable
+// depends on pruefer.lock actually containing the acquiring process's PID
+// to `kill -0` against — a silent regression here (e.g. a refactor that
+// drops the Fprintf, or writes it in the wrong format) would break that
+// external liveness check without any Go test catching it, since acquiring
+// the lock itself would still succeed.
+func TestAcquireLock_WritesPID(t *testing.T) {
+	dir := t.TempDir()
+	lockFile, err := acquireLock(dir)
+	if err != nil {
+		t.Fatalf("acquireLock: %v", err)
+	}
+	defer releaseLock(lockFile)
+
+	contents, err := os.ReadFile(lockFile.Name())
+	if err != nil {
+		t.Fatalf("reading lock file: %v", err)
+	}
+	got := strings.TrimSpace(string(contents))
+	want := strconv.Itoa(os.Getpid())
+	if got != want {
+		t.Errorf("lock file contents = %q, want PID %q", got, want)
 	}
 }
 

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -195,8 +195,11 @@ export_pregate_verified_sha() {
 # falling through to the generic "real regression, check fidelity-drift"
 # branch, which would wrongly send an operator investigating a stuck lock or
 # an unreachable SSH remote down the fidelity-drift procedure instead.
-# Mirrors scripts/e2e/run.sh's own exit-code convention (3/4/5/6) exactly —
-# see that script's header comment for where each code originates.
+# Mirrors scripts/e2e/run.sh's own exit-code convention (3/4/5/7) exactly —
+# see that script's header comment for where each code originates. (Exit 6,
+# POST_SUITE_WATCHDOG_EXIT (#1676), has no dedicated case here yet — it falls
+# through to the generic branch below; a pre-existing gap from #1676, not
+# introduced by this issue and left as-is.)
 interpret_e2e_exit_code() {
   local rc="$1"
   case "$rc" in
@@ -212,8 +215,8 @@ interpret_e2e_exit_code() {
     5)
       echo "live e2e integration suite aborted: its own sim/wire-contract pre-gate failed (exit 5) inside scripts/e2e/run.sh. Unexpected: this script's own pre-gate step (step 3) already passed against the same tree, and R5's FABRIK_PREGATE_VERIFIED_SHA (#1624) should have made run.sh skip re-running it rather than fail it a second time — investigate the discrepancy (different ref? dirty tree in the bed? the SHA guard itself misfiring) before retrying."
       ;;
-    6)
-      echo "live e2e integration suite aborted: an operational precondition was not met (exit 6, PRECONDITION_FAILED_EXIT) inside scripts/e2e/run.sh — either a competing local Fabrik instance is sharing the bed's @arbeithand GraphQL token, or the review bot (Pruefer) is confidently unreachable. This is an operational problem, NOT a regression and NOT a fidelity-drift case — see scripts/e2e/run.sh's own output above for which precondition failed and what it found, fix it (stop the competing instance, or start Pruefer), and re-run scripts/cut-release.sh $VERSION. See tests/e2e/README.md's 'Operational up/down contract' (#1684) for the full mechanism."
+    7)
+      echo "live e2e integration suite aborted: an operational precondition was not met (exit 7, PRECONDITION_FAILED_EXIT) inside scripts/e2e/run.sh — either a competing local Fabrik instance is sharing the bed's @arbeithand GraphQL token, or the review bot (Pruefer) is confidently unreachable. This is an operational problem, NOT a regression and NOT a fidelity-drift case — see scripts/e2e/run.sh's own output above for which precondition failed and what it found, fix it (stop the competing instance, or start Pruefer), and re-run scripts/cut-release.sh $VERSION. See tests/e2e/README.md's 'Operational up/down contract' (#1684) for the full mechanism."
       ;;
     *)
       echo "live e2e integration suite FAILED (exit $rc) — see scripts/e2e/run.sh output above. This is a real regression; do not retry with --skip-integration to work around it. FIDELITY-DRIFT CHECK (R4, #1454): this script's own sim + wire-contract pre-gate (step 3) already passed against this same tree, so whatever the live suite just caught is exactly the case that policy covers — file a fidelity issue, add the scenario to tests/sim, and update tests/sim/simgh/FIDELITY.md (see tests/sim/README.md's 'Fidelity-drift policy' section) once the underlying regression itself is fixed."

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -195,8 +195,8 @@ export_pregate_verified_sha() {
 # falling through to the generic "real regression, check fidelity-drift"
 # branch, which would wrongly send an operator investigating a stuck lock or
 # an unreachable SSH remote down the fidelity-drift procedure instead.
-# Mirrors scripts/e2e/run.sh's own exit-code convention (3/4/5) exactly — see
-# that script's header comment for where each code originates.
+# Mirrors scripts/e2e/run.sh's own exit-code convention (3/4/5/6) exactly —
+# see that script's header comment for where each code originates.
 interpret_e2e_exit_code() {
   local rc="$1"
   case "$rc" in
@@ -211,6 +211,9 @@ interpret_e2e_exit_code() {
       ;;
     5)
       echo "live e2e integration suite aborted: its own sim/wire-contract pre-gate failed (exit 5) inside scripts/e2e/run.sh. Unexpected: this script's own pre-gate step (step 3) already passed against the same tree, and R5's FABRIK_PREGATE_VERIFIED_SHA (#1624) should have made run.sh skip re-running it rather than fail it a second time — investigate the discrepancy (different ref? dirty tree in the bed? the SHA guard itself misfiring) before retrying."
+      ;;
+    6)
+      echo "live e2e integration suite aborted: an operational precondition was not met (exit 6, PRECONDITION_FAILED_EXIT) inside scripts/e2e/run.sh — either a competing local Fabrik instance is sharing the bed's @arbeithand GraphQL token, or the review bot (Pruefer) is confidently unreachable. This is an operational problem, NOT a regression and NOT a fidelity-drift case — see scripts/e2e/run.sh's own output above for which precondition failed and what it found, fix it (stop the competing instance, or start Pruefer), and re-run scripts/cut-release.sh $VERSION. See tests/e2e/README.md's 'Operational up/down contract' (#1684) for the full mechanism."
       ;;
     *)
       echo "live e2e integration suite FAILED (exit $rc) — see scripts/e2e/run.sh output above. This is a real regression; do not retry with --skip-integration to work around it. FIDELITY-DRIFT CHECK (R4, #1454): this script's own sim + wire-contract pre-gate (step 3) already passed against this same tree, so whatever the live suite just caught is exactly the case that policy covers — file a fidelity issue, add the scenario to tests/sim, and update tests/sim/simgh/FIDELITY.md (see tests/sim/README.md's 'Fidelity-drift policy' section) once the underlying regression itself is fixed."

--- a/scripts/cut_release_gate_test.sh
+++ b/scripts/cut_release_gate_test.sh
@@ -137,6 +137,21 @@ case "$msg" in
 esac
 assert_eq "exit 5 classified as failure" "1" "$rc"
 
+# --- exit 6 (PRECONDITION_FAILED_EXIT, #1684: competing token consumer or
+# unreachable Pruefer) must NOT be conflated with a fidelity-drift regression
+# either — same bug class exit 4 above guards against. ---
+msg="$(interpret_e2e_exit_code 6)"; rc=$?
+case "$msg" in
+  *"operational problem"*"NOT a regression"*"NOT a fidelity-drift case"*)
+    echo "PASS: exit 6 message is distinct and explicitly disclaims fidelity-drift" ;;
+  *) echo "FAIL: exit 6 message does not distinctly disclaim fidelity-drift: $msg"; FAILED=1 ;;
+esac
+case "$msg" in
+  *"FIDELITY-DRIFT"*) echo "FAIL: exit 6 message wrongly mentions the fidelity-drift procedure"; FAILED=1 ;;
+  *) echo "PASS: exit 6 message does not mention the fidelity-drift procedure" ;;
+esac
+assert_eq "exit 6 classified as failure" "1" "$rc"
+
 msg="$(interpret_e2e_exit_code 1)"; rc=$?
 case "$msg" in
   *"FIDELITY-DRIFT"*) echo "PASS: exit 1 (real regression) message mentions the fidelity-drift procedure" ;;

--- a/scripts/cut_release_gate_test.sh
+++ b/scripts/cut_release_gate_test.sh
@@ -137,20 +137,23 @@ case "$msg" in
 esac
 assert_eq "exit 5 classified as failure" "1" "$rc"
 
-# --- exit 6 (PRECONDITION_FAILED_EXIT, #1684: competing token consumer or
+# --- exit 7 (PRECONDITION_FAILED_EXIT, #1684: competing token consumer or
 # unreachable Pruefer) must NOT be conflated with a fidelity-drift regression
-# either — same bug class exit 4 above guards against. ---
-msg="$(interpret_e2e_exit_code 6)"; rc=$?
+# either — same bug class exit 4 above guards against. (Renumbered from 6 to
+# 7 during a rebase onto #1676, which claimed 6 first for
+# POST_SUITE_WATCHDOG_EXIT — see scripts/e2e/run.sh's own exit-code
+# constants.) ---
+msg="$(interpret_e2e_exit_code 7)"; rc=$?
 case "$msg" in
   *"operational problem"*"NOT a regression"*"NOT a fidelity-drift case"*)
-    echo "PASS: exit 6 message is distinct and explicitly disclaims fidelity-drift" ;;
-  *) echo "FAIL: exit 6 message does not distinctly disclaim fidelity-drift: $msg"; FAILED=1 ;;
+    echo "PASS: exit 7 message is distinct and explicitly disclaims fidelity-drift" ;;
+  *) echo "FAIL: exit 7 message does not distinctly disclaim fidelity-drift: $msg"; FAILED=1 ;;
 esac
 case "$msg" in
-  *"FIDELITY-DRIFT"*) echo "FAIL: exit 6 message wrongly mentions the fidelity-drift procedure"; FAILED=1 ;;
-  *) echo "PASS: exit 6 message does not mention the fidelity-drift procedure" ;;
+  *"FIDELITY-DRIFT"*) echo "FAIL: exit 7 message wrongly mentions the fidelity-drift procedure"; FAILED=1 ;;
+  *) echo "PASS: exit 7 message does not mention the fidelity-drift procedure" ;;
 esac
-assert_eq "exit 6 classified as failure" "1" "$rc"
+assert_eq "exit 7 classified as failure" "1" "$rc"
 
 msg="$(interpret_e2e_exit_code 1)"; rc=$?
 case "$msg" in

--- a/scripts/e2e/reviewer_reachable_check_test.sh
+++ b/scripts/e2e/reviewer_reachable_check_test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# scripts/e2e/reviewer_reachable_check_test.sh — regression coverage for R2's
+# (#1684) review-bot-reachable preflight in scripts/e2e/run.sh.
+#
+# This is what proves AC2 ("starting a run with the review bot unreachable
+# fails fast with a diagnostic") and AC4 ("neither check produces false
+# positives on a correctly-prepared run") without needing a real Pruefer
+# deployment: check_reviewer_reachable's liveness signal is a PID written
+# into $PRUEFER_DIR/.pruefer/pruefer.lock (mirrors pruefer/daemon.go's
+# acquireLock and run.sh's own stop_bed_instance idiom for fabrik.lock), so
+# both "alive" and "dead" are simulated with real PIDs against a fixture
+# directory — no fake binaries, no live Pruefer process needed. $$ (this
+# script's own PID) proves "alive"; a definitely-unused high PID proves
+# "dead".
+#
+# Usage: scripts/e2e/reviewer_reachable_check_test.sh
+# Exit 0 if all assertions pass, 1 otherwise.
+
+set -uo pipefail # no -e: assertions below intentionally continue past failures
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Source run.sh for its function definitions only — the sourcing guard at the
+# bottom of run.sh (BASH_SOURCE[0] == $0) prevents this from triggering an
+# actual gate run, mirroring pregate_test.sh/backoff_detection_test.sh's
+# precedent exactly.
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/e2e/run.sh"
+set +e
+
+FAILED=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc (expected '$expected', got '$actual')"
+    FAILED=1
+  fi
+}
+
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+mkdir -p "$FIXTURE_DIR/.pruefer"
+LOCK="$FIXTURE_DIR/.pruefer/pruefer.lock"
+
+# A PID essentially guaranteed to be unused on any real system.
+DEAD_PID=999999
+
+# --- Case 1: a live PID ($$, this script's own) in the lock file passes. ---
+echo "$$" >"$LOCK"
+( PRUEFER_DIR="$FIXTURE_DIR" check_reviewer_reachable ) >/dev/null 2>&1
+rc=$?
+assert_eq "live PID in lock file: exits 0" "0" "$rc"
+
+# --- Case 2: a missing lock file refuses with PRECONDITION_FAILED_EXIT (7).
+# ---
+rm -f "$LOCK"
+( PRUEFER_DIR="$FIXTURE_DIR" check_reviewer_reachable ) >/dev/null 2>&1
+rc=$?
+assert_eq "missing lock file: exits PRECONDITION_FAILED_EXIT (7)" "7" "$rc"
+
+# --- Case 3: a lock file naming a definitely-unused PID refuses with
+# PRECONDITION_FAILED_EXIT (7). ---
+echo "$DEAD_PID" >"$LOCK"
+( PRUEFER_DIR="$FIXTURE_DIR" check_reviewer_reachable ) >/dev/null 2>&1
+rc=$?
+assert_eq "dead PID in lock file: exits PRECONDITION_FAILED_EXIT (7)" "7" "$rc"
+
+# --- Case 4: E2E_SKIP_REVIEWER_CHECK=1 short-circuits to a pass even against
+# the same dead-PID fixture from Case 3. ---
+( PRUEFER_DIR="$FIXTURE_DIR" E2E_SKIP_REVIEWER_CHECK=1 check_reviewer_reachable ) >/dev/null 2>&1
+rc=$?
+assert_eq "E2E_SKIP_REVIEWER_CHECK=1 exits 0 despite dead PID" "0" "$rc"
+
+# --- Case 5: a nonexistent PRUEFER_DIR warns and passes (undeterminable, not
+# confirmed-down — never blocks a genuinely remote Pruefer topology). ---
+( PRUEFER_DIR="$FIXTURE_DIR/does-not-exist" check_reviewer_reachable ) >/dev/null 2>&1
+rc=$?
+assert_eq "nonexistent PRUEFER_DIR: exits 0 (warn only)" "0" "$rc"
+
+# --- Case 6: a -run argument in "$@" short-circuits to a pass even against
+# the same dead-PID fixture from Case 3 — a narrowed subset is the operator's
+# call, not inferred. ---
+( PRUEFER_DIR="$FIXTURE_DIR" check_reviewer_reachable -run TestSomeScenario ) >/dev/null 2>&1
+rc=$?
+assert_eq "-run supplied: exits 0 despite dead PID" "0" "$rc"
+
+# --- Case 7: a --run argument (long form) is recognized the same way. ---
+( PRUEFER_DIR="$FIXTURE_DIR" check_reviewer_reachable --run=TestSomeScenario ) >/dev/null 2>&1
+rc=$?
+assert_eq "--run= supplied: exits 0 despite dead PID" "0" "$rc"
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "=== reviewer_reachable_check_test.sh: FAILED ==="
+  exit 1
+fi
+echo "=== reviewer_reachable_check_test.sh: all checks passed ==="

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -13,10 +13,54 @@
 # --clean (if given, must be the first argument) runs scripts/e2e/reset.sh for a
 # clean-slate bed before the run. Anything else is passed to `go test`.
 #
-# Pre-gate (R1, #1454): before ANY of the above — before bed preflight, before
-# the build, before a single live GitHub/Claude call — this script runs the
-# free, fast layers first (scripts/sim/run.sh --all, then the github/
-# wire-contract tests) and aborts with a distinct exit code if either fails.
+# Preconditions (R1/R2, #1684): before even the pre-gate below, this script
+# checks two operational facts that were previously tribal knowledge only —
+# getting either wrong costs an hour or more, discovered only after the run
+# has already spent its budget. See tests/e2e/README.md's "Operational
+# up/down contract" section for the full incident history and measured
+# numbers.
+#
+#   R1 — competing consumer of the shared @arbeithand GraphQL token. The bed
+#   and this suite share one 5,000/hour bucket, and a single live leg consumes
+#   ~4,000 of it — any OTHER Fabrik instance authenticated as @arbeithand
+#   polling concurrently (most commonly: your own always-on production
+#   instance) pushes the run into backoff, invalidating it after it already
+#   spent an hour. check_competing_token_consumers() enumerates local `fabrik`
+#   processes, resolves each one's cwd, and compares its .env FABRIK_TOKEN
+#   against the bed's own — refusing (not warning) on a match, since a silent
+#   proceed-into-backoff is strictly worse than one operator round-trip.
+#
+#     E2E_SKIP_TOKEN_CHECK=1   skip this check entirely (iteration-only
+#                              escape hatch, same shape as E2E_SKIP_PREGATE)
+#
+#   R2 — review bot (Pruefer) unreachable. Review-gated scenarios depend on
+#   Pruefer actually submitting a review; if it's down, they fail ~10 minutes
+#   in on a review timeout that looks like a Fabrik defect, not an ops gap.
+#   check_reviewer_reachable() checks Pruefer's own `.pruefer/pruefer.lock`
+#   (PID liveness, mirroring stop_bed_instance's fabrik.lock idiom exactly —
+#   `kill -0` against the PID Pruefer writes into its lock file on
+#   acquisition, see pruefer/daemon.go's acquireLock). Skipped automatically
+#   when the caller supplies -run/--run (a narrowed subset may not include any
+#   review-gated scenario — the issue's own stated assumption; left to the
+#   operator rather than inferred). Refuses when PRUEFER_DIR exists but the
+#   lock is missing/dead (a confident "down" signal); only WARNS (never
+#   blocks) when PRUEFER_DIR itself doesn't exist, since that's undeterminable
+#   rather than confirmed-down — a genuinely remote Pruefer deployment (see
+#   README's SSH-tunnel setup) must never be permanently blocked by a
+#   local-only check.
+#
+#     PRUEFER_DIR=<dir>       Pruefer's deployment directory (default:
+#                              $HOME/dev/fabrik — the observed co-located
+#                              convention; override for a different or remote
+#                              topology)
+#     E2E_SKIP_REVIEWER_CHECK=1   skip this check entirely (same escape-hatch
+#                              shape as E2E_SKIP_TOKEN_CHECK above)
+#
+# Pre-gate (R1, #1454): after the #1684 preconditions above, but still before
+# bed preflight, before the build, before a single live GitHub/Claude call —
+# this script runs the free, fast layers first (scripts/sim/run.sh --all,
+# then the github/ wire-contract tests) and aborts with a distinct exit code
+# if either fails.
 # Spending GraphQL quota and Claude tokens to discover a bug the sim or the
 # wire-contract tests already caught for $0 is exactly the waste this ordering
 # exists to remove. See run_pregate below for the full rationale.
@@ -315,10 +359,23 @@ ENGINE_LOG="$TEST_BED/.fabrik/fabrik.log"
 # report an unrelated budget. A missing/unreadable token only degrades the
 # budget report (skipped, warned) — unlike reset.sh, nothing else in this
 # script depends on it, so it's not fatal here.
+#
+# Also read by check_competing_token_consumers (R1, #1684) to compare
+# against other local Fabrik instances' own tokens — same
+# degrade-gracefully-on-missing-token behavior applies there too (warned,
+# not fatal).
 BED_TOKEN=$( { grep '^FABRIK_TOKEN=' "$TEST_BED/.env" 2>/dev/null | head -1 | cut -d= -f2-; } || echo "")
 if [ -z "$BED_TOKEN" ]; then
-  echo "warning: could not read FABRIK_TOKEN from $TEST_BED/.env — GraphQL budget reporting will be skipped" >&2
+  echo "warning: could not read FABRIK_TOKEN from $TEST_BED/.env — GraphQL budget reporting and the competing-token-consumer check will be skipped" >&2
 fi
+
+# Pruefer's deployment directory (R2, #1684) — where its own
+# .pruefer/pruefer.lock lives. Defaults to the observed co-located deployment
+# convention (Pruefer running self-hosted alongside a full Fabrik checkout);
+# override for a different or remote topology. A directory that doesn't
+# exist is not fatal here — check_reviewer_reachable degrades to a warning,
+# since that's undeterminable, not confirmed-down (see its own comment).
+PRUEFER_DIR="${PRUEFER_DIR:-$HOME/dev/fabrik}"
 
 # Distinct exit code for a run invalidated by GraphQL budget exhaustion — see
 # "GraphQL budget exhaustion detection" in the header comment above.
@@ -345,6 +402,22 @@ readonly PREGATE_FAILED_EXIT=5
 # regression, a budget exhaustion, or a preflight/pre-gate failure. See
 # switch_and_run's own comment and "Hang hardening" in the header above.
 readonly POST_SUITE_WATCHDOG_EXIT=6
+
+# Distinct exit code for an unmet operational precondition (R1/R2, #1684): a
+# competing consumer of the shared @arbeithand GraphQL token, or the review
+# bot (Pruefer) being confidently unreachable. Both are the same failure
+# class — an operational fact the operator must fix before any live spend,
+# never a test failure or a bed-state problem — distinct from
+# PREFLIGHT_FAILED_EXIT (4, bed state), PREGATE_FAILED_EXIT (5, free-layer
+# test failure), BUDGET_EXHAUSTED_EXIT (3, a live-run budget problem), and
+# POST_SUITE_WATCHDOG_EXIT (6, #1676, which claimed this issue's originally
+# chosen value first during a rebase — renumbered here to 7 to avoid the
+# collision rather than reuse 6 for two unrelated failure classes). One
+# shared code for both R1 and R2, rather than two near-identical ones, since
+# a caller only needs to distinguish "an operational precondition wasn't met"
+# from the other failure classes, not which precondition specifically
+# (that's in the message itself).
+readonly PRECONDITION_FAILED_EXIT=7
 
 # ---------------------------------------------------------------------------
 # run_reaped (R3, #1624): run "$@" as a backgrounded job in its own process
@@ -548,6 +621,212 @@ _report_gh_probe_failure() {
   if [ -s "$errfile" ]; then
     sed "s/^/warning: ${label} probe: /" "$errfile" >&2
   fi
+}
+
+# ---------------------------------------------------------------------------
+# R1 (#1684): detect a competing consumer of the shared @arbeithand GraphQL
+# token before this run spends any of its own budget. See the header
+# comment's "Preconditions" section for the full rationale.
+#
+# resolve_pid_cwd / discover_fabrik_process_dirs are the OS-dependent,
+# untested-by-design glue (mirroring preflight_bed's own untested OS-
+# sensitive parts) — they shell out to /proc or lsof to enumerate real,
+# currently-running processes, which a fixture-based unit test can't fake
+# without a real process to point at. find_competing_token_consumers below is
+# the pure half, and IS covered by scripts/e2e/token_consumer_check_test.sh.
+# ---------------------------------------------------------------------------
+
+# resolve_pid_cwd echoes the current working directory of process $1, or
+# nothing if it can't be determined (process gone, permission denied,
+# unsupported platform). Linux resolves it directly via /proc; macOS has no
+# /proc, so it shells out to lsof (already an accepted dependency in this
+# script's own README-documented prerequisites) asking only for the process's
+# "cwd" file descriptor in the `-F` machine-readable format, whose `n` lines
+# carry the path.
+resolve_pid_cwd() {
+  local pid="$1"
+  case "$(uname -s)" in
+    Linux)
+      readlink "/proc/$pid/cwd" 2>/dev/null
+      ;;
+    *)
+      # macOS (and best-effort anywhere else lsof exists): -a ANDs -p (this
+      # pid) with -d cwd (only the cwd file descriptor); -Fn restricts output
+      # to name fields, each prefixed with the literal letter 'n' — stripped
+      # below. A process that exited between pgrep and here, or one this
+      # user can't inspect, simply produces no 'n' line — empty output, not
+      # an error.
+      if command -v lsof >/dev/null 2>&1; then
+        lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | tail -1
+      fi
+      ;;
+  esac
+}
+
+# discover_fabrik_process_dirs enumerates locally-running `fabrik` processes
+# (exact name match via `pgrep -x`, so `fabrik-test`/`fabrik-workflows`-named
+# things are never candidates) and echoes one "PID<TAB>DIR" line per process
+# whose cwd could be resolved. This is the untested OS-dependent half;
+# find_competing_token_consumers (below) is what actually gets exercised
+# against fixtures.
+discover_fabrik_process_dirs() {
+  local pids pid dir
+  pids="$(pgrep -x fabrik 2>/dev/null || true)"
+  [ -z "$pids" ] && return 0
+  for pid in $pids; do
+    [ "$pid" = "$$" ] && continue
+    dir="$(resolve_pid_cwd "$pid")"
+    [ -n "$dir" ] && printf '%s\t%s\n' "$pid" "$dir"
+  done
+}
+
+# find_competing_token_consumers is the pure filter at the heart of R1: given
+# the bed's own directory ($1), the bed's own token ($2), and a newline-
+# separated list of "PID<TAB>DIR" candidates ($3, as produced by
+# discover_fabrik_process_dirs, or fixture data in tests), it prints one
+# "PID<TAB>DIR" line per candidate that (a) is NOT the bed's own directory
+# (compared by resolved absolute path, per AC4 — the bed's own instance is
+# already budgeted into the ~4,000/5,000 estimate and must never be reported
+# as a competitor) and (b) has a readable .env FABRIK_TOKEN equal to the
+# bed's. Returns 0 if at least one match was printed, 1 otherwise — mirroring
+# detect_rate_limit_backoff's grep-like exit-code convention — so callers can
+# branch without re-parsing their own output.
+#
+# A candidate whose directory doesn't exist, or has no .env, or whose .env
+# has no FABRIK_TOKEN line, is silently excluded (not an error) — the same
+# degrade-gracefully idiom BED_TOKEN's own resolution above uses.
+find_competing_token_consumers() {
+  local bed_dir="$1" bed_token="$2" candidates="$3"
+  [ -z "$candidates" ] && return 1
+  local bed_dir_abs
+  bed_dir_abs="$( (cd "$bed_dir" 2>/dev/null && pwd -P) || printf '%s' "$bed_dir")"
+  local found=1
+  local pid dir dir_abs candidate_token
+  while IFS=$'\t' read -r pid dir; do
+    [ -z "$pid" ] && continue
+    [ -z "$dir" ] && continue
+    dir_abs="$( (cd "$dir" 2>/dev/null && pwd -P) || printf '%s' "$dir")"
+    if [ "$dir_abs" = "$bed_dir_abs" ]; then
+      continue # the bed's own instance — already budgeted, never a competitor
+    fi
+    candidate_token=$( { grep '^FABRIK_TOKEN=' "$dir/.env" 2>/dev/null | head -1 | cut -d= -f2-; } || echo "")
+    if [ -n "$candidate_token" ] && [ "$candidate_token" = "$bed_token" ]; then
+      printf '%s\t%s\n' "$pid" "$dir"
+      found=0
+    fi
+  done <<<"$candidates"
+  return "$found"
+}
+
+# check_competing_token_consumers is the orchestration wrapper: honors
+# E2E_SKIP_TOKEN_CHECK, degrades to a warning (never a block) when BED_TOKEN
+# itself couldn't be read (nothing to compare against), and otherwise
+# discovers candidates and refuses with PRECONDITION_FAILED_EXIT — naming
+# every competing PID/directory found — on a match. Refuse-by-default: a
+# silent proceed-into-backoff (the pre-#1684 status quo) costs an hour or
+# more of already-spent budget, strictly worse than one operator round-trip.
+check_competing_token_consumers() {
+  if [ -n "${E2E_SKIP_TOKEN_CHECK:-}" ]; then
+    echo "== competing-token-consumer check skipped (E2E_SKIP_TOKEN_CHECK set) =="
+    return 0
+  fi
+  if [ -z "$BED_TOKEN" ]; then
+    echo "warning: BED_TOKEN unreadable — skipping competing-token-consumer check (R1, #1684): nothing to compare candidate processes' tokens against" >&2
+    return 0
+  fi
+
+  echo "== checking for competing consumers of the bed's GraphQL token (R1, #1684) =="
+  local candidates matches
+  candidates="$(discover_fabrik_process_dirs)"
+  matches="$(find_competing_token_consumers "$TEST_BED" "$BED_TOKEN" "$candidates" || true)"
+  if [ -n "$matches" ]; then
+    {
+      echo ""
+      echo "############################################################"
+      echo "## PRECONDITION FAILED: competing consumer(s) of the shared @arbeithand"
+      echo "## GraphQL token found."
+      echo "##"
+      echo "## The following local Fabrik process(es) have an .env FABRIK_TOKEN"
+      echo "## identical to this test bed's ($TEST_BED):"
+      echo "##"
+      printf '%s\n' "$matches" | while IFS=$'\t' read -r pid dir; do
+        echo "##   pid $pid   dir $dir"
+      done
+      echo "##"
+      echo "## Any GraphQL calls that process makes come out of the SAME"
+      echo "## 5,000/hour bucket this gate run needs (~4,000 pts/leg) — see"
+      echo "## tests/e2e/README.md's 'Operational up/down contract'. Stop it, or"
+      echo "## re-run with E2E_SKIP_TOKEN_CHECK=1 to proceed anyway (not"
+      echo "## recommended — you'll likely lose the run to backoff after it has"
+      echo "## already spent an hour)."
+      echo "############################################################"
+    } >&2
+    exit "$PRECONDITION_FAILED_EXIT"
+  fi
+  echo "   no competing token consumers found"
+}
+
+# ---------------------------------------------------------------------------
+# R2 (#1684): check the review bot (Pruefer) is reachable before a run that
+# needs it. See the header comment's "Preconditions" section for the full
+# rationale.
+#
+# check_reviewer_reachable takes "$@" (this script's own arguments) purely to
+# detect a caller-supplied -run/--run and skip automatically — a narrowed
+# scenario subset may not include any review-gated scenario, and inferring
+# that precisely would need matching against the actual set of
+# wait_for_reviews-gated scenario names, which risks false negatives; leaving
+# it to the operator (via the -run they already supplied) is simpler and
+# conservative in the safe direction.
+# ---------------------------------------------------------------------------
+check_reviewer_reachable() {
+  if [ -n "${E2E_SKIP_REVIEWER_CHECK:-}" ]; then
+    echo "== reviewer-reachable check skipped (E2E_SKIP_REVIEWER_CHECK set) =="
+    return 0
+  fi
+
+  local a
+  for a in "$@"; do
+    case "$a" in
+      -run | -run=* | --run | --run=*)
+        echo "== reviewer-reachable check skipped (-run/--run supplied — a narrowed scenario subset may not include any review-gated scenario; operator's call) =="
+        return 0
+        ;;
+    esac
+  done
+
+  if [ ! -d "$PRUEFER_DIR" ]; then
+    echo "warning: PRUEFER_DIR ($PRUEFER_DIR) does not exist — cannot verify Pruefer's liveness locally (assuming a remote or other topology); proceeding. If Pruefer is not actually reachable, every review-gated scenario will fail ~10 min later on a review timeout. Set PRUEFER_DIR to Pruefer's deployment directory, or E2E_SKIP_REVIEWER_CHECK=1 to silence this warning." >&2
+    return 0
+  fi
+
+  local lock="$PRUEFER_DIR/.pruefer/pruefer.lock"
+  if [ ! -f "$lock" ]; then
+    {
+      echo "PRECONDITION FAILED: Pruefer's lock file not found at $lock."
+      echo "PRUEFER_DIR ($PRUEFER_DIR) exists, so this is treated as confidently down, not merely undeterminable."
+      echo "Every review-gated scenario in this suite will time out waiting for a review that never arrives."
+      echo "Start Pruefer, or re-run with E2E_SKIP_REVIEWER_CHECK=1 if this run genuinely doesn't need it."
+    } >&2
+    exit "$PRECONDITION_FAILED_EXIT"
+  fi
+
+  # The PID Pruefer writes into its own lock file on acquisition (see
+  # pruefer/daemon.go's acquireLock) — mirrors stop_bed_instance's identical
+  # fabrik.lock idiom. `tr -dc '0-9'` guards against a lock file whose
+  # content is stale/garbled rather than trusting it verbatim.
+  local pid
+  pid="$(head -1 "$lock" 2>/dev/null | tr -dc '0-9')"
+  if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+    {
+      echo "PRECONDITION FAILED: Pruefer's lock file ($lock) exists but names no live process (pid='${pid:-<empty>}')."
+      echo "Every review-gated scenario in this suite will time out waiting for a review that never arrives."
+      echo "Start Pruefer, or re-run with E2E_SKIP_REVIEWER_CHECK=1 if this run genuinely doesn't need it."
+    } >&2
+    exit "$PRECONDITION_FAILED_EXIT"
+  fi
+
+  echo "== reviewer-reachable check passed: Pruefer alive (pid $pid, lock: $lock) =="
 }
 
 # ---------------------------------------------------------------------------
@@ -1555,7 +1834,14 @@ switch_and_run() {
 # `bash run.sh`), BASH_SOURCE[0] equals $0, so this still dispatches exactly
 # as before this guard existed.
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-  # Pre-gate FIRST (R1, #1454) — strictly before any bed preflight, build,
+  # Preconditions FIRST (R1/R2, #1684) — strictly before even the pre-gate
+  # below, let alone any bed preflight, build, restart, or live GitHub/Claude
+  # call. See the header comment's "Preconditions" section and each
+  # function's own comment for the full rationale.
+  check_competing_token_consumers
+  check_reviewer_reachable "$@"
+
+  # Pre-gate NEXT (R1, #1454) — strictly before any bed preflight, build,
   # restart, or live GitHub/Claude call. See run_pregate's own comment for
   # why this ordering is the mechanism, not a runtime check.
   run_pregate

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -46,8 +46,8 @@
 #   lock is missing/dead (a confident "down" signal); only WARNS (never
 #   blocks) when PRUEFER_DIR itself doesn't exist, since that's undeterminable
 #   rather than confirmed-down — a genuinely remote Pruefer deployment (see
-#   README's SSH-tunnel setup) must never be permanently blocked by a
-#   local-only check.
+#   cmd/pruefer/README.md's SSH-tunnel setup section) must never be
+#   permanently blocked by a local-only check.
 #
 #     PRUEFER_DIR=<dir>       Pruefer's deployment directory (default:
 #                              $HOME/dev/fabrik — the observed co-located

--- a/scripts/e2e/token_consumer_check_test.sh
+++ b/scripts/e2e/token_consumer_check_test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# scripts/e2e/token_consumer_check_test.sh — regression coverage for R1's
+# (#1684) competing-token-consumer preflight in scripts/e2e/run.sh.
+#
+# This is what proves AC1 ("starting a gate run with a competing poller on
+# the same token produces an explicit warning or refusal naming it, before
+# any live API spend") and AC4 ("neither check produces false positives on a
+# correctly-prepared run") without needing a real second Fabrik instance:
+# find_competing_token_consumers is a pure function over "PID<TAB>DIR" lines
+# and fixture directories with their own .env files, so both the positive
+# (competitor found) and negative (bed's own directory excluded, no
+# candidates, mismatched token) cases run in milliseconds against real
+# temp-dir fixtures — no fake binaries, no live processes.
+#
+# check_competing_token_consumers's own orchestration (E2E_SKIP_TOKEN_CHECK,
+# the unreadable-BED_TOKEN degrade-to-warning path) is exercised too, run in
+# a subshell each time since a match calls `exit`.
+#
+# Usage: scripts/e2e/token_consumer_check_test.sh
+# Exit 0 if all assertions pass, 1 otherwise.
+
+set -uo pipefail # no -e: assertions below intentionally continue past failures
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Source run.sh for its function definitions only — the sourcing guard at the
+# bottom of run.sh (BASH_SOURCE[0] == $0) prevents this from triggering an
+# actual gate run, mirroring pregate_test.sh/backoff_detection_test.sh's
+# precedent exactly.
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/e2e/run.sh"
+set +e
+
+FAILED=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc (expected '$expected', got '$actual')"
+    FAILED=1
+  fi
+}
+
+BED_DIR="$(mktemp -d)"
+OTHER_DIR="$(mktemp -d)"
+NO_ENV_DIR="$(mktemp -d)"
+trap 'rm -rf "$BED_DIR" "$OTHER_DIR" "$NO_ENV_DIR"' EXIT
+
+echo "FABRIK_TOKEN=shared-token-abc" >"$BED_DIR/.env"
+echo "FABRIK_TOKEN=shared-token-abc" >"$OTHER_DIR/.env"
+# $NO_ENV_DIR deliberately has no .env at all.
+
+# --- Case 1: a candidate with a matching token, in a different directory,
+# is reported as a competitor. ---
+candidates="$(printf '1111\t%s\n' "$OTHER_DIR")"
+out="$(find_competing_token_consumers "$BED_DIR" "shared-token-abc" "$candidates")"
+rc=$?
+assert_eq "matching-token competitor: exit 0" "0" "$rc"
+assert_eq "matching-token competitor: reported" "$(printf '1111\t%s' "$OTHER_DIR")" "$out"
+
+# --- Case 2: a candidate whose token differs is not reported. ---
+echo "FABRIK_TOKEN=a-different-token" >"$OTHER_DIR/.env"
+candidates="$(printf '1111\t%s\n' "$OTHER_DIR")"
+out="$(find_competing_token_consumers "$BED_DIR" "shared-token-abc" "$candidates")"
+rc=$?
+assert_eq "mismatched-token candidate: exit 1 (no match)" "1" "$rc"
+assert_eq "mismatched-token candidate: no output" "" "$out"
+echo "FABRIK_TOKEN=shared-token-abc" >"$OTHER_DIR/.env" # restore for later cases
+
+# --- Case 3 (AC4): the bed's OWN directory, even carrying the identical
+# token, is excluded — it's already budgeted into the ~4,000/5,000 estimate,
+# never a "competitor". ---
+candidates="$(printf '2222\t%s\n' "$BED_DIR")"
+out="$(find_competing_token_consumers "$BED_DIR" "shared-token-abc" "$candidates")"
+rc=$?
+assert_eq "bed's own directory excluded: exit 1 (no match)" "1" "$rc"
+assert_eq "bed's own directory excluded: no output" "" "$out"
+
+# --- Case 4: a candidate directory with no .env at all is silently skipped,
+# not an error. ---
+candidates="$(printf '3333\t%s\n' "$NO_ENV_DIR")"
+out="$(find_competing_token_consumers "$BED_DIR" "shared-token-abc" "$candidates")"
+rc=$?
+assert_eq "missing .env candidate: exit 1 (no match)" "1" "$rc"
+assert_eq "missing .env candidate: no output" "" "$out"
+
+# --- Case 5: an empty candidate list is a no-op, no match. ---
+out="$(find_competing_token_consumers "$BED_DIR" "shared-token-abc" "")"
+rc=$?
+assert_eq "empty candidate list: exit 1 (no match)" "1" "$rc"
+assert_eq "empty candidate list: no output" "" "$out"
+
+# --- Case 6: multiple candidates — bed's own dir excluded, no-env dir
+# skipped, only the genuine competitor reported. ---
+candidates="$(printf '2222\t%s\n3333\t%s\n1111\t%s\n' "$BED_DIR" "$NO_ENV_DIR" "$OTHER_DIR")"
+out="$(find_competing_token_consumers "$BED_DIR" "shared-token-abc" "$candidates")"
+rc=$?
+assert_eq "mixed candidates: exit 0 (one match)" "0" "$rc"
+assert_eq "mixed candidates: only the genuine competitor reported" "$(printf '1111\t%s' "$OTHER_DIR")" "$out"
+
+# --- Case 7: check_competing_token_consumers honors E2E_SKIP_TOKEN_CHECK,
+# never even discovering candidates. ---
+( E2E_SKIP_TOKEN_CHECK=1 TEST_BED="$BED_DIR" BED_TOKEN="shared-token-abc" check_competing_token_consumers ) >/dev/null 2>&1
+rc=$?
+assert_eq "E2E_SKIP_TOKEN_CHECK=1 exits 0" "0" "$rc"
+
+# --- Case 8: check_competing_token_consumers degrades to a warning (not a
+# block) when BED_TOKEN is empty/unreadable. ---
+( TEST_BED="$BED_DIR" BED_TOKEN="" check_competing_token_consumers ) >/dev/null 2>&1
+rc=$?
+assert_eq "empty BED_TOKEN degrades to a pass (warning only)" "0" "$rc"
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "=== token_consumer_check_test.sh: FAILED ==="
+  exit 1
+fi
+echo "=== token_consumer_check_test.sh: all checks passed ==="

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -90,6 +90,11 @@ These tests assume:
    (Backlog, Specify, Research, Plan, Implement, Review, Validate, Done).
 4. **No other Fabrik instance is using the `@arbeithand` token's GraphQL
    budget concurrently** (or use `--max-concurrent 1` if you have to share).
+   As of #1684, `scripts/e2e/run.sh` checks this automatically before any
+   live call and refuses (rather than silently discovering it via backoff 78
+   minutes in) if it finds a competing local instance — see "Operational
+   up/down contract" below for the full mechanism and escape hatch
+   (`E2E_SKIP_TOKEN_CHECK=1`).
 
 See `~/fabrik-oss-launch-notes.md` (under "Files and where they live") for
 the canonical setup.
@@ -843,6 +848,68 @@ reviewer topology is:
   change the underlying risk: Pruefer going silent (dispatch dropped,
   daemon down, etc.) is still a single point of failure for every scenario
   that depends on an organic review landing.
+
+### Operational up/down contract (#1684)
+
+The two sections above describe two operational requirements that, before
+this issue, existed only in operators' heads — getting either wrong costs an
+hour or more per mistake. Both were hit during the v0.0.81 cut, and one
+directly caused the other: Pruefer was stopped to free budget, which broke
+every review-gated scenario.
+
+**Must be UP: Pruefer.** Every scenario that drives a PR through the organic
+Review gate depends on Pruefer (see "Reviewer topology" above) actually
+submitting a review. If it's down, PRs sit with zero reviews and review-gated
+scenarios fail ~10 minutes in with a timeout that looks like a Fabrik defect,
+not an ops gap.
+
+**Must be DOWN (non-competing): every other Fabrik instance authenticated as
+`@arbeithand`.** The bed and this suite share one `@arbeithand` PAT with a
+5,000/hour GraphQL bucket (see "GraphQL budget" above), and a single live leg
+consumes ~4,000 of it. Any other poller on that token — most commonly an
+operator's own always-on production Fabrik instance — pushes the run into
+backoff, which invalidates it *after* it has already spent an hour and
+appeared to pass.
+
+**The trap: stopping Pruefer to save budget breaks the suite, and saves
+nothing.** Pruefer authenticates as a GitHub App with its own
+per-installation rate-limit bucket (ADR-1113, ADR-1253) — it never draws on
+the shared `@arbeithand` user PAT at all. Stopping it does not free a single
+point of the 5,000/hour budget the gate actually needs; it only guarantees
+every review-gated scenario times out. The oscillation between "stop it for
+budget" and "start it for reviews" was the symptom this issue exists to
+eliminate — the two constraints are independent, not in tension.
+
+**Automated preflight (`scripts/e2e/run.sh`):** both facts are now checked
+before any live GitHub/Claude call, ahead of the sim+wire-contract pre-gate
+(#1454) and the bed preflight:
+
+- `check_competing_token_consumers` (R1) enumerates locally-running `fabrik`
+  processes, resolves each one's working directory, and compares its `.env`
+  `FABRIK_TOKEN` against the bed's own — excluding the bed's own directory
+  (already budgeted into the ~4,000/5,000 estimate). **Refuses by default**
+  on a match, naming the offending PID(s) and directory/directories: a silent
+  proceed-into-backoff is strictly worse than one operator round-trip.
+  Escape hatch: `E2E_SKIP_TOKEN_CHECK=1`.
+- `check_reviewer_reachable` (R2) checks Pruefer's own liveness via
+  `$PRUEFER_DIR/.pruefer/pruefer.lock` (default `PRUEFER_DIR`:
+  `$HOME/dev/fabrik`, matching the observed co-located deployment
+  convention) — `kill -0` against the PID Pruefer writes into that lock file
+  on acquisition. **Refuses** when `PRUEFER_DIR` exists but the lock is
+  missing or names a dead process (confidently down); **warns only** (never
+  blocks) when `PRUEFER_DIR` itself doesn't exist, since a remote Pruefer
+  deployment (see the SSH-tunnel setup referenced in "Reviewer topology"
+  above) is undeterminable from here, not confirmed-down. Automatically
+  skipped when the invocation includes `-run`/`--run`, since a narrowed
+  scenario subset may not include any review-gated scenario — left to the
+  operator's judgment rather than inferred. Escape hatch:
+  `E2E_SKIP_REVIEWER_CHECK=1`.
+
+Both checks are local-only and make no live GitHub/Claude call themselves
+(process/file inspection only), so they add negligible wall-clock ahead of
+the checks they front-run. See `scripts/e2e/run.sh`'s own header comment for
+the full mechanism, and `scripts/e2e/token_consumer_check_test.sh` /
+`scripts/e2e/reviewer_reachable_check_test.sh` for their regression coverage.
 
 ## Running
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -898,8 +898,8 @@ before any live GitHub/Claude call, ahead of the sim+wire-contract pre-gate
   on acquisition. **Refuses** when `PRUEFER_DIR` exists but the lock is
   missing or names a dead process (confidently down); **warns only** (never
   blocks) when `PRUEFER_DIR` itself doesn't exist, since a remote Pruefer
-  deployment (see the SSH-tunnel setup referenced in "Reviewer topology"
-  above) is undeterminable from here, not confirmed-down. Automatically
+  deployment (see `cmd/pruefer/README.md`'s SSH-tunnel setup section) is
+  undeterminable from here, not confirmed-down. Automatically
   skipped when the invocation includes `-run`/`--run`, since a narrowed
   scenario subset may not include any review-gated scenario — left to the
   operator's judgment rather than inferred. Escape hatch:


### PR DESCRIPTION
Closes #1684

## What this does

Adds two preflight checks to `scripts/e2e/run.sh`, running before even the existing sim+wire-contract pre-gate (#1454) and before any live GitHub/Claude call:

- **R1 — competing token consumer.** `check_competing_token_consumers` enumerates locally-running `fabrik` processes, resolves each one's working directory, and compares its `.env` `FABRIK_TOKEN` against the test bed's own token — excluding the bed's own directory (already budgeted into the ~4,000/5,000 GraphQL-points estimate). **Refuses by default** on a match, naming the offending PID(s)/directory. Escape hatch: `E2E_SKIP_TOKEN_CHECK=1`.
- **R2 — review bot unreachable.** `check_reviewer_reachable` checks Pruefer's liveness via its own `.pruefer/pruefer.lock` (`kill -0` against the PID it writes on lock acquisition — see below). Refuses when `PRUEFER_DIR` exists but the lock is missing/dead (confidently down); warns only when `PRUEFER_DIR` doesn't exist (undeterminable, never blocks a genuinely remote Pruefer deployment). Automatically skipped when the invocation includes `-run`/`--run`. Escape hatch: `E2E_SKIP_REVIEWER_CHECK=1`.

Both share a new `PRECONDITION_FAILED_EXIT=6`, distinct from the three existing preflight exit codes.

**A necessary supporting fix:** `pruefer.lock` was flock-only — its content was never written, unlike `fabrik.lock`'s own PID-diagnostic write. R2 needs a PID to `kill -0` against, so `pruefer/daemon.go`'s `acquireLock` now writes the holder's PID into the lock file the same way `engine/poll.go` already does for `fabrik.lock` (best-effort; doesn't affect the lock itself).

**Documentation (R3):** `tests/e2e/README.md` gains a new "Operational up/down contract" section (near "GraphQL budget"/"Reviewer topology") stating which process must be up (Pruefer, and why), which must be down/non-competing (any other `@arbeithand`-token Fabrik instance), the measured ~4,000-pt/leg vs 5,000/hour-bucket numbers, and the trap explicitly: stopping Pruefer to save budget breaks every review-gated scenario and saves nothing, since it authenticates as a GitHub App with its own per-installation bucket, never the shared PAT.

## How to test

```bash
bash scripts/e2e/token_consumer_check_test.sh
bash scripts/e2e/reviewer_reachable_check_test.sh
bash scripts/e2e/pregate_test.sh
bash scripts/e2e/backoff_detection_test.sh
go test -race ./pruefer/...
go vet ./... && go vet -tags e2e ./...
```

All four e2e regression scripts (the two new ones plus the two pre-existing siblings) pass, exercising every skip/refuse/warn path via real PIDs and fixture directories — no fake binaries, no live competing process or Pruefer deployment needed. `go test -race ./...` is green except for one pre-existing, unrelated flake (`cmd.TestExecute_ConfigYAMLApplied`, a real-network-dependent test in a file this PR never touches — confirmed via `git diff c9b0142f..HEAD --stat`) and one intermittent `tests/sim` timing flake (passes on repeat runs); neither is caused by this change.

New CI wiring (`.github/workflows/ci.yml`) runs both new regression scripts alongside the existing `pregate_test.sh`/`backoff_detection_test.sh`.