### PR TITLE
test: close #1684's orchestrator wiring gap, record guard-testing convention (R1–R4)

### DIFF
--- a/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
@@ -135,6 +135,22 @@ git diff "origin/$base_branch"..HEAD
 - Do tests cover error paths, not just happy paths?
 - Are tests actually testing behavior, not just exercising code?
 - Run the test suite: do all tests pass?
+- (#1687, R1) If a test's purpose is to prove a specific guard rejects, does its
+  assertion distinguish that guard's rejection from every other possible rejection
+  reason — not just a boolean/exit-code outcome that any rejection would satisfy? See
+  `tests/sim/README.md`'s "Guard-testing convention" for the worked example and fix
+  pattern.
+- (#1687, R2) If a guard is deliberately redundant with another (defence-in-depth), does
+  the code or its test state how the guard's loss would be detected — either via a
+  directly-testable extracted predicate, or an explicit unreachable-by-construction note?
+  See `tests/sim/README.md`'s same section.
+- (#1687, R3) Does every new guard have at least one test exercising its call site end to
+  end (not only a unit test of the guard's own logic in isolation) — proving the
+  orchestrator actually invokes the guard and observably acts on its result?
+- (#1687, R4 — neutralization in review) For any change adding a new guard: does the PR
+  description or review notes state which mutation the new test catches? Confirm that
+  mutation was actually run against the guard and observed to turn the test red — not
+  merely reasoned about. A guard test that hasn't been neutralized hasn't been trusted.
 
 **Security**:
 - No command injection, SQL injection, XSS, or path traversal

--- a/scripts/e2e/token_consumer_check_test.sh
+++ b/scripts/e2e/token_consumer_check_test.sh
@@ -112,6 +112,47 @@ assert_eq "E2E_SKIP_TOKEN_CHECK=1 exits 0" "0" "$rc"
 rc=$?
 assert_eq "empty BED_TOKEN degrades to a pass (warning only)" "0" "$rc"
 
+# --- Case 9 (#1687, R3): wiring-level coverage of
+# check_competing_token_consumers' match->refuse path itself. Cases 1-6
+# above only prove find_competing_token_consumers (the pure detection unit)
+# works in isolation; cases 7-8 only exercise check_competing_token_consumers
+# paths that never reach the match/refuse logic. Nothing before this proved
+# the orchestrator actually calls discover_fabrik_process_dirs, feeds its
+# output through find_competing_token_consumers, and exit()s
+# PRECONDITION_FAILED_EXIT on a positive match — replacing
+# check_competing_token_consumers' body with `return 0` left every prior
+# case green. Here discover_fabrik_process_dirs (the untestable,
+# OS-dependent half) is overridden with a canned candidate so the
+# orchestrator's own match-handling can be exercised deterministically,
+# without a real competing process.
+#
+# Left intentionally un-restored: this is the last case in the file, so the
+# override can't leak into a later one — a future editor appending Case 10+
+# after this should redefine discover_fabrik_process_dirs back to its
+# original body first (or move this case to the end again).
+discover_fabrik_process_dirs() { printf '9999\t%s\n' "$OTHER_DIR"; }
+out="$( ( TEST_BED="$BED_DIR" BED_TOKEN="shared-token-abc" check_competing_token_consumers ) 2>&1 )"
+rc=$?
+assert_eq "orchestrator match: exits PRECONDITION_FAILED_EXIT" "$PRECONDITION_FAILED_EXIT" "$rc"
+if ! printf '%s' "$out" | grep -q "PRECONDITION FAILED"; then
+  echo "FAIL: orchestrator match: output names PRECONDITION FAILED"
+  FAILED=1
+else
+  echo "PASS: orchestrator match: output names PRECONDITION FAILED"
+fi
+if ! printf '%s' "$out" | grep -q "9999"; then
+  echo "FAIL: orchestrator match: output names competing PID"
+  FAILED=1
+else
+  echo "PASS: orchestrator match: output names competing PID"
+fi
+if ! printf '%s' "$out" | grep -qF "$OTHER_DIR"; then
+  echo "FAIL: orchestrator match: output names competing dir"
+  FAILED=1
+else
+  echo "PASS: orchestrator match: output names competing dir"
+fi
+
 if [ "$FAILED" -ne 0 ]; then
   echo "=== token_consumer_check_test.sh: FAILED ==="
   exit 1

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -837,6 +837,77 @@ first, not a defect in the refund mechanism itself.
   `CommentReviewCompleted` (both of which commit), mirroring
   `simclaude/scripts.go`'s existing naming convention.
 
+## Guard-testing convention (R1–R4, #1687)
+
+Three times in one working session, a guard (a check that rejects, refuses, or falls
+through under some condition) was deletable with no test failing. In every case the
+guard's *logic* was thoroughly tested while the *wiring that invokes it* was not — the
+neutralization discipline this package's own `nonvacuity.sh` (below) already applies at
+package scale, just never asked of an individual guard's own test. None of the three
+underlying guards were ever wrong; this is about whether a regression in one would be
+noticed, and none would have been caught by reading the tests — every suite looked
+thorough until someone actually ran the mutation.
+
+The convention below (R1–R3; R4 is a review-time obligation and lives in the
+`fabrik-review` skill instead) applies identically whether the guard is a Go function
+returning `(bool, string)` or a bash function with an exit code and stdout — it is not
+specific to this package's own Go-and-`simgh` regime.
+
+**R1 — Assert the reason, not just the outcome.** A test proving a specific guard
+rejects must distinguish that guard's rejection from every other possible rejection
+reason — e.g. via a shared fixture that makes every earlier condition pass, so the guard
+under test is the only thing that can reject, plus an assertion on the returned
+reason/error string, not only the boolean/exit-code outcome.
+
+*Worked example:* `engine/merge_train_test.go`'s
+`TestSingletonFastPathEligible_BaseNotAncestor_FallsThrough` (part of the
+`singletonFastPathEligible` battery, `engine/merge_train.go`) originally asserted only
+`eligible == false` — true for *any* rejection. Its own fixture defaulted to zero check
+runs, which rejects via an unrelated arm, so deleting the ancestry guard's own
+`if behind > 0 { return false }` left the test green: it passed for the wrong reason. The
+fix (now in place) rebuilds the fixture so every other guard passes and the ancestry
+check is the only thing that can reject, then asserts `strings.Contains(reason, ...)` on
+the specific rejection string. Every sibling test in that same battery follows the
+identical shape.
+
+**R2 — Make deliberate redundancy accountable.** When a guard is deliberately redundant
+with another (defence-in-depth), the code or its test must state how the guard's loss
+would be detected. If the honest answer is "it wouldn't," either extract it into a
+directly-testable predicate, or record explicitly that it is unreachable-by-construction
+and therefore untested.
+
+*Worked example:* the merge train's R8 fail-closed identity check
+(`shouldCloseStaleTrainPR`, `engine/merge_train.go`) is deliberately redundant with R7 —
+removing either alone changes no observable behavior, which is the point, and which made
+the loss of one layer undetectable by outcome alone. It was extracted into its own
+directly-testable predicate specifically so it can be asserted in isolation:
+`engine/merge_train_test.go`'s test carries the comment "deleting
+`shouldCloseStaleTrainPR`'s identity check turns this test red (AC1)" — stating exactly
+how the guard's loss would be caught, per this rule.
+
+**R3 — Test the wiring, not only the unit.** Every guard needs at least one test case
+where the orchestrator/call site is exercised end to end and the guard's effect is
+observable — not only a unit test of the guard's own logic in isolation.
+
+*Worked example:* `scripts/e2e/run.sh`'s `check_competing_token_consumers` orchestrator
+wraps a well-tested pure detection function (`find_competing_token_consumers`, six cases
+in `scripts/e2e/token_consumer_check_test.sh`) but, until #1687, had no test exercising
+its own match→refuse path — replacing its body with `return 0` left every existing case
+green. The fix added a case that overrides the untestable OS-dependent half
+(`discover_fabrik_process_dirs`) with a canned candidate, then asserts the orchestrator
+itself detects the match and exits `PRECONDITION_FAILED_EXIT` — proving the wiring, not
+just the detection logic it calls.
+
+**Neutralize before trusting a guard test.** The only way any of the three gaps above
+were found was by actually running the mutation the test claims to catch and observing
+whether it stayed green — not by reading the test. `tests/sim/simgh/nonvacuity.sh`
+applies the identical discipline at package scale (neutralize each modeled `simgh`
+behavior in turn, fail loudly if any leaves the suite green); treat a new guard test the
+same way before trusting it. The review-time version of this obligation (R4 — state which
+mutation a new guard's test catches, and show it turning the test red) is a
+`fabrik-review` skill checklist item, not a sim-bed one, since it's an author obligation
+applied during review, not a testing-layer property.
+
 ## Running it
 
 ```bash


### PR DESCRIPTION
Closes #1687

## What this does

Addresses #1687 — a recurring pattern found across three prior issues (#1622, #1644, #1684) where a guard was deletable with no test failing, because the guard's *logic* was tested but the *wiring that invokes it* wasn't, or the test asserted the outcome rather than the specific rejection reason. This PR closes the one remaining open gap (#1684) and records the convention so it's caught earlier next time.

**AC2 — closes the #1684 orchestrator gap** (`scripts/e2e/token_consumer_check_test.sh`): adds Case 9, a wiring-level test of `check_competing_token_consumers` (`scripts/e2e/run.sh`). Cases 1–6 already covered `find_competing_token_consumers` (the pure detection unit) in isolation; cases 7–8 only exercised orchestrator paths that never reach the match/refuse logic. Nothing proved the orchestrator itself calls `discover_fabrik_process_dirs`, feeds the result through `find_competing_token_consumers`, and exits `PRECONDITION_FAILED_EXIT` on a match. Case 9 overrides the untestable OS-dependent half (`discover_fabrik_process_dirs`) with a canned candidate, then asserts the orchestrator's own exit code and refusal output (naming the failure, the competing PID, and the competing directory).

**Self-applied R4 (neutralization in review):** verified manually — replacing `check_competing_token_consumers`'s body with `return 0` turns Case 9 red (all four of its assertions fail) while cases 1–8 stay green; reverting restores a clean pass. No behavioral change to `check_competing_token_consumers` itself.

**AC1 — guidance recorded** in two places, split by audience:
- `tests/sim/README.md`: new "Guard-testing convention" section stating R1 (assert the reason, not the outcome), R2 (make deliberate redundancy accountable), and R3 (test the wiring, not only the unit), each with its worked example (#1644's `TestSingletonFastPathEligible_BaseNotAncestor_FallsThrough`, #1622's `shouldCloseStaleTrainPR`, and this PR's Case 9), plus a pointer to `simgh/nonvacuity.sh` as the same neutralization discipline already applied at package scale.
- `plugin/fabrik-workflows/skills/fabrik-review/SKILL.md`: four new bullets in the Testing checklist (R1–R4), with R4 as the actionable review-time check — cross-referencing the README section rather than duplicating the worked examples.

**AC3 — spot-check already recorded**: the [Research stage comment on #1687](https://github.com/handarbeit/fabrik/issues/1687#issuecomment-thread) reviewed all 36 `_FallsThrough`/`_Rejects`-named tests across the 9 files the issue names, and flagged three candidates showing the "asserts outcome, not reason" shape (`github/contents_test.go`'s two `Rejects*` tests, `cmd/init_test.go`'s `TestRunInit_RejectsInvalidURL`, `engine/ci_test.go`'s `TestCheckCIGate_MergeableStateBlocked_FallsThroughToCheckRuns`). Per the issue's own Scope, fixing those is available follow-up work, not required here.

## No behavior changes

None of the three underlying guards (#1622's R8 identity check, #1644's ancestry check, #1684's `check_competing_token_consumers`) were modified — this is test-coverage and documentation only, confirmed by Research/Plan and reflected in the diff (no Go source touched at all).

## How to test

```bash
bash scripts/e2e/token_consumer_check_test.sh   # all 9 cases, standalone
go vet ./...
go test -race ./...
```

Note: `go test -race ./...` has one pre-existing, unrelated failure — `TestExecute_ConfigYAMLApplied` in `cmd/` (a live-network-dependent SIGINT-shutdown test hitting real GitHub API 404s) — reproducible identically on `main` at the branch point (`c0961347`), since this PR touches no Go source.