### PR TITLE
fix(e2e): preflight_bed resolves any origin ref, not just main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,19 @@ jobs:
       - name: reviewer-reachable regression test (#1684)
         run: bash scripts/e2e/reviewer_reachable_check_test.sh
 
+      # E2E_BED_REF resolution (scripts/e2e/run.sh's preflight_bed, #1693)
+      # exists so a gate run against a non-main ref actually tests that ref,
+      # instead of silently building the bed from origin/main while go test
+      # ran assertions for the intended ref — a confidently wrong result.
+      # Regression coverage against two scratch git repos (a bare "origin"
+      # and a single-branch "bed" clone matching the real bed's refspec
+      # shape) exercises the fetch/resolve step directly: a never-fetched
+      # branch resolves, a bogus ref fails with a wrapped preflight-context
+      # message (not git's raw error), and the unset-default path (origin/main)
+      # is unaffected. No network, no real ~/dev/fabrik-test involved.
+      - name: preflight_bed ref resolution regression test (#1693)
+        run: bash scripts/e2e/preflight_bed_ref_test.sh
+
       # cut-release.sh's flag parsing — in particular --skip-integration's
       # validation (R2, #1454) — sourced and exercised directly via
       # parse_args(), never reaching main() (the real publish sequence). No

--- a/scripts/e2e/preflight_bed_ref_test.sh
+++ b/scripts/e2e/preflight_bed_ref_test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# scripts/e2e/preflight_bed_ref_test.sh — regression coverage for #1693:
+# preflight_bed (scripts/e2e/run.sh) must resolve any E2E_BED_REF the origin
+# remote actually has, not just origin/main, even though the bed checkout is
+# a single-branch clone (fetch refspec
+# +refs/heads/main:refs/remotes/origin/main). A bare `git fetch origin`
+# obeys that refspec and only ever updates origin/main, so any other ref
+# used to die with git's raw `fatal: ambiguous argument` on the following
+# rev-parse — outside any preflight wrapping.
+#
+# This exercises the real preflight_bed function from run.sh (sourced,
+# mirroring pregate_test.sh's precedent) against two local scratch git
+# repos standing in for the remote and the bed: a bare "origin" with a
+# branch never fetched into the bed, and a "bed" that is a single-branch
+# clone of it, matching the real bed's refspec shape exactly (verified
+# below via `git config --get-all remote.origin.fetch`, the same check the
+# issue's own repro used). No network, no real ~/dev/fabrik-test involved —
+# FABRIK_TEST_DIR points preflight_bed at the scratch bed instead.
+#
+# Every scenario runs with E2E_BED_NO_BUILD=1 so preflight_bed never
+# reaches the checkout/build/`./fabrik --version` steps (R3's guard is
+# untouched code and out of scope for this regression test) — it stops
+# right after the fetch/resolve step this issue changes, either at the
+# "bed is at X, want Y ... and E2E_BED_NO_BUILD is set" refusal (a
+# pre-existing, correct outcome for a mismatched bed) or at the "already at"
+# no-op path when the bed already matches.
+#
+# Usage: scripts/e2e/preflight_bed_ref_test.sh
+# Exit 0 if all assertions pass, 1 otherwise.
+
+set -uo pipefail # no -e: assertions below intentionally continue past failures
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# --- Build the scratch fixture BEFORE sourcing run.sh: TEST_BED is derived
+# from FABRIK_TEST_DIR once, at source time (scripts/e2e/run.sh:352), not
+# read lazily inside preflight_bed. ---
+SCRATCH_DIR="$(mktemp -d)"
+ORIGIN_DIR="$SCRATCH_DIR/origin.git"
+SEED_DIR="$SCRATCH_DIR/seed"
+BED_DIR="$SCRATCH_DIR/bed"
+trap 'rm -rf "$SCRATCH_DIR"' EXIT
+
+git init -q --bare "$ORIGIN_DIR"
+git init -q "$SEED_DIR"
+git -C "$SEED_DIR" config user.email "test@example.com"
+git -C "$SEED_DIR" config user.name "test"
+git -C "$SEED_DIR" commit -q --allow-empty -m "main commit"
+git -C "$SEED_DIR" branch -M main
+git -C "$SEED_DIR" remote add origin "$ORIGIN_DIR"
+git -C "$SEED_DIR" push -q origin main
+
+# A branch that exists on origin but is never fetched into the bed's
+# single-branch clone below — this is the exact shape of the issue's repro
+# (origin/fabrik/my-branch, never fetched, single-branch bed clone).
+git -C "$SEED_DIR" checkout -q -b feature
+git -C "$SEED_DIR" commit -q --allow-empty -m "feature commit"
+git -C "$SEED_DIR" push -q origin feature
+git -C "$SEED_DIR" checkout -q main
+
+MAIN_SHA="$(git -C "$SEED_DIR" rev-parse main)"
+MAIN_SHORT="${MAIN_SHA:0:7}"
+FEATURE_SHA="$(git -C "$SEED_DIR" rev-parse feature)"
+FEATURE_SHORT="${FEATURE_SHA:0:7}"
+
+git clone -q --single-branch --branch main "$ORIGIN_DIR" "$BED_DIR"
+
+# Verify the fixture actually reproduces the real bed's single-branch
+# refspec shape — a fixture that drifts from this would silently test the
+# wrong thing.
+FIXTURE_REFSPEC="$(git -C "$BED_DIR" config --get-all remote.origin.fetch)"
+EXPECTED_REFSPEC="+refs/heads/main:refs/remotes/origin/main"
+
+export FABRIK_TEST_DIR="$BED_DIR"
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/e2e/run.sh"
+set +e
+
+FAILED=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc (expected '$expected', got '$actual')"
+    FAILED=1
+  fi
+}
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc (expected output to contain '$needle')"
+    FAILED=1
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "FAIL: $desc (expected output NOT to contain '$needle')"
+    FAILED=1
+  else
+    echo "PASS: $desc"
+  fi
+}
+
+assert_eq "scratch bed reproduces the real bed's single-branch refspec" "$EXPECTED_REFSPEC" "$FIXTURE_REFSPEC"
+
+# --- Scenario R1 (#1693): a branch pushed to origin but never fetched into
+# the bed resolves — the fetch/resolve step must reach it despite the bed's
+# single-branch clone refspec. preflight_bed still exits non-zero here (bed
+# HEAD is at main, E2E_BED_NO_BUILD is set, so the pre-existing
+# mismatch-and-refuse-to-build path fires) — that outcome is correct and
+# unrelated to this fix; what this asserts is that resolution itself
+# succeeded (the target short SHA appears) and no fetch-failure occurred. ---
+OUTPUT="$( ( E2E_BED_REF=origin/feature E2E_BED_NO_BUILD=1 preflight_bed ) 2>&1 )"
+assert_contains "never-fetched branch resolves to its short SHA" "$OUTPUT" "$FEATURE_SHORT"
+assert_not_contains "never-fetched branch: no fetch-failure message" "$OUTPUT" "git fetch failed in"
+
+# --- Scenario R2 (#1693): a ref that doesn't exist on origin at all fails
+# with a preflight-context message naming the ref and $TEST_BED, exiting via
+# PREFLIGHT_FAILED_EXIT — not git's raw, unwrapped message escaping under
+# set -e (the pre-fix failure mode: a bare fetch always "succeeds" since it
+# only ever touches origin/main, so resolution used to die later at an
+# unwrapped `git rev-parse` with a bare `fatal: ambiguous argument`). ---
+OUTPUT="$( ( E2E_BED_REF=origin/does-not-exist E2E_BED_NO_BUILD=1 preflight_bed ) 2>&1 )"
+RC=$?
+assert_eq "bogus ref exits PREFLIGHT_FAILED_EXIT ($PREFLIGHT_FAILED_EXIT)" "$PREFLIGHT_FAILED_EXIT" "$RC"
+assert_contains "bogus ref: wrapped message names the ref" "$OUTPUT" "does-not-exist"
+assert_contains "bogus ref: wrapped message names \$TEST_BED" "$OUTPUT" "$BED_DIR"
+assert_contains "bogus ref: wrapped message reassures the bed is untouched" "$OUTPUT" "bed is untouched"
+assert_not_contains "bogus ref: no bare unwrapped rev-parse failure" "$OUTPUT" "ambiguous argument"
+
+# --- Scenario R4 (#1693): E2E_BED_REF unset resolves to origin/main exactly
+# as before — the bed (already cloned at main's tip) is reported already
+# up to date, with no fetch-failure message. ---
+unset E2E_BED_REF
+OUTPUT="$( ( E2E_BED_NO_BUILD=1 preflight_bed ) 2>&1 )"
+assert_not_contains "default ref (unset): no fetch-failure message" "$OUTPUT" "git fetch failed in"
+assert_contains "default ref (unset): resolves to main's short SHA" "$OUTPUT" "$MAIN_SHORT"
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "=== preflight_bed_ref_test.sh: FAILED ==="
+  exit 1
+fi
+echo "=== preflight_bed_ref_test.sh: all checks passed ==="

--- a/scripts/e2e/preflight_bed_ref_test.sh
+++ b/scripts/e2e/preflight_bed_ref_test.sh
@@ -121,6 +121,29 @@ OUTPUT="$( ( E2E_BED_REF=origin/feature E2E_BED_NO_BUILD=1 preflight_bed ) 2>&1 
 assert_contains "never-fetched branch resolves to its short SHA" "$OUTPUT" "$FEATURE_SHORT"
 assert_not_contains "never-fetched branch: no fetch-failure message" "$OUTPUT" "git fetch failed in"
 
+# --- Scenario (review finding, PR #1700): a ref the bed already fetched once
+# gets rewritten upstream (rebase/force-push) — the destination-refspec fetch
+# must still succeed. This requires the leading `+` (force) marker on the
+# refspec: the remote's own configured single-branch refspec is
+# `+refs/heads/main:refs/remotes/origin/main`, and without matching that with
+# `+` on our explicit destination refspec too, git refuses the update as
+# non-fast-forward (exit 1) — which the wrapping here would then misreport as
+# an SSH-key or nonexistent-ref failure, neither of which is the real cause.
+# "feature" was already fetched into the bed by the scenario above (at
+# FEATURE_SHA); rewrite it on origin to a divergent sibling commit before
+# fetching it again. ---
+git -C "$SEED_DIR" checkout -q feature
+git -C "$SEED_DIR" reset -q --hard HEAD~1
+git -C "$SEED_DIR" commit -q --allow-empty -m "feature commit rewritten"
+git -C "$SEED_DIR" push -q -f origin feature
+git -C "$SEED_DIR" checkout -q main
+FEATURE_REWRITTEN_SHA="$(git -C "$SEED_DIR" rev-parse feature)"
+FEATURE_REWRITTEN_SHORT="${FEATURE_REWRITTEN_SHA:0:7}"
+
+OUTPUT="$( ( E2E_BED_REF=origin/feature E2E_BED_NO_BUILD=1 preflight_bed ) 2>&1 )"
+assert_contains "rewritten (force-pushed) branch still resolves to its new short SHA" "$OUTPUT" "$FEATURE_REWRITTEN_SHORT"
+assert_not_contains "rewritten branch: no fetch-failure message" "$OUTPUT" "git fetch failed in"
+
 # --- Scenario R2 (#1693): a ref that doesn't exist on origin at all fails
 # with a preflight-context message naming the ref and $TEST_BED, exiting via
 # PREFLIGHT_FAILED_EXIT — not git's raw, unwrapped message escaping under

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -981,8 +981,13 @@ preflight_bed() {
   # updates origin/main and silently fails to resolve any other ref. An
   # explicit destination writes to that ref regardless of the remote's
   # configured refspec, and for the default ref (origin/main) this is a
-  # harmless, byte-for-byte equivalent of the old bare fetch.
-  if ! ( cd "$TEST_BED" && git fetch origin --quiet "$ref_name:refs/remotes/origin/$ref_name" ); then
+  # harmless, byte-for-byte equivalent of the old bare fetch. The leading `+`
+  # is load-bearing, not decorative: without it, fetch refuses a non-fast-forward
+  # update, whereas the remote's own configured refspec (above) is `+`-prefixed
+  # and would force-update — so a rebased/force-pushed upstream ref (main or a
+  # feature branch) would fail here instead of updating as it did before this
+  # fix (caught in review, see PR #1700).
+  if ! ( cd "$TEST_BED" && git fetch origin --quiet "+$ref_name:refs/remotes/origin/$ref_name" ); then
     echo "preflight: git fetch failed in $TEST_BED — cannot resolve $ref." >&2
     echo "  Two likely causes:" >&2
     echo "  - The SSH key for the remote is not loaded: try 'ssh-add' (see 'ssh-add -l')." >&2

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -946,6 +946,11 @@ run_pregate() {
 # ---------------------------------------------------------------------------
 preflight_bed() {
   local ref="${E2E_BED_REF:-origin/main}"
+  # $ref is always fully-qualified as origin/<name> (see header comment above
+  # and both E2E_BED_REF doc blocks) — strip only the literal "origin/"
+  # prefix, not the last path segment, since branch names can themselves
+  # contain slashes (e.g. "fabrik/my-branch").
+  local ref_name="${ref#origin/}"
 
   echo "== preflight: bed at $TEST_BED, target ref $ref =="
 
@@ -969,12 +974,19 @@ preflight_bed() {
 
   # Wrapped, not bare: under `set -e` a bare fetch aborts the script with git's
   # own exit code (128) and git's own message, so the run looks like it died of
-  # nothing in particular. The most common cause is an SSH key that is not
-  # loaded or no longer accepted, which reads as "Permission denied
-  # (publickey)" with no indication it came from the bed preflight.
-  if ! ( cd "$TEST_BED" && git fetch origin --quiet ); then
+  # nothing in particular. Fetch with an explicit destination refspec
+  # (<name>:refs/remotes/origin/<name>) rather than a bare `git fetch origin` —
+  # the bed checkout is a single-branch clone (fetch refspec
+  # +refs/heads/main:refs/remotes/origin/main), so a bare fetch only ever
+  # updates origin/main and silently fails to resolve any other ref. An
+  # explicit destination writes to that ref regardless of the remote's
+  # configured refspec, and for the default ref (origin/main) this is a
+  # harmless, byte-for-byte equivalent of the old bare fetch.
+  if ! ( cd "$TEST_BED" && git fetch origin --quiet "$ref_name:refs/remotes/origin/$ref_name" ); then
     echo "preflight: git fetch failed in $TEST_BED — cannot resolve $ref." >&2
-    echo "  Most likely the SSH key for the remote is not loaded: try 'ssh-add' (see 'ssh-add -l')." >&2
+    echo "  Two likely causes:" >&2
+    echo "  - The SSH key for the remote is not loaded: try 'ssh-add' (see 'ssh-add -l')." >&2
+    echo "  - '$ref_name' does not exist on origin (e.g. not pushed, or misspelled)." >&2
     echo "  The bed is untouched; nothing was stopped, rebuilt, or reset." >&2
     exit "$PREFLIGHT_FAILED_EXIT"
   fi


### PR DESCRIPTION
Closes #1693

## What

`preflight_bed` (`scripts/e2e/run.sh`) used a bare `git fetch origin` to prepare `E2E_BED_REF` for resolution. Because the bed checkout (`~/dev/fabrik-test`) is a single-branch clone (`+refs/heads/main:refs/remotes/origin/main`), that bare fetch only ever updated `origin/main` — any other `E2E_BED_REF` died with git's raw, unwrapped `fatal: ambiguous argument` on the subsequent `rev-parse`, outside any preflight error handling.

## Key changes

- **`scripts/e2e/run.sh`**: the fetch step now supplies an explicit destination refspec (`"$ref_name:refs/remotes/origin/$ref_name"`), which writes to that ref regardless of the remote's configured single-branch refspec — the same mechanism the issue's own manual workaround demonstrated. This is a strict, harmless generalization of the old bare fetch for the default `origin/main` path, so the default path is unaffected (R4). The wrapped fetch-failure message is generalized to name both possible causes (SSH key not loaded, or the ref not existing on `origin`) along with `$ref` and `$TEST_BED`, since there's now only one fetch call to wrap (R1/R2). The downstream `rev-parse`, checkout, build, and the `./fabrik --version` / `$want_short` guard (R3) are untouched.
- **`scripts/e2e/preflight_bed_ref_test.sh`** (new): regression coverage modeled on `pregate_test.sh`'s sourced-function pattern. Builds two scratch git repos (a bare `origin` and a single-branch `bed` clone matching the real bed's refspec shape — asserted directly) and exercises three scenarios: a never-fetched branch resolves; a bogus ref fails with the wrapped preflight-context message (not git's raw error) and exits `PREFLIGHT_FAILED_EXIT`; the unset-default path is unaffected. Verified this test fails against the pre-fix code and passes against the fix.
- **`.github/workflows/ci.yml`**: wires the new test in alongside `pregate_test.sh` and friends.

## How to test

```bash
bash scripts/e2e/preflight_bed_ref_test.sh
```

Also manually verified against the real bed (`~/dev/fabrik-test`, verify-only mode): `E2E_BED_REF=origin/fabrik/issue-1693` (a branch never previously fetched into the bed) resolved correctly with no manual fetch, and a bogus ref failed with the wrapped message — bed left untouched in both cases.