### PR TITLE
fix(e2e): the release gate budget probe measured nothing; move suite reads to REST

### DIFF
--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -262,11 +262,12 @@
 # present as a pass just as easily as a fail — and short-circuits any
 # remaining legs immediately (exit, not return).
 #
-# This is a log-scrape, not a live `gh api rate_limit` polling loop: it needs
-# zero new API calls against the very budget being protected, and the log
-# line already fires at the moment of interest. Each leg is also bracketed
-# with a `gh api rate_limit` call before/after (a REST metadata call, free
-# against the GraphQL budget), scoped to the bed's own FABRIK_TOKEN (read
+# This is a log-scrape, not a live budget-polling loop: it needs zero new API
+# calls against the very budget being protected, and the log line already
+# fires at the moment of interest. Each leg is also bracketed with a
+# graphql_budget_remaining call before/after (an inline `rateLimit` query
+# costing 1 point each — see that function for why the REST endpoint cannot
+# be used despite being free), scoped to the bed's own FABRIK_TOKEN (read
 # from $TEST_BED/.env into $BED_TOKEN, mirroring reset.sh's gh_() token-
 # scoping precedent — the ambient `gh` CLI's own auth is very likely a
 # different identity than the bed's @arbeithand token and would silently
@@ -1079,8 +1080,14 @@ preflight_bed_start() {
 
   # No --auto-upgrade: it would replace this freshly built binary with a
   # release mid-suite (README item 17).
-  echo "== preflight: starting bed instance (-notui, no --auto-upgrade) =="
-  ( cd "$TEST_BED" && nohup ./fabrik -notui > "$TEST_BED/bed-run.log" 2>&1 & )
+  #
+  # -poll is passed explicitly, matching StartFabrikTestBed's own launch (see
+  # defaultBedPollSeconds in tests/e2e/lifecycle.go for the measured budget
+  # rationale). Both launch sites must agree: switch_and_run restarts the bed
+  # through the Go path on every mode switch, so a cadence set only here would
+  # be silently reverted for the legs that actually matter.
+  echo "== preflight: starting bed instance (-notui -poll ${BED_POLL_SECONDS}s, no --auto-upgrade) =="
+  ( cd "$TEST_BED" && nohup ./fabrik -notui -poll "$BED_POLL_SECONDS" > "$TEST_BED/bed-run.log" 2>&1 & )
 
   # The startup banner goes to the engine's STDOUT (captured in bed-run.log),
   # while ENGINE_LOG holds the structured per-item log — which never contains
@@ -1155,11 +1162,43 @@ PARALLEL="${E2E_PARALLEL:-4}"
 # header comment's "on"-leg-specific parallelism cap section (#1527).
 PARALLEL_ON="${E2E_PARALLEL_ON:-2}"
 
-# Timeout for the ancillary `gh api rate_limit` budget-report calls (R1,
-# #1676) — see with_timeout's own comment above. These are lightweight REST
-# metadata calls (see "GraphQL budget exhaustion detection" above), so 30s is
-# generous, not tight; override with E2E_GH_API_TIMEOUT.
+# Timeout for the ancillary budget-report calls (R1, #1676) — see
+# with_timeout's own comment above. These are single lightweight GraphQL
+# queries (see graphql_budget_remaining below), so 30s is generous, not
+# tight; override with E2E_GH_API_TIMEOUT.
 GH_API_TIMEOUT="${E2E_GH_API_TIMEOUT:-30}"
+
+# Bed engine poll cadence, passed as -poll to both launch sites. Kept in sync
+# with defaultBedPollSeconds in tests/e2e/lifecycle.go, which carries the
+# measured budget rationale and honours the same E2E_BED_POLL_SECONDS override.
+BED_POLL_SECONDS="${E2E_BED_POLL_SECONDS:-60}"
+
+# graphql_budget_remaining prints the caller-scoped token's actual remaining
+# GraphQL budget, via GraphQL's own inline `rateLimit` field.
+#
+# It does NOT use `gh api rate_limit` (the REST endpoint), which this script
+# used until it was measured: for the bed's token that endpoint reports a
+# permanently full bucket. Observed 2026-09-06, same token, seconds apart:
+#
+#   inline rateLimit : 4248 remaining, reset 15:44   (5 board queries -> 4243)
+#   REST rate_limit  : 5000 remaining, reset 16:33   (5 board queries -> 5000)
+#
+# The REST figure never moved. Every "GraphQL budget (leg: X): 5000 -> 5000
+# remaining (consumed 0 pts)" line this script has ever printed was that dead
+# gauge, including for legs that demonstrably burned thousands of points and
+# for the off leg of the v0.0.82 gate, which tripped the engine's own 20%
+# backoff while this probe was still reporting a full bucket. A budget report
+# that cannot go down is worse than no report: it was read as evidence of
+# headroom before launching runs that then exhausted the budget.
+#
+# The inline query costs 1 point per call (2 per leg, before + after). That
+# is the price of the report being true, and is negligible against a leg.
+# Takes the token as $1 and scopes GH_TOKEN itself, rather than being wrapped
+# in `env GH_TOKEN=... `: `env` execs a binary and cannot invoke a shell
+# function. (with_timeout runs "$@" & in-shell, so it invokes this fine.)
+graphql_budget_remaining() {
+  GH_TOKEN="$1" gh api graphql -f query='query { rateLimit { remaining } }' --jq '.data.rateLimit.remaining'
+}
 
 # Window for R2's post-suite watchdog (#1676) — see switch_and_run's own
 # comment for the full mechanism. Everything the watchdog covers (draining
@@ -1531,7 +1570,7 @@ switch_and_run() {
     local budget_before_tmp budget_before_err
     budget_before_tmp="$(mktemp)"
     budget_before_err="$(mktemp)"
-    if with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' \
+    if with_timeout "$GH_API_TIMEOUT" graphql_budget_remaining "$BED_TOKEN" \
         > "$budget_before_tmp" 2>"$budget_before_err"; then
       budget_before="$(cat "$budget_before_tmp" 2>/dev/null || echo "")"
     else
@@ -1737,7 +1776,7 @@ switch_and_run() {
     local budget_after_tmp budget_after_err
     budget_after_tmp="$(mktemp)"
     budget_after_err="$(mktemp)"
-    if with_timeout "$GH_API_TIMEOUT" env "GH_TOKEN=$BED_TOKEN" gh api rate_limit --jq '.resources.graphql.remaining' \
+    if with_timeout "$GH_API_TIMEOUT" graphql_budget_remaining "$BED_TOKEN" \
         > "$budget_after_tmp" 2>"$budget_after_err"; then
       budget_after="$(cat "$budget_after_tmp" 2>/dev/null || echo "")"
     else

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -350,13 +350,10 @@ func WaitForIssueLabel(t *testing.T, env *Env, repo string, issueNumber int, lab
 // IssueLabels returns the current labels on the issue.
 func IssueLabels(t *testing.T, env *Env, repo string, issueNumber int) []string {
 	t.Helper()
-	out, err := ghOutput(env, "issue", "view", fmt.Sprint(issueNumber), "-R", repo,
-		"--json", "labels", "--jq", "[.labels[].name]")
+	labels, err := restIssueLabels(env, repo, issueNumber)
 	if err != nil {
 		t.Fatalf("read labels for %s#%d: %v", repo, issueNumber, err)
 	}
-	var labels []string
-	_ = json.Unmarshal([]byte(strings.TrimSpace(out)), &labels)
 	return labels
 }
 
@@ -593,25 +590,12 @@ func WaitForLabelAbsent(t *testing.T, env *Env, repo string, issueNumber int, la
 // instead of t.Fatalf'ing. Used by long-running pollers so a single transient
 // gh failure doesn't kill an otherwise-healthy multi-minute wait.
 func tryIssueState(env *Env, repo string, issueNumber int) (string, error) {
-	out, err := ghOutput(env, "issue", "view", fmt.Sprint(issueNumber), "-R", repo, "--json", "state", "--jq", ".state")
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(out), nil
+	return restIssueState(env, repo, issueNumber)
 }
 
 // tryIssueLabels is the non-fatal counterpart to IssueLabels.
 func tryIssueLabels(env *Env, repo string, issueNumber int) ([]string, error) {
-	out, err := ghOutput(env, "issue", "view", fmt.Sprint(issueNumber), "-R", repo,
-		"--json", "labels", "--jq", "[.labels[].name]")
-	if err != nil {
-		return nil, err
-	}
-	var labels []string
-	if uerr := json.Unmarshal([]byte(strings.TrimSpace(out)), &labels); uerr != nil {
-		return nil, fmt.Errorf("parse labels: %w", uerr)
-	}
-	return labels, nil
+	return restIssueLabels(env, repo, issueNumber)
 }
 
 // AssertLabelWasApplied queries the issue's timeline events and asserts the
@@ -758,8 +742,7 @@ func CreateThrowawayBaseBranch(t *testing.T, env *Env, repo, branchName string) 
 // to the repo default.
 func PRBaseRef(t *testing.T, env *Env, repo string, prNumber int) string {
 	t.Helper()
-	out, err := ghOutput(env, "pr", "view", fmt.Sprint(prNumber), "-R", repo,
-		"--json", "baseRefName", "--jq", ".baseRefName")
+	out, err := restPRField(env, repo, prNumber, ".base.ref")
 	if err != nil {
 		t.Fatalf("read base ref of PR #%d in %s: %v\n%s", prNumber, repo, err, out)
 	}
@@ -777,7 +760,7 @@ func mapKeys(m map[string]bool) []string {
 // IssueState returns "OPEN" or "CLOSED".
 func IssueState(t *testing.T, env *Env, repo string, issueNumber int) string {
 	t.Helper()
-	out, err := ghOutput(env, "issue", "view", fmt.Sprint(issueNumber), "-R", repo, "--json", "state", "--jq", ".state")
+	out, err := restIssueState(env, repo, issueNumber)
 	if err != nil {
 		t.Fatalf("read state for %s#%d: %v", repo, issueNumber, err)
 	}
@@ -1127,6 +1110,95 @@ func ghOutput(env *Env, args ...string) (string, error) {
 	cmd.Env = append(os.Environ(), "GH_TOKEN="+env.GHToken)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+// ---------------------------------------------------------------------------
+// REST read helpers (#1695)
+//
+// `gh issue view`, `gh pr view`, `gh issue list` and `gh pr list` are served by
+// GitHub's GraphQL API and cost ~1 GraphQL point per call. `gh api <path>` is
+// REST, which has its own separate 5,000/hour bucket that these runs leave
+// almost entirely idle. Measured on the bed's token, 10 calls each:
+//
+//   gh issue view --json labels        -> ~10 GraphQL points
+//   gh api repos/{o}/{r}/issues/{n}    ->   0 GraphQL points
+//
+// The suite and the bed engine share the one GraphQL budget, and the engine
+// cannot be moved off it (ProjectV2 and much of its work is GraphQL-only). The
+// suite's polling loops can be, and they are the larger share: ~20 scenarios
+// each polling labels every 30-60s across a ~70 minute leg is thousands of
+// points spent on reads REST serves for free. That is what pushed the v0.0.82
+// off leg into the engine's own rate-limit backoff.
+//
+// These helpers exist so the gh-vs-REST field-shape differences are handled
+// once. They are NOT cosmetic — each was verified against live data, and two
+// of them are outright traps:
+//
+//	gh --json field   REST equivalent                               verified
+//	state (issue)     .state, uppercased        CLOSED vs closed    yes
+//	state (PR)        .merged ? MERGED : upper  REST /pulls .state  yes
+//	                  never reports MERGED — merged-ness is a
+//	                  separate boolean, so a naive .state mapping
+//	                  makes every merge assertion silently wrong
+//	baseRefName       .base.ref                                     yes
+//	headRefName       .head.ref                                     yes
+//	author.login      .user.login                                   yes
+//	isDraft           .draft                                        yes
+//	createdAt         .created_at                                   yes
+//	labels[].name     labels[].name             (identical)         yes
+//
+// tryPRComments already used REST before this change and is the precedent.
+// ---------------------------------------------------------------------------
+
+// restIssueState returns the issue's state in gh's uppercase form (OPEN/CLOSED).
+func restIssueState(env *Env, repo string, issueNumber int) (string, error) {
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		return "", fmt.Errorf("bad repo: %q", repo)
+	}
+	out, err := ghOutput(env, "api", fmt.Sprintf("repos/%s/%s/issues/%d", owner, name, issueNumber),
+		"--jq", ".state | ascii_upcase")
+	return strings.TrimSpace(out), err
+}
+
+// restIssueLabels returns the issue's label names.
+func restIssueLabels(env *Env, repo string, issueNumber int) ([]string, error) {
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		return nil, fmt.Errorf("bad repo: %q", repo)
+	}
+	out, err := ghOutput(env, "api", fmt.Sprintf("repos/%s/%s/issues/%d", owner, name, issueNumber),
+		"--jq", "[.labels[].name]")
+	if err != nil {
+		return nil, fmt.Errorf("%v: %s", err, strings.TrimSpace(out))
+	}
+	var labels []string
+	if uerr := json.Unmarshal([]byte(strings.TrimSpace(out)), &labels); uerr != nil {
+		return nil, fmt.Errorf("parse labels: %w", uerr)
+	}
+	return labels, nil
+}
+
+// restPRState returns the PR's state in gh's form: OPEN, CLOSED, or MERGED.
+// REST's own .state is only open/closed — see the trap note above.
+func restPRState(env *Env, repo string, prNumber int) (string, error) {
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		return "", fmt.Errorf("bad repo: %q", repo)
+	}
+	out, err := ghOutput(env, "api", fmt.Sprintf("repos/%s/%s/pulls/%d", owner, name, prNumber),
+		"--jq", `if .merged then "MERGED" else (.state | ascii_upcase) end`)
+	return strings.TrimSpace(out), err
+}
+
+// restPRField returns a single jq-selected field from the PR's REST object.
+func restPRField(env *Env, repo string, prNumber int, jq string) (string, error) {
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		return "", fmt.Errorf("bad repo: %q", repo)
+	}
+	out, err := ghOutput(env, "api", fmt.Sprintf("repos/%s/%s/pulls/%d", owner, name, prNumber), "--jq", jq)
+	return strings.TrimSpace(out), err
 }
 
 func lastNonEmpty(s string) string {
@@ -2020,7 +2092,7 @@ func AssertPRAuthorIsExpectedIdentity(t *testing.T, env *Env, repo string, prNum
 	if !ok {
 		t.Fatalf("bad repo: %q", repo)
 	}
-	out, err := ghOutput(env, "pr", "view", fmt.Sprint(prNumber), "-R", repo, "--json", "author", "--jq", ".author.login")
+	out, err := restPRField(env, repo, prNumber, ".user.login")
 	if err != nil {
 		t.Fatalf("read author of %s/%s PR #%d: %v\n%s", owner, name, prNumber, err, out)
 	}

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -282,7 +282,14 @@ func pollSleep(base time.Duration) {
 // Override with E2E_POLL_INTERVAL (any time.ParseDuration value) to tune without
 // a code change — e.g. E2E_POLL_INTERVAL=15s to restore the old cadence when
 // running a single scenario in isolation, where budget is not a constraint.
-const defaultPollBase = 30 * time.Second
+// Raised 30s -> 60s after the v0.0.82 gate (#1695). The suite and the bed
+// engine share one 5,000/hour GraphQL budget; the off leg tripped the engine's
+// own 20% backoff and was invalidated after every one of its 47 tests had
+// already passed. This is the suite's half of that fix — the bed engine's half
+// is defaultBedPollSeconds in lifecycle.go. Neither alone was enough: the
+// v0.0.81 cut set E2E_POLL_INTERVAL=60s and still hit backoff, because the
+// engine kept polling at 30s throughout.
+const defaultPollBase = 60 * time.Second
 
 func pollBase() time.Duration {
 	if s := os.Getenv("E2E_POLL_INTERVAL"); s != "" {

--- a/tests/e2e/lifecycle.go
+++ b/tests/e2e/lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -152,6 +153,37 @@ func StopFabrikTestBed(t *testing.T, env *Env) {
 	}
 }
 
+// defaultBedPollSeconds is the bed engine's poll cadence for e2e runs, passed
+// explicitly as -poll rather than left to the engine's own 30s default.
+//
+// The bed and this suite share one 5,000/hour GraphQL budget, and the engine is
+// the larger consumer: measured from its own inline rateLimit telemetry during
+// the v0.0.82 gate, ~1,320 points/hour while a leg is active (~310/hour idle,
+// where the idle-upgrade backoff already stretches the cadence). Over a ~70
+// minute leg that is ~1,500 points before the suite's own calls are counted,
+// which is what put the off leg into the engine's 20% backoff and invalidated
+// it. Halving the cadence halves that share.
+//
+// Passed as a flag, not left to FABRIK_POLL in the bed's .env: the flag is
+// visible in `ps`, travels with the repo rather than with one machine's
+// untracked .env, and cannot be silently lost when the bed is re-provisioned.
+// cmd/root.go only consults FABRIK_POLL when -poll is still at its default, so
+// an explicit flag deliberately wins over the .env.
+//
+// Override with E2E_BED_POLL_SECONDS, mirroring E2E_POLL_INTERVAL's convention
+// — e.g. to restore the 30s cadence for a single scenario in isolation, where
+// budget is not a constraint and detection latency matters more.
+const defaultBedPollSeconds = "60"
+
+func bedPollSeconds() string {
+	if s := os.Getenv("E2E_BED_POLL_SECONDS"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			return s
+		}
+	}
+	return defaultBedPollSeconds
+}
+
 // StartFabrikTestBed launches a fresh detached bed from the bed's own binary and
 // waits for it to acquire the lock. No-op if already running.
 func StartFabrikTestBed(t *testing.T, env *Env) {
@@ -165,7 +197,7 @@ func StartFabrikTestBed(t *testing.T, env *Env) {
 		t.Fatalf("bed binary not found at %s: %v", bin, err)
 	}
 
-	cmd := exec.Command(bin, "-notui")
+	cmd := exec.Command(bin, "-notui", "-poll", bedPollSeconds())
 	cmd.Dir = env.FabrikTestDir
 	// Strip GITHUB_TOKEN so Fabrik uses FABRIK_TOKEN (@arbeithand) from the bed's
 	// .env — an ambient token must not hijack the bed's identity.

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -328,8 +328,7 @@ func waitForPRClosed(t *testing.T, env *Env, repo string, prNumber int, timeout 
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for {
-		out, err := ghOutput(env, "pr", "view", fmt.Sprint(prNumber), "-R", repo,
-			"--json", "state", "--jq", ".state")
+		out, err := restPRState(env, repo, prNumber)
 		if err == nil {
 			switch strings.TrimSpace(out) {
 			case "CLOSED", "MERGED":
@@ -440,8 +439,7 @@ func waitForLandingPRDetail(t *testing.T, env *Env, repo string, memberPRNum int
 // assertPRMerged fails unless the PR is in the MERGED state.
 func assertPRMerged(t *testing.T, env *Env, repo string, prNumber int) {
 	t.Helper()
-	out, err := ghOutput(env, "pr", "view", fmt.Sprint(prNumber), "-R", repo,
-		"--json", "state", "--jq", ".state")
+	out, err := restPRState(env, repo, prNumber)
 	if err != nil {
 		t.Fatalf("could not read state of integration PR #%d: %v\n%s", prNumber, err, out)
 	}

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -288,10 +288,23 @@ func WaitForIssueComment(t *testing.T, env *Env, repo string, issueNumber int, s
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for {
-		out, err := ghOutput(env, "issue", "view", fmt.Sprint(issueNumber), "-R", repo,
-			"--json", "comments", "--jq", ".comments[].body")
-		if err == nil && strings.Contains(out, substring) {
-			return
+		// REST, via tryPRComments: GitHub numbers issues and PRs in one space
+		// and serves both from repos/{o}/{r}/issues/{n}/comments, so this is
+		// the same endpoint for an issue as for a PR despite the helper's
+		// name. Verified against live issues (not PRs) with comments: bodies
+		// identical to `gh issue view --json comments`.
+		//
+		// This loop is why it matters: 10s interval for up to 25 minutes in
+		// mergetrain_bisect_test.go is ~150 GraphQL points per use on the old
+		// path (found in review — it was missed in the first pass, not
+		// deliberately left).
+		bodies, err := tryPRComments(env, repo, issueNumber)
+		if err == nil {
+			for _, b := range bodies {
+				if strings.Contains(b, substring) {
+					return
+				}
+			}
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for comment containing %q on %s#%d", substring, repo, issueNumber)


### PR DESCRIPTION
## Problem

The v0.0.82 gate's **off leg passed all 47 of its tests and was then invalidated** by GraphQL rate-limit backoff. Three separate defects combined to make that both inevitable and invisible.

### 1. The budget report was reading a dead gauge

`run.sh` bracketed each leg with `gh api rate_limit --jq .resources.graphql.remaining`. For the bed's token that REST endpoint reports a permanently full bucket. Measured, same token, seconds apart:

```
inline rateLimit : 4248 remaining, reset 15:44   (5 board queries -> 4243)
REST rate_limit  : 5000 remaining, reset 16:33   (5 board queries -> 5000)
```

The REST figure never moves. **Every `GraphQL budget (leg: X): 5000 -> 5000 remaining (consumed 0 pts)` line this script has ever printed was that dead gauge** — including for the off leg, which tripped the engine's own 20% backoff while the probe still reported a full bucket.

A budget report that cannot go down is worse than no report: it was read as evidence of headroom before launching runs that then exhausted the budget. It is also why the true cost of a leg has never been known.

### 2. Nothing configured the bed engine's poll cadence

The bed ran at the engine's 30s default. From its own inline telemetry: **~1,320 GraphQL points/hour while a leg is active** (~310 idle, where idle-upgrade backoff already stretches the cadence). Over a ~70 minute leg that is ~1,500 points before the suite's own calls are counted.

The v0.0.81 cut set `E2E_POLL_INTERVAL=60s` and still hit backoff — because that only throttles the *suite*, and the engine kept polling at 30s throughout.

### 3. The suite spent GraphQL budget on reads REST serves for free

`gh issue view`, `gh pr view`, `gh issue list`, `gh pr list` are served by GraphQL. `gh api <path>` is REST — **a separate 5,000/hour bucket these runs leave almost entirely idle**. Measured, 10 calls each:

| call | GraphQL cost |
|---|---|
| `gh issue view --json labels` | ~10 pts |
| `gh api repos/{o}/{r}/issues/{n}` | **0 pts** |

~20 scenarios each polling labels every 30–60s across a ~70 minute leg is thousands of points spent on reads REST would serve free.

## Changes

**`c61f25ee`** — `graphql_budget_remaining` replaces both REST probe sites with an inline `rateLimit` query (1 point per call, 2 per leg — the price of the report being true). It takes the token as an argument rather than being wrapped in `env GH_TOKEN=...`, because `env` execs a binary and cannot invoke a shell function; `with_timeout` runs `"$@" &` in-shell and invokes it fine.

Both bed launch sites now pass `-poll` explicitly (`defaultBedPollSeconds=60`, override `E2E_BED_POLL_SECONDS`), and `defaultPollBase` goes 30s → 60s. **Both launch sites must agree**: `switch_and_run` restarts the bed through the Go path on every mode switch, so a cadence set only in `run.sh` would be silently reverted for exactly the legs that matter. Passed as a flag rather than left to `FABRIK_POLL` in the bed's untracked `.env`, so it travels with the repo.

**`efcff197`** — the read paths that run inside wait loops move to REST behind four helpers, so the gh-vs-REST field-shape differences are handled once: `IssueLabels`, `tryIssueState`, `tryIssueLabels`, `IssueState`, `PRBaseRef`, `PRAuthor`, and the merge-train `waitForPRClosed`/`assertPRMerged` state reads. `tryPRComments` already used REST and is the precedent.

## The trap in the REST conversion

Two shape differences are correctness issues, not cosmetics:

- **REST `/pulls/{n}.state` is only `open`/`closed` and NEVER reports merged** — merged-ness is a separate `.merged` boolean. A naive `.state` mapping would have made *every merge assertion in the suite silently wrong*, including the one guarding #1692's singleton fast path. `restPRState` uses `if .merged then "MERGED" else (.state|ascii_upcase) end`.
- `gh` reports `OPEN`/`CLOSED`/`MERGED` uppercase; REST reports lowercase.

Every mapping was verified against live data before conversion — 5 PRs across open/closed/merged × state/baseRef/author, 5 issues × state/labels — all equivalent. The mapping table is in the helper block's doc comment.

## Verification

- `graphql_budget_remaining` tracks consumption: 4190 → 4185 across 5 known queries, where the REST probe it replaces stayed pinned at 5000.
- REST/gh equivalence check passed on live data (table above).
- `go test -race ./...` green; `bash -n scripts/e2e/run.sh` and `go vet -tags e2e ./tests/e2e/` clean.

**Not verified: a real leg.** These are budget-and-instrumentation changes; proving the numbers needs a live run with the dev daemon down (R1 competing-consumer check). I'd rather have this reviewed before spending an hour of live budget on it, particularly the REST mappings.

## Left on GraphQL deliberately

`tryPRReviewState` (needs a second REST call for reviews) and the issue-list search paths (REST search semantics differ). Both one-shot or low-frequency; ~1 point per call, and the conversion risk outweighs the saving.

## Related

Same family as #1676/#1677/#1693/#1694 — the release gate's own failure modes being quieter than the failures it exists to catch. This one is the quietest yet: the instrument that was supposed to detect budget exhaustion reported full headroom while the budget was being exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Vo5Gx9AYEk9rfA3jY7SBt
