### PR TITLE
fix(e2e): detached bed leaked run.sh output pipe, wedging the gate and silently skipping legs

### DIFF
--- a/scripts/e2e/hang_hardening_test.sh
+++ b/scripts/e2e/hang_hardening_test.sh
@@ -413,9 +413,15 @@ mkfifo "$drain_fifo"
 { tee "$drain_json" >/dev/null; } < "$drain_fifo" &
 drain_consumer=$!
 exec 4> "$drain_fifo"
+drain_holder_pidfile="$drain_dir/holder.pid"
 (
   echo '{"Action":"output","Output":"hello"}' >&4
   ( sleep 60 ) >&4 2>/dev/null &     # the "bed": outlives go test holding fd 4
+  # Record it: this is a GRANDchild, reparented the moment its parent subshell
+  # exits, so neither this case's own cleanup nor the trailing `pkill -P $$`
+  # can reach it by process tree. Without the pidfile it lingers as an orphan
+  # for the full 60s after the script finishes (found in review).
+  echo $! > "$drain_holder_pidfile"
 ) &
 drain_suite=$!
 exec 4>&-
@@ -454,6 +460,9 @@ fi
 # #1694 hung the gate — turning a legible FAIL into an unexplained stall.
 kill -TERM "$drain_consumer" 2>/dev/null || true
 wait "$drain_consumer" 2>/dev/null || true
+# Read the pidfile BEFORE rm -rf takes the directory with it.
+drain_holder="$(cat "$drain_holder_pidfile" 2>/dev/null || echo "")"
+[ -n "$drain_holder" ] && kill -TERM "$drain_holder" 2>/dev/null
 pkill -P $$ >/dev/null 2>&1 || true
 rm -rf "$drain_dir"
 

--- a/scripts/e2e/hang_hardening_test.sh
+++ b/scripts/e2e/hang_hardening_test.sh
@@ -394,6 +394,92 @@ else
 fi
 rm -f "$probe_err"
 
+# Case 16 (#1694): the post-suite output drain must be BOUNDED, and this guard
+# must exercise run.sh's REAL drain_output_consumer — not a local copy of the
+# pattern, and not a grep for a string that also appears in a comment. The
+# first attempt at this guard did exactly that and passed with the bound
+# removed; see drain_output_consumer's own comment.
+#
+# Mechanism being modelled: the consumer only exits on EOF, which needs every
+# write end of the fifo closed. A descendant of `go test` that outlives it
+# holding fd 3 keeps it open forever — which is what the detached bed did. A
+# bare `wait` then blocks until the post-suite watchdog kills the whole script,
+# silently skipping the remaining legs (on the default gate path, the isolated
+# runaway-guard leg never ran and nothing said so).
+drain_dir="$(mktemp -d)"
+drain_fifo="$drain_dir/fifo"
+drain_json="$drain_dir/out.json"
+mkfifo "$drain_fifo"
+{ tee "$drain_json" >/dev/null; } < "$drain_fifo" &
+drain_consumer=$!
+exec 4> "$drain_fifo"
+(
+  echo '{"Action":"output","Output":"hello"}' >&4
+  ( sleep 60 ) >&4 2>/dev/null &     # the "bed": outlives go test holding fd 4
+) &
+drain_suite=$!
+exec 4>&-
+wait "$drain_suite" 2>/dev/null || true
+
+# Sanity first: the wedge must actually exist, or this case proves nothing.
+sleep 1
+if ! kill -0 "$drain_consumer" 2>/dev/null; then
+  fail "consumer exited on its own despite a descendant holding the fifo open — this case no longer reproduces #1694's mechanism and would not catch its return"
+else
+  drain_started=$SECONDS
+  # Called under with_timeout so that an UNBOUNDED implementation (the #1694
+  # bug: a bare `wait`) fails this case legibly instead of hanging the whole
+  # test script — verified by neutralization: without the bound this branch
+  # reports rc=124 rather than the suite wedging.
+  with_timeout 15 drain_output_consumer "$drain_consumer" 3 "test" 2>/dev/null
+  drain_rc=$?
+  if [ "$drain_rc" -eq 124 ]; then
+    fail "drain_output_consumer did not return within 15s against a wedged consumer — its bound is not being enforced (this is #1694: a bare wait blocks until the post-suite watchdog kills the script, silently skipping the remaining legs)"
+  elif [ "$drain_rc" -eq 0 ]; then
+    fail "drain_output_consumer reported a clean drain against a deliberately wedged consumer — it is not detecting the wedge"
+  else
+    drain_elapsed=$((SECONDS - drain_started))
+    if [ "$drain_elapsed" -gt 10 ]; then
+      fail "drain_output_consumer took ${drain_elapsed}s against a 3s bound — the bound is not being enforced"
+    elif [ ! -s "$drain_json" ]; then
+      fail "drain abandoned but the JSON log is empty — the premise that a leg's results survive an abandoned drain does not hold"
+    else
+      pass "drain_output_consumer bounds a wedged drain (gave up after ${drain_elapsed}s against a 3s bound) and go test's JSON is already complete ($(wc -c < "$drain_json" | tr -d ' ') bytes) — the leg's results survive"
+    fi
+  fi
+fi
+# Unconditional cleanup: on the failure paths above (an implementation that
+# never bounds, or never abandons) the consumer is still alive and still
+# wedged, so a bare `wait` here would hang this script for the same reason
+# #1694 hung the gate — turning a legible FAIL into an unexplained stall.
+kill -TERM "$drain_consumer" 2>/dev/null || true
+wait "$drain_consumer" 2>/dev/null || true
+pkill -P $$ >/dev/null 2>&1 || true
+rm -rf "$drain_dir"
+
+# Case 17 (#1694): the healthy path must not be slowed or misreported — a
+# consumer that drains normally returns success, promptly.
+healthy_dir="$(mktemp -d)"
+mkfifo "$healthy_dir/fifo"
+{ tee "$healthy_dir/out.json" >/dev/null; } < "$healthy_dir/fifo" &
+healthy_consumer=$!
+exec 4> "$healthy_dir/fifo"
+echo '{"Action":"output","Output":"bye"}' >&4
+exec 4>&-
+healthy_started=$SECONDS
+if drain_output_consumer "$healthy_consumer" 30 "test"; then
+  healthy_elapsed=$((SECONDS - healthy_started))
+  if [ "$healthy_elapsed" -le 3 ]; then
+    pass "drain_output_consumer returns success promptly (${healthy_elapsed}s) when the consumer drains normally — the bound costs a healthy run nothing"
+  else
+    fail "drain_output_consumer took ${healthy_elapsed}s on a healthy drain — the bound is adding latency to every leg"
+  fi
+else
+  fail "drain_output_consumer reported failure on a consumer that drained normally — a false positive here prints a scary warning on every healthy run"
+fi
+wait "$healthy_consumer" 2>/dev/null || true
+rm -rf "$healthy_dir"
+
 if [ "$FAILED" -ne 0 ]; then
   echo "=== hang_hardening_test.sh: FAILED ==="
   exit 1

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -1168,6 +1168,41 @@ PARALLEL_ON="${E2E_PARALLEL_ON:-2}"
 # tight; override with E2E_GH_API_TIMEOUT.
 GH_API_TIMEOUT="${E2E_GH_API_TIMEOUT:-30}"
 
+# How long the post-suite output drain may take before it is abandoned (R1/R2,
+# #1694). Deliberately well under E2E_POST_SUITE_WATCHDOG (300s), so a stuck
+# drain is reported and stepped over by this bound rather than escalating into
+# the watchdog killing the whole script and skipping its remaining legs. A
+# healthy drain finishes in well under a second.
+POST_SUITE_DRAIN_TIMEOUT="${E2E_POST_SUITE_DRAIN_TIMEOUT:-30}"
+
+# drain_output_consumer waits up to $2 seconds for the output consumer ($1) to
+# finish draining, then gives up loudly and terminates it. Returns 0 if it
+# drained on its own, 1 if it had to be abandoned.
+#
+# A FUNCTION, not inline in switch_and_run, specifically so
+# hang_hardening_test.sh can exercise the real implementation against a real
+# wedged consumer. An earlier revision of this fix left it inline and guarded
+# it with a `grep POST_SUITE_DRAIN_TIMEOUT run.sh` check — which passed even
+# with the bound removed, because the string still appeared in the surrounding
+# comment. That is precisely the vacuous-guard shape #1687 was filed about, and
+# it is why this is shaped to be callable.
+drain_output_consumer() {
+  local pid="$1" timeout_secs="$2" mode="${3:-?}"
+  local deadline=$((SECONDS + timeout_secs))
+  while kill -0 "$pid" 2>/dev/null && [ "$SECONDS" -lt "$deadline" ]; do
+    sleep 1
+  done
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+  echo "warning: output consumer did not drain within ${timeout_secs}s after go test exited (leg: ${mode})." >&2
+  echo "         Something that outlived go test is holding the output pipe open — find it with" >&2
+  echo "         'lsof -p <pid> | grep FIFO'. go test has already exited, so its JSON log is" >&2
+  echo "         complete and this leg's results are unaffected; continuing to the next leg." >&2
+  kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+  return 1
+}
+
 # Bed engine poll cadence, passed as -poll to both launch sites. Kept in sync
 # with defaultBedPollSeconds in tests/e2e/lifecycle.go, which carries the
 # measured budget rationale and honours the same E2E_BED_POLL_SECONDS override.
@@ -1761,9 +1796,23 @@ switch_and_run() {
   trap '_post_suite_watchdog_signal 130' INT
 
   # Wait for the consumer to drain and finish writing $jsonlog before any of
-  # it is read below — see the comment above. Still under a TERM trap (the
-  # post-suite watchdog's, installed just above), so a stuck drain is still
-  # covered by R2 rather than left unbounded with no signal path.
+  # it is read below — see the comment above.
+  #
+  # BOUNDED, not a bare `wait` (R1/R2, #1694). The consumer only exits on EOF,
+  # which needs every write end of the fifo closed; a descendant of `go test`
+  # that outlives it and inherited fd 3 keeps it open forever. That is exactly
+  # what the detached bed did (fixed at source in tests/e2e/lifecycle.go's
+  # markInheritedFDsCloseOnExec), and a bare `wait` turned it into a wedge: the
+  # post-suite watchdog aborted the whole script, which silently skipped the
+  # remaining legs — on the default gate path, the isolated runaway-guard leg
+  # never ran and nothing said so.
+  #
+  # This is the defence-in-depth half: whatever leaks the descriptor next, the
+  # drain gives up, says so, and lets the run continue to its remaining legs
+  # rather than wedging. go test has already exited by here, so its JSON is
+  # complete on disk even when the consumer is stuck holding the pipe open —
+  # the classification below reads $jsonlog, not the consumer.
+  drain_output_consumer "$consumer_pid" "$POST_SUITE_DRAIN_TIMEOUT" "$mode"
   wait "$consumer_pid" 2>/dev/null || true
 
   echo "gh api rate_limit budget_after probe" > "$watchdog_dir/checkpoint"

--- a/tests/e2e/lifecycle.go
+++ b/tests/e2e/lifecycle.go
@@ -184,6 +184,34 @@ func bedPollSeconds() string {
 	return defaultBedPollSeconds
 }
 
+// markInheritedFDsCloseOnExec marks every descriptor above stdio close-on-exec,
+// so processes this test spawns from here on do not inherit descriptors this
+// test itself inherited — most importantly run.sh's JSON pipe (see the call
+// site in StartFabrikTestBed for the full #1694 history).
+//
+// Marking a descriptor close-on-exec does not affect this process's own use of
+// it: the flag is consulted only at exec(2). fds we do not own are left
+// readable and writable here and simply stop crossing an exec boundary, which
+// is the correct default for all of them — nothing this suite spawns has any
+// business holding the runner's descriptors.
+//
+// The scan is bounded by RLIMIT_NOFILE (capped, since that can be enormous or
+// unlimited). fcntl on an unopened descriptor returns EBADF, which is the
+// expected result for most of the range and is deliberately ignored — there is
+// no portable way to enumerate only the open ones, and the syscall is cheap.
+func markInheritedFDsCloseOnExec() {
+	max := 4096
+	var rl syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl); err == nil {
+		if cur := int(rl.Cur); cur > 0 && cur < max {
+			max = cur
+		}
+	}
+	for fd := 3; fd < max; fd++ {
+		syscall.CloseOnExec(fd)
+	}
+}
+
 // StartFabrikTestBed launches a fresh detached bed from the bed's own binary and
 // waits for it to acquire the lock. No-op if already running.
 func StartFabrikTestBed(t *testing.T, env *Env) {
@@ -208,6 +236,28 @@ func StartFabrikTestBed(t *testing.T, env *Env) {
 		cmd.Stdin, cmd.Stdout, cmd.Stderr = devnull, devnull, devnull
 		defer devnull.Close()
 	}
+	// Setting stdio to /dev/null covers fds 0-2 only. Every OTHER descriptor
+	// this test process inherited is still passed to the child: os/exec sets
+	// up ProcAttr.Files and ExtraFiles but does not close arbitrary inherited
+	// fds, and descriptors created by a parent shell are not close-on-exec.
+	//
+	// That leaked scripts/e2e/run.sh's JSON pipe into a daemon designed to
+	// outlive the run, and wedged the gate (#1694). run.sh feeds `go test`'s
+	// output through a FIFO — `exec 3> "$fifo"`, `go test ... >&3`, then
+	// `exec 3>&-` to drop the shell's own copy — and afterwards waits for the
+	// consumer to drain, which requires EOF, which requires every write end to
+	// be closed. `go test` inherits fd 3, the test binary inherits it, and
+	// this detached bed inherited it too and then held it open indefinitely.
+	// Confirmed by lsof against a bed still running hours after its run:
+	//
+	//   fabrik 13897 bpja 3w FIFO ... /tmp.xHMuUtjYKA/fifo
+	//
+	// The consumer therefore never saw EOF, the post-suite wait blocked, and
+	// the #1676 watchdog aborted the script — silently skipping the isolated
+	// runaway-guard leg that should have run next. It only ever bit the "on"
+	// leg because that is where the bed is (re)started from inside a `go test`
+	// invocation rather than by run.sh before the pipe exists.
+	markInheritedFDsCloseOnExec()
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start bed Fabrik (%s): %v", bin, err)
 	}


### PR DESCRIPTION
Fixes #1694.

## Root cause

The gate aborted at the post-suite watchdog on the `on` leg of **both** the v0.0.82 run and the post-#1697 run, after every test had already passed:

```
## POST-SUITE WATCHDOG (leg: on): go test exited 300s ago,
## Stuck in: waiting for tee/jq consumer to drain
```

The real cost was never the missing report. The abort skipped the script's **remaining legs**, so on the default gate path the isolated runaway-guard leg never ran — and nothing said so. It took a set-difference against the off leg's JSON to notice it was absent.

Confirmed by `lsof` against a bed still running hours after its run had finished:

```
fabrik 13897 bpja 3w FIFO ... /private/var/folders/.../tmp.xHMuUtjYKA/fifo
```

`run.sh` feeds `go test`'s output through a fifo — `exec 3> "$fifo"`, `go test ... >&3`, then `exec 3>&-` to drop the shell's own copy — and afterwards waits for the consumer to drain. That wait needs EOF, which needs **every** write end closed.

`go test` inherits fd 3. The test binary inherits it. And `StartFabrikTestBed`'s detached bed inherited it too: `os/exec` sets up `ProcAttr.Files` and `ExtraFiles` but does not close arbitrary inherited descriptors, and descriptors created by a parent shell are not close-on-exec. Setting `cmd.Stdin/Stdout/Stderr` to `/dev/null` covers fds 0–2 only. The bed is *designed* to outlive the run, so it held the write end open indefinitely and the consumer never saw EOF.

It only ever bit the `on` leg because that is the only leg where the bed is (re)started from **inside** a `go test` invocation rather than by `run.sh` before the pipe exists.

## Fix

**Root cause** — `markInheritedFDsCloseOnExec()` before launching the bed, so nothing this suite spawns crosses an exec boundary holding the runner's descriptors. Marking a descriptor close-on-exec doesn't affect this process's own use of it; the flag is consulted only at `exec(2)`.

**Defence in depth** — `drain_output_consumer` bounds the wait (`E2E_POST_SUITE_DRAIN_TIMEOUT`, default 30s, well under the 300s watchdog), says what to look for, and lets the run **continue to its remaining legs** rather than wedging. `go test` has already exited by then, so its JSON is complete on disk and the leg's results are unaffected — asserted in the test, not assumed.

## On the guards — worth reading

The first version of this guard was two greps: one for `POST_SUITE_DRAIN_TIMEOUT` in `run.sh`, one for `markInheritedFDsCloseOnExec` in `lifecycle.go`. **Both passed with the fix removed** — the strings still matched a surrounding comment and the function's own `func` definition respectively.

That is precisely the vacuous-guard shape #1687 was filed about, in the fix meant to stop silent skipping. It was caught only because the mutations were actually run rather than reasoned about.

So the drain is now **extracted as a function specifically to be testable**, and `hang_hardening_test.sh` exercises the real implementation against a real wedged consumer — a fifo whose write end is held by a descendant that outlives its parent, i.e. the actual mechanism.

Neutralization, each turning exactly one case red, and legibly rather than by hanging (the guard calls the drain under `with_timeout` and cleans up unconditionally, so a wedged implementation cannot stall the suite):

| mutation | result |
|---|---|
| bound removed (bare `wait`) | `FAIL: drain_output_consumer did not return within 15s …` |
| never abandons, always returns 0 | `FAIL: … reported a clean drain against a deliberately wedged consumer` |
| restored | all checks passed, rc=0 |

The `markInheritedFDsCloseOnExec` half was verified separately, both directions, against a verbatim copy of the helper: without it a detached child inherits the descriptor; with it it does not.

## Verification

- `go test -race ./...` green
- `scripts/e2e/hang_hardening_test.sh` — all checks passed (2 new cases)
- `go vet -tags e2e ./tests/e2e/`, `bash -n scripts/e2e/run.sh` clean

**Not verified: a live gate run.** That is the actual proof — the `on` leg reaching its second invocation and the isolated runaway-guard leg running. Worth doing after review rather than before, since a full gate is ~4 hours.

## Context

Last of the three release-gate defects found during the v0.0.82 cut (#1693 `E2E_BED_REF`, #1694 this, plus #1697's dead budget gauge). All the same family: the gate's own failure modes being quieter than the failures it exists to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Vo5Gx9AYEk9rfA3jY7SBt
