### PR TITLE
fix(tui): stop labelling every comment pass as a pending retry

### DIFF
--- a/tui/detail.go
+++ b/tui/detail.go
@@ -16,6 +16,7 @@ type DetailItem struct {
 	StageName      string
 	StageModel     string
 	IsActive       bool // true for in-flight jobs, false for history entries
+	IsComment      bool // comment-processing invocation rather than a stage run
 	Elapsed        time.Duration
 	Duration       time.Duration
 	Success        bool
@@ -71,6 +72,12 @@ func (d DetailPanelComponent) View(width int) string {
 		} else if !item.Completed {
 			if item.TurnLimited {
 				statusStr = "incomplete (turn limit)"
+			} else if item.IsComment {
+				// Comment processing never emits FABRIK_STAGE_COMPLETE by design —
+				// see the same guard in tui/history.go's rebuildViewportContent for
+				// the full reasoning. "incomplete" would be wrong for every comment
+				// pass, not just some of them.
+				statusStr = "success"
 			} else {
 				statusStr = "incomplete"
 			}

--- a/tui/detail_test.go
+++ b/tui/detail_test.go
@@ -65,6 +65,51 @@ func TestDetailPanel_TurnLimitStatus(t *testing.T) {
 	}
 }
 
+// TestDetailPanel_CommentPassStatus is the detail-panel half of the comment-pass
+// fix (the history-pane half is TestViewHistory_TurnLimitClassification's
+// comment cases). The two are separate implementations rather than shared code,
+// so each needs its own coverage — a regression in one would not be caught by
+// the other.
+//
+// Comment processing never emits FABRIK_STAGE_COMPLETE: every fabrik-*-comment
+// skill forbids it ("Do NOT output FABRIK_STAGE_COMPLETE ... returns control to
+// the engine without advancing the pipeline"). Completed is therefore false for
+// every comment invocation by design, and reporting that as "incomplete"
+// mislabels all of them.
+func TestDetailPanel_CommentPassStatus(t *testing.T) {
+	var d DetailPanelComponent
+	d.SetVisible(true)
+	d.SetWidth(80)
+
+	// A comment pass that succeeded, was not blocked, and did not hit the turn
+	// cap is complete — not "incomplete".
+	d.SetItem(&DetailItem{IssueNumber: 1, StageName: "Review", IsComment: true, Success: true, TurnLimited: false, Completed: false})
+	view := d.View(80)
+	if !strings.Contains(view, "Status:   success") {
+		t.Errorf("expected %q for a completed comment pass, got: %q", "Status:   success", view)
+	}
+	if strings.Contains(view, "incomplete") {
+		t.Errorf("comment pass must not render as incomplete, got: %q", view)
+	}
+
+	// A comment pass CAN genuinely exhaust its turn budget — the comment skills
+	// carry their own "If You Hit the Turn Limit" section — so that must still
+	// be reported rather than swallowed by the branch above.
+	d.SetItem(&DetailItem{IssueNumber: 2, StageName: "Review", IsComment: true, Success: true, TurnLimited: true, Completed: false})
+	view = d.View(80)
+	if !strings.Contains(view, "incomplete (turn limit)") {
+		t.Errorf("expected %q for a turn-capped comment pass, got: %q", "incomplete (turn limit)", view)
+	}
+
+	// The stage-run path is unchanged: a stage that ends without the marker
+	// really will be re-dispatched.
+	d.SetItem(&DetailItem{IssueNumber: 3, StageName: "Implement", IsComment: false, Success: true, TurnLimited: false, Completed: false})
+	view = d.View(80)
+	if !strings.Contains(view, "Status:   incomplete") || strings.Contains(view, "turn limit") {
+		t.Errorf("stage run without the marker must still render as incomplete, got: %q", view)
+	}
+}
+
 // TestUpdate_EnterKey_ActivePane_TogglesDetailPanel verifies enter in active pane toggles the detail panel.
 func TestUpdate_EnterKey_ActivePane_TogglesDetailPanel(t *testing.T) {
 	m := New(30, ProjectInfo{}, "", nil, nil, 0, false)

--- a/tui/history.go
+++ b/tui/history.go
@@ -247,10 +247,22 @@ func (h *HistoryPaneComponent) rebuildViewportContent(innerWidth int) {
 			status = activeStyle.Render("?")
 			result = dimStyle.Render("  (input needed)")
 		} else if !he.Completed {
-			status = dimStyle.Render("↻")
 			if he.TurnLimited {
+				status = dimStyle.Render("↻")
 				result = dimStyle.Render("  (turn limit)")
+			} else if he.IsComment {
+				// Comment processing never emits FABRIK_STAGE_COMPLETE — every
+				// fabrik-*-comment skill forbids it outright ("Do NOT output
+				// FABRIK_STAGE_COMPLETE ... returns control to the engine without
+				// advancing the pipeline"), because a comment pass answers a comment
+				// rather than completing a stage. So Completed is false for every
+				// comment invocation by design, and reading it as "incomplete, will
+				// be retried" mislabels every one of them. A comment pass that
+				// succeeded, was not blocked on input and did not hit the turn cap
+				// did exactly what it was asked to do.
+				status = successStyle.Render("✓")
 			} else {
+				status = dimStyle.Render("↻")
 				result = dimStyle.Render("  (retry)")
 			}
 		} else {

--- a/tui/history_test.go
+++ b/tui/history_test.go
@@ -311,6 +311,33 @@ func TestViewHistory_TurnLimitClassification(t *testing.T) {
 			want:  "✓",
 			unwnt: []string{"(error)", "(turn limit)", "(retry)", "(input needed)"},
 		},
+		{
+			// A comment pass never emits FABRIK_STAGE_COMPLETE — every
+			// fabrik-*-comment skill forbids it — so Completed is false for all of
+			// them. Rendering that as "(retry)" mislabelled every comment row in
+			// the history pane; a successful comment pass is simply done.
+			name:  "comment pass is complete, not a retry",
+			entry: HistoryEntry{IssueNumber: 6, StageName: "Review", IsComment: true, Success: true, TurnLimited: false, Completed: false},
+			want:  "✓",
+			unwnt: []string{"(error)", "(turn limit)", "(retry)", "(input needed)"},
+		},
+		{
+			// A comment pass CAN genuinely hit the turn cap (the comment skills
+			// have their own "If You Hit the Turn Limit" section), so that case
+			// must keep reporting it rather than being swallowed by the above.
+			name:  "turn-capped comment pass still reports the cap",
+			entry: HistoryEntry{IssueNumber: 7, StageName: "Review", IsComment: true, Success: true, TurnLimited: true, Completed: false},
+			want:  "(turn limit)",
+			unwnt: []string{"(error)", "(retry)"},
+		},
+		{
+			// The stage-run path is unchanged: a stage that ends without the
+			// marker really will be re-dispatched.
+			name:  "stage run without the marker still shows retry",
+			entry: HistoryEntry{IssueNumber: 8, StageName: "Implement", IsComment: false, Success: true, TurnLimited: false, Completed: false},
+			want:  "(retry)",
+			unwnt: []string{"(error)", "(turn limit)"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/tui/model.go
+++ b/tui/model.go
@@ -854,6 +854,7 @@ func (m *Model) prepareDetailItem() {
 			Title:          entry.Title,
 			StageName:      entry.StageName,
 			StageModel:     entry.StageModel,
+			IsComment:      entry.IsComment,
 			Success:        entry.Success,
 			TurnLimited:    entry.TurnLimited,
 			Completed:      entry.Completed,


### PR DESCRIPTION
The history pane renders every comment-processing invocation as `↻ (retry)`, and the detail panel as `incomplete`. Neither is true, and it affects **all** of them rather than some.

Spotted in the TUI, where the giveaway is a row like:

```
#221  Validate 💬 ↻  00:30  ...  6/200 turns  $0.72  (retry)  Replace in-proce
```

Six turns of two hundred. Nothing was exhausted; nothing is pending.

## Cause

Both sites key purely on `HistoryEntry.Completed`, which is set from whether the invocation emitted `FABRIK_STAGE_COMPLETE`:

```go
} else if !he.Completed {
    status = dimStyle.Render("↻")
    if he.TurnLimited { result = "  (turn limit)" } else { result = "  (retry)" }
}
```

But comment processing is **instructed never to emit that marker**. Every `fabrik-*-comment` skill says so outright:

> **Do NOT output `FABRIK_STAGE_COMPLETE`.** Comment processing in Review returns control to the engine without advancing the pipeline.

> - **Do not signal stage completion** — never output `FABRIK_STAGE_COMPLETE`

So `Completed` is false for every comment invocation by design, and the status branch reads that as "incomplete, will be retried". A comment pass that did exactly what it was asked gets the same glyph as a stage run that ran out of turns and is genuinely queued for re-dispatch.

The information needed to tell them apart was already there: `history.go` reads `he.IsComment` thirty-five lines below the status branch, purely to append the 💬 glyph. This PR uses it in the branch where it changes the meaning.

## Change

A comment pass that succeeded, was not blocked on input, and did not hit the turn cap is complete — `✓` in the history pane, `success` in the detail panel.

Deliberately narrow:

- **turn-limited comment passes still report `(turn limit)`.** The comment skills have their own "If You Hit the Turn Limit" section, so that state is real for them and must not be swallowed by the new branch.
- **the stage-run path is untouched.** A stage ending without the marker really will be re-dispatched, and still shows `↻ (retry)`.
- `DetailItem` gains `IsComment` (populated in `prepareDetailItem`) because it did not carry the field; nothing else consumes it.

## Tests

Three cases added to `TestViewHistory_TurnLimitClassification`: the comment-complete case, the turn-capped comment case, and the unchanged stage-run case — so the fix cannot be satisfied by an implementation that simply stops reporting turn limits, or one that changes stage behaviour.

**Demonstrated non-vacuous:** neutralising the new branch (`else if false`) fails `comment_pass_is_complete,_not_a_retry` specifically, and only that case.

`gofmt`, `go vet ./...`, and `go test -race ./tui/` all clean.

## Related

Same class as #1178, which corrected this exact branch once before for turn-budget exhaustion — `tui/detail_test.go` still carries a comment referencing that fix. This is the second reading of `Completed` that turned out not to mean what the renderer assumed.

Filed from a local worktree as a small self-contained fix, with no issue behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGkxr9LQo5Lme39rfQMJ3W
